### PR TITLE
fix(auth): ScheduleRemovals should use uint256[]

### DIFF
--- a/service_contracts/src/SimplePDPServiceWithPayments.sol
+++ b/service_contracts/src/SimplePDPServiceWithPayments.sol
@@ -143,7 +143,7 @@ contract SimplePDPServiceWithPayments is PDPListener, IArbiter, Initializable, U
     );
     
     bytes32 private constant SCHEDULE_REMOVALS_TYPEHASH = keccak256(
-        "ScheduleRemovals(uint256 clientDataSetId,bytes32 rootIdsHash)"
+        "ScheduleRemovals(uint256 clientDataSetId,uint256[] rootIds)"
     );
     
     bytes32 private constant DELETE_PROOFSET_TYPEHASH = keccak256(

--- a/service_contracts/test/SignatureFixtureTest.t.sol
+++ b/service_contracts/test/SignatureFixtureTest.t.sol
@@ -43,7 +43,7 @@ contract TestableSimplePDPServiceEIP712 is EIP712 {
     );
 
     bytes32 private constant SCHEDULE_REMOVALS_TYPEHASH = keccak256(
-        "ScheduleRemovals(uint256 clientDataSetId,bytes32 rootIdsHash)"
+        "ScheduleRemovals(uint256 clientDataSetId,uint256[] rootIds)"
     );
 
     bytes32 private constant DELETE_PROOFSET_TYPEHASH = keccak256(
@@ -374,7 +374,7 @@ contract SignatureFixtureTest is Test {
         console.log("");
         console.log("  ScheduleRemovals: [");
         console.log('    { name: "clientDataSetId", type: "uint256" },');
-        console.log('    { name: "rootIdsHash", type: "bytes32" }');
+        console.log('    { name: "rootIds", type: "uint256[]" }');
         console.log("  ]");
         console.log("");
         console.log("  DeleteProofSet: [");

--- a/service_contracts/test/external_signatures.json
+++ b/service_contracts/test/external_signatures.json
@@ -14,7 +14,7 @@
     "rootSizes": [1024, 2048]
   },
   "scheduleRemovals": {
-    "signature": "0x637540b0c46cced57f3125cc8aa73cf14f1057046183497960552948416d016a6c6addded575081b35c8384dbcc8d926b350aa15892821a4537ed0519a3ee10a1c",
+    "signature": "0x22c6669700d387f17f82098cfe09163eb6a11c21ce2befe2fcd832a63544572a2fa9ce673b448a0f4dec1dbb6da2f53baaa412be09ad71c501aca47bcd43cd4b1c",
     "clientDataSetId": 12345,
     "rootIds": [1, 3, 5]
   },


### PR DESCRIPTION
We have an easier time in JavaScript emulating this.

Also:

![Screenshot 2025-06-04 at 9 00 49 pm](https://github.com/user-attachments/assets/98ec9509-83aa-4aa0-960d-16e36c819119)

vs

![Screenshot 2025-06-04 at 9 15 16 pm](https://github.com/user-attachments/assets/417da917-7b26-488c-a007-e327048338ab)

