### PR TITLE
feat: add proof set retrieval with payment info

### DIFF
--- a/service_contracts/src/PandoraService.sol
+++ b/service_contracts/src/PandoraService.sol
@@ -69,6 +69,17 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
         bool withCDN; // Whether the proof set is using CDN
     }
 
+    // View struct for returning proof set payment information
+    struct ProofSetPaymentView {
+        uint256 proofSetId;
+        uint256 railId;
+        address payer;
+        address payee;
+        uint256 commissionBps;
+        bool withCDN;
+        string metadata;
+    }
+
     // Decode structure for proof set creation extra data
     struct ProofSetCreateData {
         string metadata;
@@ -1161,6 +1172,38 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
         return proofSets;
     }
 
+    /**
+     * @notice Get all proof sets with their payment information for a client
+     * @param client The address of the client
+     * @return Array of ProofSetPaymentView containing payment information for each proof set
+     */
+    function getClientProofSetsWithPayments(address client) external view returns (ProofSetPaymentView[] memory) {
+        // Get all proof set IDs associated with this client
+        uint256[] memory proofSetIds = clientProofSets[client];
+        
+        // Create a new array to hold the payment view data
+        ProofSetPaymentView[] memory result = new ProofSetPaymentView[](proofSetIds.length);
+
+        // Iterate through each proof set ID and create a payment view
+        for (uint256 i = 0; i < proofSetIds.length; i++) {
+            // Get the storage info for this proof set
+            ProofSetInfo storage info = proofSetInfo[proofSetIds[i]];
+            
+            // Create a payment view with the relevant information
+            result[i] = ProofSetPaymentView({
+                proofSetId: proofSetIds[i],
+                railId: info.railId,
+                payer: info.payer,
+                payee: info.payee,
+                commissionBps: info.commissionBps,
+                withCDN: info.withCDN,
+                metadata: info.metadata
+            });
+        }
+
+        return result;
+    }
+    
     /**
      * @notice Arbitrates payment based on faults in the given epoch range
      * @dev Implements the IArbiter interface function

--- a/service_contracts/test/PandoraService.t.sol
+++ b/service_contracts/test/PandoraService.t.sol
@@ -1110,6 +1110,43 @@ contract PandoraServiceTest is Test {
         assertEq(proofSets[1].metadata, "Metadata 2", "Second proof set metadata should match");
         assertEq(proofSets[1].clientDataSetId, 1, "Second dataset ID should be 1");
     }
+
+    function testGetClientProofSetsWithPayments() public {
+        // Create first and second proof set
+        uint256 proofSetId1 = createProofSetForClient(sp1, client, "metadata1");
+        uint256 proofSetId2 = createProofSetForClient(sp2, client, "metadata2");
+
+        // Get all proof sets with payment info
+        PandoraService.ProofSetPaymentView[] memory proofSets = pdpServiceWithPayments.getClientProofSetsWithPayments(client);
+
+        // Verify the results
+        assertEq(proofSets.length, 2, "Should have 2 proof sets");
+        
+        // Verify first proof set
+        assertEq(proofSets[0].proofSetId, proofSetId1, "First proof set ID should match");
+        assertEq(proofSets[0].payer, client, "First proof set payer should be client");
+        assertEq(proofSets[0].payee, sp1, "First proof set payee should be storage provider");
+        assertEq(proofSets[0].commissionBps, initialOperatorCommissionBps, "First proof set commission should match");
+        assertEq(proofSets[0].withCDN, false, "First proof set should not have CDN enabled");
+        assertEq(proofSets[0].metadata, "metadata1", "First proof set metadata should match");
+        
+        // Verify second proof set
+        assertEq(proofSets[1].proofSetId, proofSetId2, "Second proof set ID should match");
+        assertEq(proofSets[1].payer, client, "Second proof set payer should be client");
+        assertEq(proofSets[1].payee, sp2, "Second proof set payee should be storage provider");
+        assertEq(proofSets[1].commissionBps, initialOperatorCommissionBps, "Second proof set commission should match");
+        assertEq(proofSets[1].withCDN, false, "Second proof set should not have CDN enabled");
+        assertEq(proofSets[1].metadata, "metadata2", "Second proof set metadata should match");
+    }
+
+    function testGetClientProofSetsWithPayments_Empty() public view{
+        // Get proof sets for a client with no proof sets
+        PandoraService.ProofSetPaymentView[] memory proofSets = pdpServiceWithPayments.getClientProofSetsWithPayments(address(0x1234));
+        
+        // Verify empty array is returned
+        assertEq(proofSets.length, 0, "Should return empty array for client with no proof sets");
+    }
+
 }
 
 contract SignatureCheckingService is PandoraService {


### PR DESCRIPTION
# Add Proof Set Retrieval with Payment Information

## Description
This PR adds a new function `getClientProofSetsWithPayments` that provides a comprehensive view of a client's proof sets along with their payment information in a single call. This improves the contract's usability by:

- Reducing the number of calls needed to get complete proof set information
- Providing payment details alongside proof set data
- Simplifying client-side data handling

## Changes
- Added new `getClientProofSetsWithPayments` function that takes:
  - `client`: The address of the client
- Function returns an array of `ProofSetPaymentView` containing:
  - Proof set ID
  - Payment rail ID
  - Payer and payee addresses
  - Commission rate
  - CDN status
  - Metadata

## Implementation Details
The implementation:
1. Retrieves all proof set IDs for the client
2. Creates a new array to hold the payment view data
3. For each proof set, extracts relevant payment information
4. Returns the complete array of payment views

## Testing
- [x] Test with empty client address
- [x] Test with client having no proof sets
- [x] Test with client having multiple proof sets
- [x] Verify all payment information is correctly included
- [x] Verify metadata is properly returned

## Related Issues
Closes #40