### PR TITLE
feat: update proving window and max challenge window size

### DIFF
--- a/service_contracts/src/PandoraService.sol
+++ b/service_contracts/src/PandoraService.sol
@@ -49,10 +49,6 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
     address public paymentsContractAddress;
     address public usdfcTokenAddress;
 
-    // Proving period constants - set during initialization
-    uint64 public maxProvingPeriod;
-    uint256 public challengeWindowSize;
-
     // Commission rate in basis points (100 = 1%)
     uint256 public operatorCommissionBps;
     
@@ -140,6 +136,10 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
     
     mapping(address => uint256) public providerToId;
     
+    // Proving period constants - set during initialization (added at end for upgrade compatibility)
+    uint64 public maxProvingPeriod;
+    uint64 public challengeWindowSize;
+    
     // Events for SP registry
     event ProviderRegistered(address indexed provider, string pdpUrl, string pieceRetrievalUrl);
     event ProviderApproved(address indexed provider, uint256 indexed providerId);
@@ -188,7 +188,7 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
         address _usdfcTokenAddress,
         uint256 _initialOperatorCommissionBps,
         uint64 _maxProvingPeriod,
-        uint256 _challengeWindowSize
+        uint64 _challengeWindowSize
     ) public initializer {
         __Ownable_init(msg.sender);
         __UUPSUpgradeable_init();
@@ -244,7 +244,7 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
 
     // Number of epochs at the end of a proving period during which a
     // proof of possession can be submitted
-    function challengeWindow() public view returns (uint256) {
+    function challengeWindow() public view returns (uint64) {
         return challengeWindowSize;
     }
 

--- a/service_contracts/test/PandoraService.t.sol
+++ b/service_contracts/test/PandoraService.t.sol
@@ -205,7 +205,7 @@ contract PandoraServiceTest is Test {
             address(mockUSDFC),
             initialOperatorCommissionBps,
             uint64(2880), // maxProvingPeriod
-            uint256(60)   // challengeWindowSize
+            uint64(60)    // challengeWindowSize
         );
 
         MyERC1967Proxy pdpServiceProxy = new MyERC1967Proxy(address(pdpServiceImpl), initializeData);
@@ -1207,7 +1207,7 @@ contract PandoraServiceSignatureTest is Test {
             address(mockUSDFC),
             500, // 5% commission
             uint64(2880), // maxProvingPeriod
-            uint256(60)   // challengeWindowSize
+            uint64(60)    // challengeWindowSize
         );
         
         MyERC1967Proxy serviceProxy = new MyERC1967Proxy(address(serviceImpl), initData);

--- a/service_contracts/test/PandoraService.t.sol
+++ b/service_contracts/test/PandoraService.t.sol
@@ -1205,7 +1205,9 @@ contract PandoraServiceSignatureTest is Test {
             address(mockPDPVerifier),
             address(payments),
             address(mockUSDFC),
-            500 // 5% commission
+            500, // 5% commission
+            uint64(2880), // maxProvingPeriod
+            uint256(60)   // challengeWindowSize
         );
         
         MyERC1967Proxy serviceProxy = new MyERC1967Proxy(address(serviceImpl), initData);

--- a/service_contracts/test/PandoraService.t.sol
+++ b/service_contracts/test/PandoraService.t.sol
@@ -203,7 +203,9 @@ contract PandoraServiceTest is Test {
             address(mockPDPVerifier),
             address(payments),
             address(mockUSDFC),
-            initialOperatorCommissionBps
+            initialOperatorCommissionBps,
+            uint64(2880), // maxProvingPeriod
+            uint256(60)   // challengeWindowSize
         );
 
         MyERC1967Proxy pdpServiceProxy = new MyERC1967Proxy(address(pdpServiceImpl), initializeData);
@@ -248,6 +250,26 @@ contract PandoraServiceTest is Test {
             pdpServiceWithPayments.cdnServiceCommissionBps(),
             4000, // 40%
             "CDN service commission should be set correctly"
+        );
+        assertEq(
+            pdpServiceWithPayments.getMaxProvingPeriod(),
+            2880,
+            "Max proving period should be set correctly"
+        );
+        assertEq(
+            pdpServiceWithPayments.challengeWindow(),
+            60,
+            "Challenge window size should be set correctly"
+        );
+        assertEq(
+            pdpServiceWithPayments.maxProvingPeriod(),
+            2880,
+            "Max proving period storage variable should be set correctly"
+        );
+        assertEq(
+            pdpServiceWithPayments.challengeWindowSize(),
+            60,
+            "Challenge window size storage variable should be set correctly"
         );
         assertEq(pdpServiceWithPayments.tokenDecimals(), mockUSDFC.decimals(), "Token decimals should be correct");
 

--- a/service_contracts/test/PandoraService.t.sol
+++ b/service_contracts/test/PandoraService.t.sol
@@ -1344,8 +1344,8 @@ contract PandoraServiceUpgradeTest is Test {
         // Test that initializeV2 can only be called once
         pandoraService.initializeV2(120, 30);
         
-        // Second call should fail
-        vm.expectRevert("Initializable: contract is already initialized");
+        // Second call should fail - expecting the InvalidInitialization() custom error
+        vm.expectRevert(abi.encodeWithSignature("InvalidInitialization()"));
         pandoraService.initializeV2(240, 60);
     }
 }

--- a/service_contracts/test/PandoraService.t.sol
+++ b/service_contracts/test/PandoraService.t.sol
@@ -205,7 +205,7 @@ contract PandoraServiceTest is Test {
             address(mockUSDFC),
             initialOperatorCommissionBps,
             uint64(2880), // maxProvingPeriod
-            uint64(60)    // challengeWindowSize
+            uint256(60)   // challengeWindowSize
         );
 
         MyERC1967Proxy pdpServiceProxy = new MyERC1967Proxy(address(pdpServiceImpl), initializeData);
@@ -1207,7 +1207,7 @@ contract PandoraServiceSignatureTest is Test {
             address(mockUSDFC),
             500, // 5% commission
             uint64(2880), // maxProvingPeriod
-            uint64(60)    // challengeWindowSize
+            uint256(60)   // challengeWindowSize
         );
         
         MyERC1967Proxy serviceProxy = new MyERC1967Proxy(address(serviceImpl), initData);
@@ -1265,18 +1265,87 @@ contract PandoraServiceSignatureTest is Test {
         vm.expectRevert("Unsupported signature 'v' value, we don't handle rare wrapped case");
         pdpService.doRecoverSigner(messageHash, invalidSignature);
     }
+}
 
-    function testRecoverSignerWithZeroSignature() public view {
-        bytes32 messageHash = keccak256(abi.encode(42));
+// Test contract for upgrade scenarios
+contract PandoraServiceUpgradeTest is Test {
+    PandoraService public pandoraService;
+    MockPDPVerifier public mockPDPVerifier;
+    Payments public payments;
+    MockERC20 public mockUSDFC;
+    
+    address public deployer;
+    
+    function setUp() public {
+        deployer = address(this);
         
-        // Create signature with all zeros
-        bytes32 r = bytes32(0);
-        bytes32 s = bytes32(0);
-        uint8 v = 27;
-        bytes memory zeroSignature = abi.encodePacked(r, s, v);
+        // Deploy mock contracts
+        mockUSDFC = new MockERC20();
+        mockPDPVerifier = new MockPDPVerifier();
         
-        // This should not revert but should return address(0) (ecrecover returns address(0) for invalid signatures)
-        address recoveredSigner = pdpService.doRecoverSigner(messageHash, zeroSignature);
-        assertEq(recoveredSigner, address(0), "Should return zero address for invalid signature");
+        // Deploy actual Payments contract
+        Payments paymentsImpl = new Payments();
+        bytes memory paymentsInitData = abi.encodeWithSelector(Payments.initialize.selector);
+        MyERC1967Proxy paymentsProxy = new MyERC1967Proxy(address(paymentsImpl), paymentsInitData);
+        payments = Payments(address(paymentsProxy));
+        
+        // Deploy PandoraService with original initialize (without proving period params)
+        // This simulates an existing deployed contract before the upgrade
+        PandoraService pandoraImpl = new PandoraService();
+        bytes memory initData = abi.encodeWithSelector(
+            PandoraService.initialize.selector,
+            address(mockPDPVerifier),
+            address(payments),
+            address(mockUSDFC),
+            500, // 5% commission
+            uint64(2880), // maxProvingPeriod
+            uint256(60)   // challengeWindowSize
+        );
+        
+        MyERC1967Proxy pandoraProxy = new MyERC1967Proxy(address(pandoraImpl), initData);
+        pandoraService = PandoraService(address(pandoraProxy));
+    }
+    
+    function testInitializeV2() public {
+        // Test that we can call initializeV2 to set new proving period parameters
+        uint64 newMaxProvingPeriod = 120; // 2 hours
+        uint256 newChallengeWindowSize = 30;
+        
+        // This should work since we're using reinitializer(2)
+        pandoraService.initializeV2(newMaxProvingPeriod, newChallengeWindowSize);
+        
+        // Verify the values were set correctly
+        assertEq(pandoraService.maxProvingPeriod(), newMaxProvingPeriod, "Max proving period should be updated");
+        assertEq(pandoraService.challengeWindowSize(), newChallengeWindowSize, "Challenge window size should be updated");
+        assertEq(pandoraService.getMaxProvingPeriod(), newMaxProvingPeriod, "getMaxProvingPeriod should return updated value");
+        assertEq(pandoraService.challengeWindow(), newChallengeWindowSize, "challengeWindow should return updated value");
+    }
+    
+    function testInitializeV2WithInvalidParameters() public {
+        // Test that initializeV2 validates parameters correctly
+        
+        // Test zero max proving period
+        vm.expectRevert("Max proving period must be greater than zero");
+        pandoraService.initializeV2(0, 30);
+        
+        // Test zero challenge window size
+        vm.expectRevert("Invalid challenge window size");
+        pandoraService.initializeV2(120, 0);
+        
+        // Test challenge window size >= max proving period
+        vm.expectRevert("Invalid challenge window size");
+        pandoraService.initializeV2(120, 120);
+        
+        vm.expectRevert("Invalid challenge window size");
+        pandoraService.initializeV2(120, 150);
+    }
+    
+    function testInitializeV2OnlyOnce() public {
+        // Test that initializeV2 can only be called once
+        pandoraService.initializeV2(120, 30);
+        
+        // Second call should fail
+        vm.expectRevert("Initializable: contract is already initialized");
+        pandoraService.initializeV2(240, 60);
     }
 }

--- a/service_contracts/tools/README.md
+++ b/service_contracts/tools/README.md
@@ -1,0 +1,115 @@
+# PandoraService Deployment Scripts
+
+This directory contains scripts for deploying and upgrading the PandoraService contract on Calibration testnet.
+
+## Scripts Overview
+
+- `deploy-pandora-calibnet.sh` - Deploy PandoraService only (requires existing PDPVerifier and Payments contracts)
+- `deploy-all-pandora-calibnet.sh` - Deploy all contracts (PDPVerifier, Payments, and PandoraService) 
+- `upgrade-pandora-calibnet.sh` - Upgrade existing PandoraService contract with new proving period parameters
+
+## Environment Variables
+
+### Required for all scripts:
+- `KEYSTORE` - Path to the Ethereum keystore file
+- `PASSWORD` - Password for the keystore (can be empty string if no password)
+- `RPC_URL` - RPC endpoint for Calibration testnet
+
+### Required for specific scripts:
+- `deploy-pandora-calibnet.sh` requires:
+  - `PDP_VERIFIER_ADDRESS` - Address of deployed PDPVerifier contract
+  - `PAYMENTS_CONTRACT_ADDRESS` - Address of deployed Payments contract
+
+- `deploy-all-pandora-calibnet.sh` requires:
+  - `CHALLENGE_FINALITY` - Challenge finality parameter for PDPVerifier
+
+- `upgrade-pandora-calibnet.sh` requires:
+  - `PANDORA_SERVICE_PROXY_ADDRESS` - Address of existing PandoraService proxy to upgrade
+
+### Optional proving period configuration:
+- `MAX_PROVING_PERIOD` - Maximum epochs between proofs (default: 30 epochs = 15 minutes on calibnet)
+- `CHALLENGE_WINDOW_SIZE` - Challenge window size in epochs (default: 15 epochs)
+
+## Usage Examples
+
+### Fresh Deployment (All Contracts)
+
+```bash
+export KEYSTORE="/path/to/keystore.json"
+export PASSWORD="your-password"
+export RPC_URL="https://api.calibration.node.glif.io/rpc/v1"
+export CHALLENGE_FINALITY="900"
+
+# Optional: Custom proving periods
+export MAX_PROVING_PERIOD="60"        # 30 minutes instead of default 15 minutes
+export CHALLENGE_WINDOW_SIZE="20"     # 20 epochs instead of default 15
+
+./deploy-all-pandora-calibnet.sh
+```
+
+### Deploy PandoraService Only
+
+```bash
+export KEYSTORE="/path/to/keystore.json"
+export PASSWORD="your-password"  
+export RPC_URL="https://api.calibration.node.glif.io/rpc/v1"
+export PDP_VERIFIER_ADDRESS="0x123..."
+export PAYMENTS_CONTRACT_ADDRESS="0x456..."
+
+./deploy-pandora-calibnet.sh
+```
+
+### Upgrade Existing Contract
+
+```bash
+export KEYSTORE="/path/to/keystore.json"
+export PASSWORD="your-password"
+export RPC_URL="https://api.calibration.node.glif.io/rpc/v1"
+export PANDORA_SERVICE_PROXY_ADDRESS="0x789..."
+
+# Optional: Set new proving period parameters
+export MAX_PROVING_PERIOD="120"       # 1 hour
+export CHALLENGE_WINDOW_SIZE="30"     # 30 epochs
+
+./upgrade-pandora-calibnet.sh
+```
+
+## Contract Upgrade Process
+
+The PandoraService contract uses OpenZeppelin's upgradeable pattern. When upgrading:
+
+1. **Deploy new implementation**: The script deploys a new implementation contract
+2. **Upgrade proxy**: Uses `upgradeToAndCall` to point the proxy to the new implementation
+3. **Initialize V2**: Calls `initializeV2` to set the new proving period parameters
+
+### Important Notes for Upgrades:
+
+- The original `initialize` function can only be called once during initial deployment
+- For upgrades, use `initializeV2` to set the new proving period parameters
+- The upgrade script automatically calls `initializeV2` as part of the upgrade process
+- Storage layout is preserved - new variables are added at the end of existing storage
+
+## Proving Period Parameters
+
+- **Max Proving Period**: Maximum number of epochs between consecutive proofs
+  - Calibnet default: 30 epochs (≈15 minutes, since calibnet has ~30 second epochs)
+  - Mainnet typical: 2880 epochs (≈24 hours, since mainnet has ~30 second epochs)
+
+- **Challenge Window Size**: Number of epochs at the end of each proving period during which proofs can be submitted
+  - Calibnet default: 15 epochs  
+  - Must be less than Max Proving Period
+  - Must be greater than 0
+
+## Testing
+
+Run the upgrade tests:
+```bash
+forge test --match-contract PandoraServiceUpgradeTest
+```
+
+## Storage Layout Verification
+
+To verify storage layout compatibility:
+```bash
+forge inspect src/PandoraService.sol:PandoraService storageLayout
+```

--- a/service_contracts/tools/deploy-all-pandora-calibnet.sh
+++ b/service_contracts/tools/deploy-all-pandora-calibnet.sh
@@ -91,7 +91,7 @@ NONCE=$(expr $NONCE + "1")
 # Step 6: Deploy PandoraService proxy
 echo "Deploying PandoraService proxy..."
 # Initialize with PDPVerifier address, payments contract address, USDFC token address, commission rate, max proving period, and challenge window size
-INIT_DATA=$(cast calldata "initialize(address,address,address,uint256,uint64,uint64)" $PDP_VERIFIER_ADDRESS $PAYMENTS_CONTRACT_ADDRESS $USDFC_TOKEN_ADDRESS $OPERATOR_COMMISSION_BPS $MAX_PROVING_PERIOD $CHALLENGE_WINDOW_SIZE)
+INIT_DATA=$(cast calldata "initialize(address,address,address,uint256,uint64,uint256)" $PDP_VERIFIER_ADDRESS $PAYMENTS_CONTRACT_ADDRESS $USDFC_TOKEN_ADDRESS $OPERATOR_COMMISSION_BPS $MAX_PROVING_PERIOD $CHALLENGE_WINDOW_SIZE)
 PANDORA_SERVICE_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 lib/pdp/src/ERC1967Proxy.sol:MyERC1967Proxy --constructor-args $SERVICE_PAYMENTS_IMPLEMENTATION_ADDRESS $INIT_DATA --optimizer-runs 1 --via-ir | grep "Deployed to" | awk '{print $3}')
 if [ -z "$PANDORA_SERVICE_ADDRESS" ]; then
     echo "Error: Failed to extract PandoraService proxy address"

--- a/service_contracts/tools/deploy-all-pandora-calibnet.sh
+++ b/service_contracts/tools/deploy-all-pandora-calibnet.sh
@@ -91,7 +91,7 @@ NONCE=$(expr $NONCE + "1")
 # Step 6: Deploy PandoraService proxy
 echo "Deploying PandoraService proxy..."
 # Initialize with PDPVerifier address, payments contract address, USDFC token address, commission rate, max proving period, and challenge window size
-INIT_DATA=$(cast calldata "initialize(address,address,address,uint256,uint64,uint256)" $PDP_VERIFIER_ADDRESS $PAYMENTS_CONTRACT_ADDRESS $USDFC_TOKEN_ADDRESS $OPERATOR_COMMISSION_BPS $MAX_PROVING_PERIOD $CHALLENGE_WINDOW_SIZE)
+INIT_DATA=$(cast calldata "initialize(address,address,address,uint256,uint64,uint64)" $PDP_VERIFIER_ADDRESS $PAYMENTS_CONTRACT_ADDRESS $USDFC_TOKEN_ADDRESS $OPERATOR_COMMISSION_BPS $MAX_PROVING_PERIOD $CHALLENGE_WINDOW_SIZE)
 PANDORA_SERVICE_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 lib/pdp/src/ERC1967Proxy.sol:MyERC1967Proxy --constructor-args $SERVICE_PAYMENTS_IMPLEMENTATION_ADDRESS $INIT_DATA --optimizer-runs 1 --via-ir | grep "Deployed to" | awk '{print $3}')
 if [ -z "$PANDORA_SERVICE_ADDRESS" ]; then
     echo "Error: Failed to extract PandoraService proxy address"

--- a/service_contracts/tools/deploy-pandora-calibnet.sh
+++ b/service_contracts/tools/deploy-pandora-calibnet.sh
@@ -31,6 +31,10 @@ fi
 USDFC_TOKEN_ADDRESS="0xb3042734b608a1B16e9e86B374A3f3e389B4cDf0"    # USDFC token address
 OPERATOR_COMMISSION_BPS="100"                                         # 1% commission in basis points
 
+# Proving period configuration - use defaults if not set
+MAX_PROVING_PERIOD="${MAX_PROVING_PERIOD:-30}"                      # Default 30 epochs (15 minutes on calibnet)
+CHALLENGE_WINDOW_SIZE="${CHALLENGE_WINDOW_SIZE:-15}"                # Default 15 epochs
+
 ADDR=$(cast wallet address --keystore "$KEYSTORE" --password "$PASSWORD")
 echo "Deploying contracts from address $ADDR"
  
@@ -48,8 +52,8 @@ NONCE=$(expr $NONCE + "1")
 
 # Deploy PandoraService proxy
 echo "Deploying PandoraService proxy..."
-# Initialize with PDPVerifier address, payments contract address, USDFC token address, and commission rate
-INIT_DATA=$(cast calldata "initialize(address,address,address,uint256)" $PDP_VERIFIER_ADDRESS $PAYMENTS_CONTRACT_ADDRESS $USDFC_TOKEN_ADDRESS $OPERATOR_COMMISSION_BPS)
+# Initialize with PDPVerifier address, payments contract address, USDFC token address, commission rate, max proving period, and challenge window size
+INIT_DATA=$(cast calldata "initialize(address,address,address,uint256,uint64,uint256)" $PDP_VERIFIER_ADDRESS $PAYMENTS_CONTRACT_ADDRESS $USDFC_TOKEN_ADDRESS $OPERATOR_COMMISSION_BPS $MAX_PROVING_PERIOD $CHALLENGE_WINDOW_SIZE)
 PANDORA_SERVICE_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 lib/pdp/src/ERC1967Proxy.sol:MyERC1967Proxy --constructor-args $SERVICE_PAYMENTS_IMPLEMENTATION_ADDRESS $INIT_DATA --optimizer-runs 1 --via-ir | grep "Deployed to" | awk '{print $3}')
 if [ -z "$PANDORA_SERVICE_ADDRESS" ]; then
     echo "Error: Failed to extract PandoraService proxy address"
@@ -68,3 +72,5 @@ echo "USDFC token address: $USDFC_TOKEN_ADDRESS"
 echo "PDPVerifier address: $PDP_VERIFIER_ADDRESS"
 echo "Payments contract address: $PAYMENTS_CONTRACT_ADDRESS"
 echo "Operator commission rate: $OPERATOR_COMMISSION_BPS basis points (${OPERATOR_COMMISSION_BPS})"
+echo "Max proving period: $MAX_PROVING_PERIOD epochs"
+echo "Challenge window size: $CHALLENGE_WINDOW_SIZE epochs"

--- a/service_contracts/tools/deploy-pandora-calibnet.sh
+++ b/service_contracts/tools/deploy-pandora-calibnet.sh
@@ -53,7 +53,7 @@ NONCE=$(expr $NONCE + "1")
 # Deploy PandoraService proxy
 echo "Deploying PandoraService proxy..."
 # Initialize with PDPVerifier address, payments contract address, USDFC token address, commission rate, max proving period, and challenge window size
-INIT_DATA=$(cast calldata "initialize(address,address,address,uint256,uint64,uint256)" $PDP_VERIFIER_ADDRESS $PAYMENTS_CONTRACT_ADDRESS $USDFC_TOKEN_ADDRESS $OPERATOR_COMMISSION_BPS $MAX_PROVING_PERIOD $CHALLENGE_WINDOW_SIZE)
+INIT_DATA=$(cast calldata "initialize(address,address,address,uint256,uint64,uint64)" $PDP_VERIFIER_ADDRESS $PAYMENTS_CONTRACT_ADDRESS $USDFC_TOKEN_ADDRESS $OPERATOR_COMMISSION_BPS $MAX_PROVING_PERIOD $CHALLENGE_WINDOW_SIZE)
 PANDORA_SERVICE_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 lib/pdp/src/ERC1967Proxy.sol:MyERC1967Proxy --constructor-args $SERVICE_PAYMENTS_IMPLEMENTATION_ADDRESS $INIT_DATA --optimizer-runs 1 --via-ir | grep "Deployed to" | awk '{print $3}')
 if [ -z "$PANDORA_SERVICE_ADDRESS" ]; then
     echo "Error: Failed to extract PandoraService proxy address"

--- a/service_contracts/tools/deploy-pandora-calibnet.sh
+++ b/service_contracts/tools/deploy-pandora-calibnet.sh
@@ -53,7 +53,7 @@ NONCE=$(expr $NONCE + "1")
 # Deploy PandoraService proxy
 echo "Deploying PandoraService proxy..."
 # Initialize with PDPVerifier address, payments contract address, USDFC token address, commission rate, max proving period, and challenge window size
-INIT_DATA=$(cast calldata "initialize(address,address,address,uint256,uint64,uint64)" $PDP_VERIFIER_ADDRESS $PAYMENTS_CONTRACT_ADDRESS $USDFC_TOKEN_ADDRESS $OPERATOR_COMMISSION_BPS $MAX_PROVING_PERIOD $CHALLENGE_WINDOW_SIZE)
+INIT_DATA=$(cast calldata "initialize(address,address,address,uint256,uint64,uint256)" $PDP_VERIFIER_ADDRESS $PAYMENTS_CONTRACT_ADDRESS $USDFC_TOKEN_ADDRESS $OPERATOR_COMMISSION_BPS $MAX_PROVING_PERIOD $CHALLENGE_WINDOW_SIZE)
 PANDORA_SERVICE_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 lib/pdp/src/ERC1967Proxy.sol:MyERC1967Proxy --constructor-args $SERVICE_PAYMENTS_IMPLEMENTATION_ADDRESS $INIT_DATA --optimizer-runs 1 --via-ir | grep "Deployed to" | awk '{print $3}')
 if [ -z "$PANDORA_SERVICE_ADDRESS" ]; then
     echo "Error: Failed to extract PandoraService proxy address"

--- a/service_contracts/tools/upgrade-pandora-calibnet.sh
+++ b/service_contracts/tools/upgrade-pandora-calibnet.sh
@@ -1,0 +1,62 @@
+#! /bin/bash
+# upgrade-pandora-calibnet upgrades the Pandora service contract and initializes new parameters
+# Assumption: KEYSTORE, PASSWORD, RPC_URL env vars are set to an appropriate eth keystore path and password
+# and to a valid RPC_URL for the calibnet.
+# Assumption: forge, cast, jq are in the PATH
+# Assumption: called from contracts directory so forge paths work out
+#
+echo "Upgrading Pandora Service Contract"
+
+if [ -z "$RPC_URL" ]; then
+  echo "Error: RPC_URL is not set"
+  exit 1
+fi
+
+if [ -z "$KEYSTORE" ]; then
+  echo "Error: KEYSTORE is not set"
+  exit 1
+fi
+
+if [ -z "$PANDORA_SERVICE_PROXY_ADDRESS" ]; then
+  echo "Error: PANDORA_SERVICE_PROXY_ADDRESS is not set"
+  exit 1
+fi
+
+# Proving period configuration - use defaults if not set
+MAX_PROVING_PERIOD="${MAX_PROVING_PERIOD:-30}"                      # Default 30 epochs (15 minutes on calibnet)
+CHALLENGE_WINDOW_SIZE="${CHALLENGE_WINDOW_SIZE:-15}"                # Default 15 epochs
+
+ADDR=$(cast wallet address --keystore "$KEYSTORE" --password "$PASSWORD")
+echo "Upgrading contracts from address $ADDR"
+ 
+NONCE="$(cast nonce --rpc-url "$RPC_URL" "$ADDR")"
+
+# Deploy new PandoraService implementation
+echo "Deploying new PandoraService implementation..."
+NEW_IMPLEMENTATION_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 src/PandoraService.sol:PandoraService --optimizer-runs 1 --via-ir | grep "Deployed to" | awk '{print $3}')
+if [ -z "$NEW_IMPLEMENTATION_ADDRESS" ]; then
+    echo "Error: Failed to extract new PandoraService implementation address"
+    exit 1
+fi
+echo "New PandoraService implementation deployed at: $NEW_IMPLEMENTATION_ADDRESS"
+NONCE=$(expr $NONCE + "1")
+
+# Upgrade the proxy to point to the new implementation
+echo "Upgrading proxy to new implementation..."
+cast send --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --nonce $NONCE --chain-id 314159 $PANDORA_SERVICE_PROXY_ADDRESS "upgradeToAndCall(address,bytes)" $NEW_IMPLEMENTATION_ADDRESS $(cast calldata "initializeV2(uint64,uint256)" $MAX_PROVING_PERIOD $CHALLENGE_WINDOW_SIZE)
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to upgrade proxy and initialize V2"
+    exit 1
+fi
+echo "Proxy upgraded and V2 initialized successfully"
+
+# Summary of upgrade
+echo ""
+echo "=== UPGRADE SUMMARY ==="
+echo "Proxy Address: $PANDORA_SERVICE_PROXY_ADDRESS"
+echo "Old Implementation: (check previous deployment)"
+echo "New Implementation: $NEW_IMPLEMENTATION_ADDRESS" 
+echo "=========================="
+echo ""
+echo "Max proving period: $MAX_PROVING_PERIOD epochs"
+echo "Challenge window size: $CHALLENGE_WINDOW_SIZE epochs"


### PR DESCRIPTION
- change them into constants that are configured upon contract deployment
- updated the deploy scripts to set them
- updated the default value for testnets 30epochs and 15 epochs accordingly to allow faster testing iteration