### PR TITLE
chore: update signature auth fixtures for padded-size change

### DIFF
--- a/service_contracts/test/SignatureFixtureTest.t.sol
+++ b/service_contracts/test/SignatureFixtureTest.t.sol
@@ -261,7 +261,7 @@ contract SignatureFixtureTest is Test {
         console.log('        "0x0181e203922020fc7e928296e516faade986b28f92d44a4f24b935485223376a799027bc18f833",');
         console.log('        "0x0181e203922020a9eb89e9825d609ab500be99bf0770bd4e01eeaba92b8dad23c08f1f59bfe10f"');
         console.log('      ],');
-        console.log('      "rootSizes": [2032, 4064]');
+        console.log('      "rootSizes": [2048, 4096]');
         console.log('    },');
         console.log('    "scheduleRemovals": {');
         console.log('      "signature": "%s",', vm.toString(scheduleRemovalsSig));
@@ -425,7 +425,7 @@ contract SignatureFixtureTest is Test {
             root: Cids.Cid({
                 data: abi.encodePacked(hex"0181e203922020fc7e928296e516faade986b28f92d44a4f24b935485223376a799027bc18f833")
             }),
-            rawSize: 2032 // Zero-padded size of 1024
+            rawSize: 2048 // Piece size of 1024
         });
 
         // CID baga6ea4seaqkt24j5gbf2ye2wual5gn7a5yl2tqb52v2sk4nvur4bdy7lg76cdy
@@ -433,7 +433,7 @@ contract SignatureFixtureTest is Test {
             root: Cids.Cid({
                 data: abi.encodePacked(hex"0181e203922020a9eb89e9825d609ab500be99bf0770bd4e01eeaba92b8dad23c08f1f59bfe10f")
             }),
-            rawSize: 4064 // Zero-padded size of 2048
+            rawSize: 4096 // Piece size of 2048
         });
 
         return rootDataArray;

--- a/service_contracts/test/external_signatures.json
+++ b/service_contracts/test/external_signatures.json
@@ -7,11 +7,11 @@
     "withCDN": true
   },
   "addRoots": {
-    "signature": "0x0d4df872fd94796a2883f5c307d4d8402ded8ad47b9800b91a781735461a629562962255f9e14927cab71c60224fdf3f79f24799efac0aa4692d06362af5f87a1c",
+    "signature": "0x93eb7bcccb7763258d7a4b86053a186db9234a93403a6e006f56fa716d85eff72e23538848e13c2632bef16c5b8380a5fddef7b81d34ede127f632217c7eab5d1c",
     "clientDataSetId": 12345,
     "firstAdded": 1,
     "rootCidBytes": ["0x0181e203922020fc7e928296e516faade986b28f92d44a4f24b935485223376a799027bc18f833", "0x0181e203922020a9eb89e9825d609ab500be99bf0770bd4e01eeaba92b8dad23c08f1f59bfe10f"],
-    "rootSizes": [2032, 4064]
+    "rootSizes": [2048, 4096]
   },
   "scheduleRemovals": {
     "signature": "0xe092fd8b6110a4914c0be071d14c1a2c838eb61bf3cb3661e9650da241a22e2d583b7c707eace2f80c9879e123906e02ca5a1eb66d162eaa13d1b7fd19d6db341c",


### PR DESCRIPTION
This is necessary here just to match the fixtures we have in the SDK. The contract doesn't really care, but in the SDK we do a transformation from raw to padded and only ever send that in our auth signature, and we want raw to be our input values in the SDK.

Ref: https://github.com/FilOzone/synapse-sdk/issues/82
Ref: https://github.com/filecoin-project/curio/pull/529
Ref: https://github.com/FilOzone/synapse-sdk/pull/95