### PR TITLE
refactor!: update and cleanup provider info/management  

### DIFF
--- a/service_contracts/src/PandoraService.sol
+++ b/service_contracts/src/PandoraService.sol
@@ -1213,37 +1213,6 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
         return providerToId[provider];
     }
     
-    /**
-     * @notice Add a service provider directly without registration process
-     * @dev Only owner can add providers directly. This bypasses the register+approve flow.
-     * @param provider The address of the provider to add
-     * @param pdpUrl The URL for PDP services
-     * @param pieceRetrievalUrl The URL for piece retrieval services
-     */
-    function addServiceProvider(address provider, string calldata pdpUrl, string calldata pieceRetrievalUrl) external onlyOwner {
-        require(provider != address(0), "Provider address cannot be zero");
-        require(!approvedProvidersMap[provider], "Provider already approved");
-        
-        // Assign ID and store provider info
-        uint256 providerId = nextServiceProviderId++;
-        approvedProviders[providerId] = ApprovedProviderInfo({
-            owner: provider,
-            pdpUrl: pdpUrl,
-            pieceRetrievalUrl: pieceRetrievalUrl,
-            registeredAt: block.number,
-            approvedAt: block.number
-        });
-        
-        approvedProvidersMap[provider] = true;
-        providerToId[provider] = providerId;
-        
-        // Clear any pending registration if it exists
-        if (pendingProviders[provider].registeredAt > 0) {
-            delete pendingProviders[provider];
-        }
-        
-        emit ProviderApproved(provider, providerId);
-    }
 
     function getClientProofSets(address client) public view returns (ProofSetInfo[] memory) {
         uint256[] memory proofSetIds = clientProofSets[client];

--- a/service_contracts/src/PandoraService.sol
+++ b/service_contracts/src/PandoraService.sol
@@ -116,14 +116,14 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
         
     struct ApprovedProviderInfo {
         address owner;
-        string serviceUrl; // HTTP server URL for provider services; TODO: Standard API endpoints:{providerServiceUrl}/api/upload / {providerServiceUrl}/api/info 
+        string serviceURL; // HTTP server URL for provider services; TODO: Standard API endpoints:{serviceURL}/api/upload / {serviceURL}/api/info 
         bytes peerId; // libp2p peer ID (optional - empty bytes if not provided)
         uint256 registeredAt; 
         uint256 approvedAt;
     }
     
     struct PendingProviderInfo {
-        string providerServiceUrl; // HTTP server URL for provider services; TODO: Standard API endpoints:{providerServiceUrl}/api/upload / {providerServiceUrl}/api/info 
+        string serviceURL; // HTTP server URL for provider services; TODO: Standard API endpoints:{serviceURL}/api/upload / {serviceURL}/api/info 
         bytes peerId; //libp2p peer ID (optional - empty bytes if not provided)
         uint256 registeredAt;
     }
@@ -141,7 +141,7 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
     uint256 public challengeWindowSize;
     
     // Events for SP registry
-    event ProviderRegistered(address indexed provider, string providerServiceUrl, bytes peerId);
+    event ProviderRegistered(address indexed provider, string serviceURL, bytes peerId);
     event ProviderApproved(address indexed provider, uint256 indexed providerId);
     event ProviderRejected(address indexed provider);
     event ProviderRemoved(address indexed provider, uint256 indexed providerId);
@@ -1072,13 +1072,13 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
     /**
      * @notice Register as a service provider
      * @dev SPs call this to register their service URL and optionally peer ID before approval
-     * @param providerServiceUrl The HTTP server URL for provider services
+     * @param serviceURL The HTTP server URL for provider services
      * @param peerId The IPFS/libp2p peer ID for the provider (optional - pass empty bytes if not available)
      */
-    function registerServiceProvider(string calldata providerServiceUrl, bytes calldata peerId) external {
+    function registerServiceProvider(string calldata serviceURL, bytes calldata peerId) external {
         require(!approvedProvidersMap[msg.sender], "Provider already approved");
-        require(bytes(providerServiceUrl).length > 0, "Provider service URL cannot be empty");
-        require(bytes(providerServiceUrl).length <= 256, "Provider service URL too long (max 256 bytes)");
+        require(bytes(serviceURL).length > 0, "Provider service URL cannot be empty");
+        require(bytes(serviceURL).length <= 256, "Provider service URL too long (max 256 bytes)");
         require(peerId.length <= 64, "Peer ID too long (max 64 bytes)");
         
         // Check if registration is already pending
@@ -1086,12 +1086,12 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
         
         // Store pending registration
         pendingProviders[msg.sender] = PendingProviderInfo({
-            providerServiceUrl: providerServiceUrl,
+            serviceURL: serviceURL,
             peerId: peerId, // Can be empty bytes
             registeredAt: block.number
         });
         
-        emit ProviderRegistered(msg.sender, providerServiceUrl, peerId);
+        emit ProviderRegistered(msg.sender, serviceURL, peerId);
     }
     
     /**
@@ -1112,7 +1112,7 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
         uint256 providerId = nextServiceProviderId++;
         approvedProviders[providerId] = ApprovedProviderInfo({
             owner: provider,
-            providerServiceUrl: pending.providerServiceUrl,
+            serviceURL: pending.serviceURL,
             peerId: pending.peerId,
             registeredAt: pending.registeredAt,
             approvedAt: block.number

--- a/service_contracts/src/PandoraService.sol
+++ b/service_contracts/src/PandoraService.sol
@@ -116,8 +116,8 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
         
     struct ApprovedProviderInfo {
         address owner;
-        string providerServiceUrl; // HTTP server URL for provider services; TODO: Standard API endpoints:{providerServiceUrl}/api/upload / {providerServiceUrl}/api/info 
-        bytes peerId; //libp2p peer ID (optional - empty bytes if not provided)
+        string serviceUrl; // HTTP server URL for provider services; TODO: Standard API endpoints:{providerServiceUrl}/api/upload / {providerServiceUrl}/api/info 
+        bytes peerId; // libp2p peer ID (optional - empty bytes if not provided)
         uint256 registeredAt; 
         uint256 approvedAt;
     }
@@ -126,7 +126,6 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
         string providerServiceUrl; // HTTP server URL for provider services; TODO: Standard API endpoints:{providerServiceUrl}/api/upload / {providerServiceUrl}/api/info 
         bytes peerId; //libp2p peer ID (optional - empty bytes if not provided)
         uint256 registeredAt;
-        
     }
     
     mapping(uint256 => ApprovedProviderInfo) public approvedProviders;

--- a/service_contracts/src/PandoraService.sol
+++ b/service_contracts/src/PandoraService.sol
@@ -116,16 +116,17 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
         
     struct ApprovedProviderInfo {
         address owner;
-        string pdpUrl;
-        string pieceRetrievalUrl;
+        string providerServiceUrl; // HTTP server URL for provider services; TODO: Standard API endpoints:{providerServiceUrl}/api/upload / {providerServiceUrl}/api/info 
+        bytes peerId; //libp2p peer ID (optional - empty bytes if not provided)
         uint256 registeredAt; 
-        uint256 approvedAt;   
+        uint256 approvedAt;
     }
     
     struct PendingProviderInfo {
-        string pdpUrl;
-        string pieceRetrievalUrl;
-        uint256 registeredAt; 
+        string providerServiceUrl; // HTTP server URL for provider services; TODO: Standard API endpoints:{providerServiceUrl}/api/upload / {providerServiceUrl}/api/info 
+        bytes peerId; //libp2p peer ID (optional - empty bytes if not provided)
+        uint256 registeredAt;
+        
     }
     
     mapping(uint256 => ApprovedProviderInfo) public approvedProviders;
@@ -141,7 +142,7 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
     uint256 public challengeWindowSize;
     
     // Events for SP registry
-    event ProviderRegistered(address indexed provider, string pdpUrl, string pieceRetrievalUrl);
+    event ProviderRegistered(address indexed provider, string providerServiceUrl, bytes peerId);
     event ProviderApproved(address indexed provider, uint256 indexed providerId);
     event ProviderRejected(address indexed provider);
     event ProviderRemoved(address indexed provider, uint256 indexed providerId);
@@ -1071,24 +1072,27 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
     
     /**
      * @notice Register as a service provider
-     * @dev SPs call this to register their URLs before approval
-     * @param pdpUrl The URL for PDP services
-     * @param pieceRetrievalUrl The URL for piece retrieval services
+     * @dev SPs call this to register their service URL and optionally peer ID before approval
+     * @param providerServiceUrl The HTTP server URL for provider services
+     * @param peerId The IPFS/libp2p peer ID for the provider (optional - pass empty bytes if not available)
      */
-    function registerServiceProvider(string calldata pdpUrl, string calldata pieceRetrievalUrl) external {
+    function registerServiceProvider(string calldata providerServiceUrl, bytes calldata peerId) external {
         require(!approvedProvidersMap[msg.sender], "Provider already approved");
+        require(bytes(providerServiceUrl).length > 0, "Provider service URL cannot be empty");
+        require(bytes(providerServiceUrl).length <= 256, "Provider service URL too long (max 256 bytes)");
+        require(peerId.length <= 64, "Peer ID too long (max 64 bytes)");
         
         // Check if registration is already pending
         require(pendingProviders[msg.sender].registeredAt == 0, "Registration already pending");
         
         // Store pending registration
         pendingProviders[msg.sender] = PendingProviderInfo({
-            pdpUrl: pdpUrl,
-            pieceRetrievalUrl: pieceRetrievalUrl,
+            providerServiceUrl: providerServiceUrl,
+            peerId: peerId, // Can be empty bytes
             registeredAt: block.number
         });
         
-        emit ProviderRegistered(msg.sender, pdpUrl, pieceRetrievalUrl);
+        emit ProviderRegistered(msg.sender, providerServiceUrl, peerId);
     }
     
     /**
@@ -1109,8 +1113,8 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
         uint256 providerId = nextServiceProviderId++;
         approvedProviders[providerId] = ApprovedProviderInfo({
             owner: provider,
-            pdpUrl: pending.pdpUrl,
-            pieceRetrievalUrl: pending.pieceRetrievalUrl,
+            providerServiceUrl: pending.providerServiceUrl,
+            peerId: pending.peerId,
             registeredAt: pending.registeredAt,
             approvedAt: block.number
         });

--- a/service_contracts/test/PandoraService.t.sol
+++ b/service_contracts/test/PandoraService.t.sol
@@ -160,7 +160,7 @@ contract PandoraServiceTest is Test {
     );
     
     // Registry events to verify
-    event ProviderRegistered(address indexed provider, string providerServiceUrl, bytes peerId);
+    event ProviderRegistered(address indexed provider, string serviceURL, bytes peerId);
     event ProviderApproved(address indexed provider, uint256 indexed providerId);
     event ProviderRejected(address indexed provider);
     event ProviderRemoved(address indexed provider, uint256 indexed providerId);
@@ -469,7 +469,7 @@ contract PandoraServiceTest is Test {
         
         // Verify pending registration
         PandoraService.PendingProviderInfo memory pending = pdpServiceWithPayments.getPendingProvider(sp1);
-        assertEq(pending.providerServiceUrl, validServiceUrl, "Provider service URL should match");
+        assertEq(pending.serviceURL, validServiceUrl, "Provider service URL should match");
         assertEq(pending.peerId, validPeerId, "Peer ID should match");
         assertEq(pending.registeredAt, block.number, "Registration epoch should match");
     }
@@ -525,7 +525,7 @@ contract PandoraServiceTest is Test {
         // Verify SP info
         PandoraService.ApprovedProviderInfo memory info = pdpServiceWithPayments.getApprovedProvider(1);
         assertEq(info.owner, sp1, "Owner should match");
-        assertEq(info.providerServiceUrl, validServiceUrl, "Provider service URL should match");
+        assertEq(info.serviceURL, validServiceUrl, "Provider service URL should match");
         assertEq(info.peerId, validPeerId, "Peer ID should match");
         assertEq(info.registeredAt, registrationBlock, "Registration epoch should match");
         assertEq(info.approvedAt, approvalBlock, "Approval epoch should match");
@@ -611,7 +611,7 @@ contract PandoraServiceTest is Test {
         // Verify new registration
         PandoraService.PendingProviderInfo memory pending = pdpServiceWithPayments.getPendingProvider(sp1);
         assertTrue(pending.registeredAt > 0, "New pending registration should exist");
-        assertEq(pending.providerServiceUrl, validServiceUrl2, "New provider service URL should match");
+        assertEq(pending.serviceURL, validServiceUrl2, "New provider service URL should match");
     }
 
     function testOnlyOwnerCanReject() public {
@@ -720,7 +720,7 @@ contract PandoraServiceTest is Test {
         // Verify new registration
         PandoraService.PendingProviderInfo memory pending = pdpServiceWithPayments.getPendingProvider(sp1);
         assertTrue(pending.registeredAt > 0, "New pending registration should exist");
-        assertEq(pending.providerServiceUrl, validServiceUrl2, "New provider service URL should match");
+        assertEq(pending.serviceURL, validServiceUrl2, "New provider service URL should match");
     }
 
     function testNonWhitelistedProviderCannotCreateProofSet() public {
@@ -805,7 +805,7 @@ contract PandoraServiceTest is Test {
         // Get provider info
         PandoraService.ApprovedProviderInfo memory info = pdpServiceWithPayments.getApprovedProvider(1);
         assertEq(info.owner, sp1, "Owner should match");
-        assertEq(info.providerServiceUrl, validServiceUrl, "Provider service URL should match");
+        assertEq(info.serviceURL, validServiceUrl, "Provider service URL should match");
     }
 
     function testGetApprovedProviderInvalidId() public {
@@ -847,7 +847,7 @@ contract PandoraServiceTest is Test {
         // Check pending
         pending = pdpServiceWithPayments.getPendingProvider(sp1);
         assertTrue(pending.registeredAt > 0, "Should have pending registration");
-        assertEq(pending.providerServiceUrl, validServiceUrl, "Provider service URL should match");
+        assertEq(pending.serviceURL, validServiceUrl, "Provider service URL should match");
     }
 
     function testGetProviderIdByAddress() public {
@@ -932,7 +932,7 @@ contract PandoraServiceTest is Test {
         assertFalse(pdpServiceWithPayments.isProviderApproved(sp1), "SP should not be approved");
         PandoraService.PendingProviderInfo memory pending = pdpServiceWithPayments.getPendingProvider(sp1);
         assertTrue(pending.registeredAt > 0, "Should have pending registration");
-        assertEq(pending.providerServiceUrl, validServiceUrl2, "Pending URL should match new registration");
+        assertEq(pending.serviceURL, validServiceUrl2, "Pending URL should match new registration");
     }
     
     function testRemoveProviderInvalidId() public {
@@ -992,8 +992,8 @@ contract PandoraServiceTest is Test {
         assertEq(providers[1].owner, sp3, "Second provider should be sp3 (sp2 filtered out)");
         
         // Verify the URLs are correct for remaining providers
-        assertEq(providers[0].providerServiceUrl, validServiceUrl, "SP1 provider service URL should be correct");
-        assertEq(providers[1].providerServiceUrl, "https://sp3.example.com", "SP3 provider service URL should be correct");
+        assertEq(providers[0].serviceURL, validServiceUrl, "SP1 provider service URL should be correct");
+        assertEq(providers[1].serviceURL, "https://sp3.example.com", "SP3 provider service URL should be correct");
         
         // Edge case 1: Remove all providers
         pdpServiceWithPayments.removeServiceProvider(1);
@@ -1018,7 +1018,7 @@ contract PandoraServiceTest is Test {
         PandoraService.ApprovedProviderInfo[] memory providers = pdpServiceWithPayments.getAllApprovedProviders();
         assertEq(providers.length, 1, "Should have one approved provider");
         assertEq(providers[0].owner, sp1, "Provider should be sp1");
-        assertEq(providers[0].providerServiceUrl, validServiceUrl, "Provider service URL should match");
+        assertEq(providers[0].serviceURL, validServiceUrl, "Provider service URL should match");
         
         // Remove the single provider
         pdpServiceWithPayments.removeServiceProvider(1);
@@ -1066,8 +1066,8 @@ contract PandoraServiceTest is Test {
         assertEq(providers.length, 2, "Should only have two active providers");
         assertEq(providers[0].owner, sp2, "First active provider should be sp2");
         assertEq(providers[1].owner, address(0xf7), "Second active provider should be sp5");
-        assertEq(providers[0].providerServiceUrl, serviceUrls[1], "SP2 URL should match");
-        assertEq(providers[1].providerServiceUrl, serviceUrls[4], "SP5 URL should match");
+        assertEq(providers[0].serviceURL, serviceUrls[1], "SP2 URL should match");
+        assertEq(providers[1].serviceURL, serviceUrls[4], "SP5 URL should match");
     }
 
 

--- a/service_contracts/test/PandoraService.t.sol
+++ b/service_contracts/test/PandoraService.t.sol
@@ -152,7 +152,6 @@ contract PandoraServiceTest is Test {
     string public validServiceUrl2 = "http://sp2.example.com:8080";
     bytes public validPeerId = hex"122019e5f1b0e1e7c1c1b1a1b1c1d1e1f1010203040506070809";
     bytes public validPeerId2 = hex"122019e5f1b0e1e7c1c1b1a1b1c1d1e1f1010203040506070810";
-    bytes public emptyPeerId = "";
 
     // Events from Payments contract to verify
     event RailCreated(

--- a/service_contracts/test/PandoraService.t.sol
+++ b/service_contracts/test/PandoraService.t.sol
@@ -147,11 +147,12 @@ contract PandoraServiceTest is Test {
     uint256 public proofSetId;
     bytes public extraData;
     
-    // Test URLs for registry
-    string public validPdpUrl = "https://sp1.example.com/pdp";
-    string public validRetrievalUrl = "https://sp1.example.com/retrieve";
-    string public validPdpUrl2 = "http://sp2.example.com:8080/pdp";
-    string public validRetrievalUrl2 = "http://sp2.example.com:8080/retrieve";
+    // Test URLs and peer IDs for registry
+    string public validServiceUrl = "https://sp1.example.com";
+    string public validServiceUrl2 = "http://sp2.example.com:8080";
+    bytes public validPeerId = hex"122019e5f1b0e1e7c1c1b1a1b1c1d1e1f1010203040506070809";
+    bytes public validPeerId2 = hex"122019e5f1b0e1e7c1c1b1a1b1c1d1e1f1010203040506070810";
+    bytes public emptyPeerId = "";
 
     // Events from Payments contract to verify
     event RailCreated(
@@ -159,7 +160,7 @@ contract PandoraServiceTest is Test {
     );
     
     // Registry events to verify
-    event ProviderRegistered(address indexed provider, string pdpUrl, string pieceRetrievalUrl);
+    event ProviderRegistered(address indexed provider, string providerServiceUrl, bytes peerId);
     event ProviderApproved(address indexed provider, uint256 indexed providerId);
     event ProviderRejected(address indexed provider);
     event ProviderRemoved(address indexed provider, uint256 indexed providerId);
@@ -460,16 +461,16 @@ contract PandoraServiceTest is Test {
         vm.startPrank(sp1);
         
         vm.expectEmit(true, false, false, true);
-        emit ProviderRegistered(sp1, validPdpUrl, validRetrievalUrl);
+        emit ProviderRegistered(sp1, validServiceUrl, validPeerId);
         
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl, validRetrievalUrl);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl, validPeerId);
         
         vm.stopPrank();
         
         // Verify pending registration
         PandoraService.PendingProviderInfo memory pending = pdpServiceWithPayments.getPendingProvider(sp1);
-        assertEq(pending.pdpUrl, validPdpUrl, "PDP URL should match");
-        assertEq(pending.pieceRetrievalUrl, validRetrievalUrl, "Retrieval URL should match");
+        assertEq(pending.providerServiceUrl, validServiceUrl, "Provider service URL should match");
+        assertEq(pending.peerId, validPeerId, "Peer ID should match");
         assertEq(pending.registeredAt, block.number, "Registration epoch should match");
     }
 
@@ -477,11 +478,11 @@ contract PandoraServiceTest is Test {
         vm.startPrank(sp1);
         
         // First registration
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl, validRetrievalUrl);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl, validPeerId);
         
         // Try to register again
         vm.expectRevert("Registration already pending");
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl2, validRetrievalUrl2);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl2, validPeerId2);
         
         vm.stopPrank();
     }
@@ -489,20 +490,20 @@ contract PandoraServiceTest is Test {
     function testCannotRegisterIfAlreadyApproved() public {
         // Register and approve SP1
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl, validRetrievalUrl);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl, validPeerId);
         
         pdpServiceWithPayments.approveServiceProvider(sp1);
         
         // Try to register again
         vm.prank(sp1);
         vm.expectRevert("Provider already approved");
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl2, validRetrievalUrl2);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl2, validPeerId2);
     }
 
     function testApproveServiceProvider() public {
         // SP registers
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl, validRetrievalUrl);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl, validPeerId);
         
         // Get the registration block from pending info
         PandoraService.PendingProviderInfo memory pendingInfo = pdpServiceWithPayments.getPendingProvider(sp1);
@@ -524,8 +525,8 @@ contract PandoraServiceTest is Test {
         // Verify SP info
         PandoraService.ApprovedProviderInfo memory info = pdpServiceWithPayments.getApprovedProvider(1);
         assertEq(info.owner, sp1, "Owner should match");
-        assertEq(info.pdpUrl, validPdpUrl, "PDP URL should match");
-        assertEq(info.pieceRetrievalUrl, validRetrievalUrl, "Retrieval URL should match");
+        assertEq(info.providerServiceUrl, validServiceUrl, "Provider service URL should match");
+        assertEq(info.peerId, validPeerId, "Peer ID should match");
         assertEq(info.registeredAt, registrationBlock, "Registration epoch should match");
         assertEq(info.approvedAt, approvalBlock, "Approval epoch should match");
         
@@ -537,10 +538,10 @@ contract PandoraServiceTest is Test {
     function testApproveMultipleProviders() public {
         // Multiple SPs register
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl, validRetrievalUrl);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl, validPeerId);
         
         vm.prank(sp2);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl2, validRetrievalUrl2);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl2, validPeerId2);
         
         // Approve both
         pdpServiceWithPayments.approveServiceProvider(sp1);
@@ -554,7 +555,7 @@ contract PandoraServiceTest is Test {
 
     function testOnlyOwnerCanApprove() public {
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl, validRetrievalUrl);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl, validPeerId);
         
         vm.prank(sp2);
         vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, sp2));
@@ -569,7 +570,7 @@ contract PandoraServiceTest is Test {
     function testCannotApproveAlreadyApprovedProvider() public {
         // Register and approve
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl, validRetrievalUrl);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl, validPeerId);
         pdpServiceWithPayments.approveServiceProvider(sp1);
         
         // Try to approve again (would need to re-register first, but we test the check)
@@ -580,7 +581,7 @@ contract PandoraServiceTest is Test {
     function testRejectServiceProvider() public {
         // SP registers
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl, validRetrievalUrl);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl, validPeerId);
         
         // Owner rejects
         vm.expectEmit(true, false, false, false);
@@ -600,22 +601,22 @@ contract PandoraServiceTest is Test {
     function testCanReregisterAfterRejection() public {
         // Register and reject
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl, validRetrievalUrl);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl, validPeerId);
         pdpServiceWithPayments.rejectServiceProvider(sp1);
         
         // Register again with different URLs
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl2, validRetrievalUrl2);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl2, validPeerId2);
         
         // Verify new registration
         PandoraService.PendingProviderInfo memory pending = pdpServiceWithPayments.getPendingProvider(sp1);
         assertTrue(pending.registeredAt > 0, "New pending registration should exist");
-        assertEq(pending.pdpUrl, validPdpUrl2, "New PDP URL should match");
+        assertEq(pending.providerServiceUrl, validServiceUrl2, "New provider service URL should match");
     }
 
     function testOnlyOwnerCanReject() public {
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl, validRetrievalUrl);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl, validPeerId);
         
         vm.prank(sp2);
         vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, sp2));
@@ -632,7 +633,7 @@ contract PandoraServiceTest is Test {
     function testRemoveServiceProvider() public {
         // Register and approve SP
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl, validRetrievalUrl);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl, validPeerId);
         pdpServiceWithPayments.approveServiceProvider(sp1);
         
         // Verify SP is approved
@@ -653,7 +654,7 @@ contract PandoraServiceTest is Test {
     function testOnlyOwnerCanRemove() public {
         // Register and approve SP
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl, validRetrievalUrl);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl, validPeerId);
         pdpServiceWithPayments.approveServiceProvider(sp1);
         
         // Try to remove as non-owner
@@ -665,7 +666,7 @@ contract PandoraServiceTest is Test {
     function testRemovedProviderCannotCreateProofSet() public {
         // Register and approve SP
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl, validRetrievalUrl);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl, validPeerId);
         pdpServiceWithPayments.approveServiceProvider(sp1);
         
         // Remove the provider
@@ -706,7 +707,7 @@ contract PandoraServiceTest is Test {
     function testCanReregisterAfterRemoval() public {
         // Register and approve SP
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl, validRetrievalUrl);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl, validPeerId);
         pdpServiceWithPayments.approveServiceProvider(sp1);
         
         // Remove the provider
@@ -714,12 +715,12 @@ contract PandoraServiceTest is Test {
         
         // Should be able to register again
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl2, validRetrievalUrl2);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl2, validPeerId2);
         
         // Verify new registration
         PandoraService.PendingProviderInfo memory pending = pdpServiceWithPayments.getPendingProvider(sp1);
         assertTrue(pending.registeredAt > 0, "New pending registration should exist");
-        assertEq(pending.pdpUrl, validPdpUrl2, "New PDP URL should match");
+        assertEq(pending.providerServiceUrl, validServiceUrl2, "New provider service URL should match");
     }
 
     function testNonWhitelistedProviderCannotCreateProofSet() public {
@@ -758,7 +759,7 @@ contract PandoraServiceTest is Test {
     function testWhitelistedProviderCanCreateProofSet() public {
         // Register and approve SP
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl, validRetrievalUrl);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl, validPeerId);
         pdpServiceWithPayments.approveServiceProvider(sp1);
         
         // Prepare extra data
@@ -798,13 +799,13 @@ contract PandoraServiceTest is Test {
     function testGetApprovedProvider() public {
         // Register and approve
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl, validRetrievalUrl);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl, validPeerId);
         pdpServiceWithPayments.approveServiceProvider(sp1);
         
         // Get provider info
         PandoraService.ApprovedProviderInfo memory info = pdpServiceWithPayments.getApprovedProvider(1);
         assertEq(info.owner, sp1, "Owner should match");
-        assertEq(info.pdpUrl, validPdpUrl, "PDP URL should match");
+        assertEq(info.providerServiceUrl, validServiceUrl, "Provider service URL should match");
     }
 
     function testGetApprovedProviderInvalidId() public {
@@ -816,7 +817,7 @@ contract PandoraServiceTest is Test {
         
         // Approve one provider
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl, validRetrievalUrl);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl, validPeerId);
         pdpServiceWithPayments.approveServiceProvider(sp1);
         
         vm.expectRevert("Invalid provider ID");
@@ -828,7 +829,7 @@ contract PandoraServiceTest is Test {
         
         // Register and approve
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl, validRetrievalUrl);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl, validPeerId);
         pdpServiceWithPayments.approveServiceProvider(sp1);
         
         assertTrue(pdpServiceWithPayments.isProviderApproved(sp1), "Should be approved after approval");
@@ -841,12 +842,12 @@ contract PandoraServiceTest is Test {
         
         // Register
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl, validRetrievalUrl);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl, validPeerId);
         
         // Check pending
         pending = pdpServiceWithPayments.getPendingProvider(sp1);
         assertTrue(pending.registeredAt > 0, "Should have pending registration");
-        assertEq(pending.pdpUrl, validPdpUrl, "PDP URL should match");
+        assertEq(pending.providerServiceUrl, validServiceUrl, "Provider service URL should match");
     }
 
     function testGetProviderIdByAddress() public {
@@ -854,7 +855,7 @@ contract PandoraServiceTest is Test {
         
         // Register and approve
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl, validRetrievalUrl);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl, validPeerId);
         pdpServiceWithPayments.approveServiceProvider(sp1);
         
         assertEq(pdpServiceWithPayments.getProviderIdByAddress(sp1), 1, "Should have ID 1 after approval");
@@ -865,7 +866,7 @@ contract PandoraServiceTest is Test {
     function testRemoveServiceProviderAfterReregistration() public {
         // Register and approve SP
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl, validRetrievalUrl);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl, validPeerId);
         pdpServiceWithPayments.approveServiceProvider(sp1);
         
         // Remove the provider
@@ -873,7 +874,7 @@ contract PandoraServiceTest is Test {
         
         // SP re-registers with different URLs
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl2, validRetrievalUrl2);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl2, validPeerId2);
         
         // Approve again
         pdpServiceWithPayments.approveServiceProvider(sp1);
@@ -887,13 +888,13 @@ contract PandoraServiceTest is Test {
     function testRemoveMultipleProviders() public {
         // Register and approve multiple SPs
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl, validRetrievalUrl);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl, validPeerId);
         
         vm.prank(sp2);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl2, validRetrievalUrl2);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl2, validPeerId2);
         
         vm.prank(sp3);
-        pdpServiceWithPayments.registerServiceProvider("https://sp3.example.com/pdp", "https://sp3.example.com/retrieve");
+        pdpServiceWithPayments.registerServiceProvider("https://sp3.example.com", hex"122019e5f1b0e1e7c1c1b1a1b1c1d1e1f1010203040506070811");
         
         // Approve all
         pdpServiceWithPayments.approveServiceProvider(sp1);
@@ -917,7 +918,7 @@ contract PandoraServiceTest is Test {
     function testRemoveProviderWithPendingRegistration() public {
         // Register and approve SP
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl, validRetrievalUrl);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl, validPeerId);
         pdpServiceWithPayments.approveServiceProvider(sp1);
         
         // Remove the provider
@@ -925,13 +926,13 @@ contract PandoraServiceTest is Test {
         
         // SP tries to register again while removed
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl2, validRetrievalUrl2);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl2, validPeerId2);
         
         // Verify SP has pending registration but is not approved
         assertFalse(pdpServiceWithPayments.isProviderApproved(sp1), "SP should not be approved");
         PandoraService.PendingProviderInfo memory pending = pdpServiceWithPayments.getPendingProvider(sp1);
         assertTrue(pending.registeredAt > 0, "Should have pending registration");
-        assertEq(pending.pdpUrl, validPdpUrl2, "Pending URL should match new registration");
+        assertEq(pending.providerServiceUrl, validServiceUrl2, "Pending URL should match new registration");
     }
     
     function testRemoveProviderInvalidId() public {
@@ -947,7 +948,7 @@ contract PandoraServiceTest is Test {
     function testCannotRemoveAlreadyRemovedProvider() public {
         // Register and approve SP
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl, validRetrievalUrl);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl, validPeerId);
         pdpServiceWithPayments.approveServiceProvider(sp1);
         
         // Remove the provider
@@ -961,15 +962,15 @@ contract PandoraServiceTest is Test {
     function testGetAllApprovedProvidersAfterRemoval() public {
         // Register and approve three providers
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl, validRetrievalUrl);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl, validPeerId);
         pdpServiceWithPayments.approveServiceProvider(sp1);
         
         vm.prank(sp2);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl2, validRetrievalUrl2);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl2, validPeerId2);
         pdpServiceWithPayments.approveServiceProvider(sp2);
         
         vm.prank(sp3);
-        pdpServiceWithPayments.registerServiceProvider("https://sp3.example.com/pdp", "https://sp3.example.com/retrieve");
+        pdpServiceWithPayments.registerServiceProvider("https://sp3.example.com", hex"122019e5f1b0e1e7c1c1b1a1b1c1d1e1f1010203040506070811");
         pdpServiceWithPayments.approveServiceProvider(sp3);
         
         // Verify all three are approved
@@ -991,8 +992,8 @@ contract PandoraServiceTest is Test {
         assertEq(providers[1].owner, sp3, "Second provider should be sp3 (sp2 filtered out)");
         
         // Verify the URLs are correct for remaining providers
-        assertEq(providers[0].pdpUrl, validPdpUrl, "SP1 PDP URL should be correct");
-        assertEq(providers[1].pdpUrl, "https://sp3.example.com/pdp", "SP3 PDP URL should be correct");
+        assertEq(providers[0].providerServiceUrl, validServiceUrl, "SP1 provider service URL should be correct");
+        assertEq(providers[1].providerServiceUrl, "https://sp3.example.com", "SP3 provider service URL should be correct");
         
         // Edge case 1: Remove all providers
         pdpServiceWithPayments.removeServiceProvider(1);
@@ -1011,13 +1012,13 @@ contract PandoraServiceTest is Test {
     function testGetAllApprovedProvidersSingleProvider() public {
         // Edge case: Only one approved provider
         vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider(validPdpUrl, validRetrievalUrl);
+        pdpServiceWithPayments.registerServiceProvider(validServiceUrl, validPeerId);
         pdpServiceWithPayments.approveServiceProvider(sp1);
         
         PandoraService.ApprovedProviderInfo[] memory providers = pdpServiceWithPayments.getAllApprovedProviders();
         assertEq(providers.length, 1, "Should have one approved provider");
         assertEq(providers[0].owner, sp1, "Provider should be sp1");
-        assertEq(providers[0].pdpUrl, validPdpUrl, "PDP URL should match");
+        assertEq(providers[0].providerServiceUrl, validServiceUrl, "Provider service URL should match");
         
         // Remove the single provider
         pdpServiceWithPayments.removeServiceProvider(1);
@@ -1030,17 +1031,24 @@ contract PandoraServiceTest is Test {
         // Edge case: Many providers removed, only few remain
         // Register and approve 5 providers
         address[5] memory sps = [sp1, sp2, sp3, address(0xf6), address(0xf7)];
-        string[5] memory pdpUrls = [
-            "https://sp1.example.com/pdp",
-            "https://sp2.example.com/pdp", 
-            "https://sp3.example.com/pdp",
-            "https://sp4.example.com/pdp",
-            "https://sp5.example.com/pdp"
+        string[5] memory serviceUrls = [
+            "https://sp1.example.com",
+            "https://sp2.example.com", 
+            "https://sp3.example.com",
+            "https://sp4.example.com",
+            "https://sp5.example.com"
         ];
+        
+        bytes[5] memory peerIds;
+        peerIds[0] = hex"122019e5f1b0e1e7c1c1b1a1b1c1d1e1f1010203040506070801";
+        peerIds[1] = hex"122019e5f1b0e1e7c1c1b1a1b1c1d1e1f1010203040506070802";
+        peerIds[2] = hex"122019e5f1b0e1e7c1c1b1a1b1c1d1e1f1010203040506070803";
+        peerIds[3] = hex"122019e5f1b0e1e7c1c1b1a1b1c1d1e1f1010203040506070804";
+        peerIds[4] = hex"122019e5f1b0e1e7c1c1b1a1b1c1d1e1f1010203040506070805";
         
         for (uint i = 0; i < 5; i++) {
             vm.prank(sps[i]);
-            pdpServiceWithPayments.registerServiceProvider(pdpUrls[i], "https://example.com/retrieve");
+            pdpServiceWithPayments.registerServiceProvider(serviceUrls[i], peerIds[i]);
             pdpServiceWithPayments.approveServiceProvider(sps[i]);
         }
         
@@ -1058,8 +1066,8 @@ contract PandoraServiceTest is Test {
         assertEq(providers.length, 2, "Should only have two active providers");
         assertEq(providers[0].owner, sp2, "First active provider should be sp2");
         assertEq(providers[1].owner, address(0xf7), "Second active provider should be sp5");
-        assertEq(providers[0].pdpUrl, pdpUrls[1], "SP2 URL should match");
-        assertEq(providers[1].pdpUrl, pdpUrls[4], "SP5 URL should match");
+        assertEq(providers[0].providerServiceUrl, serviceUrls[1], "SP2 URL should match");
+        assertEq(providers[1].providerServiceUrl, serviceUrls[4], "SP5 URL should match");
     }
 
 
@@ -1068,7 +1076,7 @@ contract PandoraServiceTest is Test {
         // Register and approve provider if not already approved
         if (!pdpServiceWithPayments.isProviderApproved(provider)) {
             vm.prank(provider);
-            pdpServiceWithPayments.registerServiceProvider("https://provider.example.com/pdp", "https://provider.example.com/retrieve");
+            pdpServiceWithPayments.registerServiceProvider("https://provider.example.com", hex"122019e5f1b0e1e7c1c1b1a1b1c1d1e1f1010203040506070850");
             pdpServiceWithPayments.approveServiceProvider(provider);
         }
 


### PR DESCRIPTION
  1. Removed addServiceProvider function;  resolves https://github.com/FilOzone/filecoin-services/pull/47
  2. Updated provider structures (providerServiceUrl + peerId) (partial of #67)        - https://github.com/FilOzone/filecoin-services/issues/62 seems dependent on this
 
~  3. allow batch approval, removal and rejection to be gas/operation efficient. note: partial success is allowed ~

this may need subgraph updates
