### PR TITLE
chore: set basic service commission to 0% (was 5%)

### DIFF
--- a/service_contracts/src/PandoraService.sol
+++ b/service_contracts/src/PandoraService.sol
@@ -53,7 +53,7 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
     uint256 public operatorCommissionBps;
     
     // Commission rates for different service types
-    uint256 public basicServiceCommissionBps;    // 5% for basic service (no CDN add-on)
+    uint256 public basicServiceCommissionBps;    // 0% for basic service (no CDN add-on)
     uint256 public cdnServiceCommissionBps;      // 40% for CDN service
 
     // Mapping from client address to clientDataSetId

--- a/service_contracts/src/PandoraService.sol
+++ b/service_contracts/src/PandoraService.sol
@@ -208,8 +208,8 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
         maxProvingPeriod = _maxProvingPeriod;
         challengeWindowSize = _challengeWindowSize;
         
-        // Set commission rates: 5% for basic, 40% for service w/ CDN add-on
-        basicServiceCommissionBps = 500;  // 5%
+        // Set commission rates: 0% for basic, 40% for service w/ CDN add-on
+        basicServiceCommissionBps = 0;   // 0%
         cdnServiceCommissionBps = 4000;   // 40%
 
         // Read token decimals from the USDFC token contract

--- a/service_contracts/test/PandoraService.t.sol
+++ b/service_contracts/test/PandoraService.t.sol
@@ -243,7 +243,7 @@ contract PandoraServiceTest is Test {
         );
         assertEq(
             pdpServiceWithPayments.basicServiceCommissionBps(),
-            500, // 5%
+            0, // 0%
             "Basic service commission should be set correctly"
         );
         assertEq(
@@ -431,7 +431,7 @@ contract PandoraServiceTest is Test {
         // Verify the commission rate was set correctly for basic service (no CDN)
         uint256 railId = pdpServiceWithPayments.getProofSetRailId(newProofSetId);
         Payments.RailView memory rail = payments.getRail(railId);
-        assertEq(rail.commissionRateBps, 500, "Commission rate should be 5% for basic service (no CDN)");
+        assertEq(rail.commissionRateBps, 0, "Commission rate should be 0% for basic service (no CDN)");
     }
 
     // Helper function to get account info from the Payments contract
@@ -1205,7 +1205,7 @@ contract PandoraServiceSignatureTest is Test {
             address(mockPDPVerifier),
             address(payments),
             address(mockUSDFC),
-            500, // 5% commission
+            0, // 0% commission
             uint64(2880), // maxProvingPeriod
             uint256(60)   // challengeWindowSize
         );
@@ -1297,7 +1297,7 @@ contract PandoraServiceUpgradeTest is Test {
             address(mockPDPVerifier),
             address(payments),
             address(mockUSDFC),
-            500, // 5% commission
+            0, // 0% commission
             uint64(2880), // maxProvingPeriod
             uint256(60)   // challengeWindowSize
         );


### PR DESCRIPTION
Updates the service creator fee configuration to set the basic service commission to 0% as requested in #59.