### PR TITLE
 Implement Key-Value Metadata Structure

### DIFF
--- a/service_contracts/src/PandoraService.sol
+++ b/service_contracts/src/PandoraService.sol
@@ -22,6 +22,13 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
     event ProofSetRailCreated(uint256 indexed proofSetId, uint256 railId, address payer, address payee, bool withCDN);
     event RailRateUpdated(uint256 indexed proofSetId, uint256 railId, uint256 newRate);
     event RootMetadataAdded(uint256 indexed proofSetId, uint256 rootId, string metadata);
+    event ProofSetCreatedWithMetadata(
+        uint256 indexed proofSetId,
+        address creator,
+        address payer,
+        string[] metadataKeys,
+        bytes[] metadataValues
+    );
 
     // Constants
     uint256 public constant NO_CHALLENGE_SCHEDULED = 0;
@@ -60,6 +67,11 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
     mapping(address => uint256) public clientDataSetIDs;
     // Mapping from proof set ID to root ID to metadata
     mapping(uint256 => mapping(uint256 => string)) public proofSetRootMetadata;
+    // Mapping from proof set ID to key value pair metadata
+    // proofSetId => (key => value)
+    mapping(uint256 => mapping(string => bytes)) public proofSetMetadata;
+    // proofSetId => array of keys
+    mapping(uint256 => string[]) internal proofSetMetadataKeys;
 
     // Storage for proof set payment information
     struct ProofSetInfo {
@@ -67,7 +79,7 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
         address payer; // Address paying for storage
         address payee; // SP's beneficiary address
         uint256 commissionBps; // Commission rate for this proof set (dynamic based on whether the client purchases CDN add-on)
-        string metadata; // General metadata for the proof set
+        // string metadata; // General metadata for the proof set
         string[] rootMetadata; // Array of metadata for each root
         uint256 clientDataSetId; // ClientDataSetID
         bool withCDN; // Whether the proof set is registered for CDN add-on
@@ -75,8 +87,9 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
 
     // Decode structure for proof set creation extra data
     struct ProofSetCreateData {
-        string metadata;
         address payer;
+        string[] metadataKeys;
+        bytes[] metadataValues;
         bool withCDN;
         bytes signature; // Authentication signature
     }
@@ -380,7 +393,21 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
         ProofSetInfo storage info = proofSetInfo[proofSetId];
         info.payer = createData.payer;
         info.payee = creator; // Using creator as the payee
-        info.metadata = createData.metadata;
+        // info.metadata = createData.metadata;
+        // Store each metadata key-value entry for this proof set
+        for (uint256 i = 0; i < createData.metadataKeys.length; i++) {
+            // proofSetMetadata[proofSetId][createData.metadataKeys[i]] = createData.metadataValues[i];
+            string memory key = createData.metadataKeys[i];
+            bytes memory value = createData.metadataValues[i];
+
+            if (proofSetMetadata[proofSetId][key].length == 0) {
+                // If the key doesn't exist, add it to the keys array
+                proofSetMetadataKeys[proofSetId].push(key);
+            }
+
+            // Store the metadata value
+            proofSetMetadata[proofSetId][key] = value;
+        }
         info.commissionBps = createData.withCDN ? cdnServiceCommissionBps : basicServiceCommissionBps;
         info.clientDataSetId = clientDataSetId;
         info.withCDN = createData.withCDN;
@@ -422,6 +449,15 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
 
         // Emit event for tracking
         emit ProofSetRailCreated(proofSetId, railId, createData.payer, creator, createData.withCDN);
+
+        // Emit event for proof set creation with metadata
+        emit ProofSetCreatedWithMetadata(
+            proofSetId,
+            creator,
+            createData.payer,
+            createData.metadataKeys,
+            createData.metadataValues
+        );
     }
 
     /**
@@ -773,12 +809,13 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
      * @return decoded The decoded ProofSetCreateData struct
      */
     function decodeProofSetCreateData(bytes calldata extraData) internal pure returns (ProofSetCreateData memory) {
-         (string memory metadata, address payer, bool withCDN, bytes memory signature) = 
-        abi.decode(extraData, (string, address, bool, bytes));
+         (address payer, string[] memory keys, bytes[] memory values, bool withCDN, bytes memory signature) = 
+        abi.decode(extraData, (address, string[], bytes[], bool, bytes));
 
         return ProofSetCreateData({
-            metadata: metadata,
             payer: payer,
+            metadataKeys: keys,
+            metadataValues: values,
             withCDN: withCDN,
             signature: signature
         });
@@ -827,10 +864,20 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
     /**
      * @notice Get the metadata for a proof set
      * @param proofSetId The ID of the proof set
+     * @param key The metadata key to look up
      * @return The metadata string
      */
-    function getProofSetMetadata(uint256 proofSetId) external view returns (string memory) {
-        return proofSetInfo[proofSetId].metadata;
+    function getProofSetMetadata(uint256 proofSetId, string calldata key) external view returns (bytes memory) {
+        return proofSetMetadata[proofSetId][key];
+    }
+
+    /*
+     * @notice Get all metadata keys for a given proof set
+     * @param proofSetId The ID of the proof set
+     * @return keys Array of metadata keys stored for the proof set
+     */
+    function getProofSetMetadataKeys(uint256 proofSetId) external view returns (string[] memory) {
+        return proofSetMetadataKeys[proofSetId];
     }
 
     /**
@@ -1258,7 +1305,7 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
                 payer: storageInfo.payer,
                 payee: storageInfo.payee,
                 commissionBps: storageInfo.commissionBps,
-                metadata: storageInfo.metadata,
+                // metadata: storageInfo.metadata,
                 rootMetadata: storageInfo.rootMetadata,
                 clientDataSetId: storageInfo.clientDataSetId,
                 withCDN: storageInfo.withCDN

--- a/service_contracts/src/PandoraService.sol
+++ b/service_contracts/src/PandoraService.sol
@@ -79,7 +79,6 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
         address payer; // Address paying for storage
         address payee; // SP's beneficiary address
         uint256 commissionBps; // Commission rate for this proof set (dynamic based on whether the client purchases CDN add-on)
-        // string metadata; // General metadata for the proof set
         string[] rootMetadata; // Array of metadata for each root
         uint256 clientDataSetId; // ClientDataSetID
         bool withCDN; // Whether the proof set is registered for CDN add-on
@@ -1305,7 +1304,6 @@ contract PandoraService is PDPListener, IArbiter, Initializable, UUPSUpgradeable
                 payer: storageInfo.payer,
                 payee: storageInfo.payee,
                 commissionBps: storageInfo.commissionBps,
-                // metadata: storageInfo.metadata,
                 rootMetadata: storageInfo.rootMetadata,
                 clientDataSetId: storageInfo.clientDataSetId,
                 withCDN: storageInfo.withCDN

--- a/service_contracts/test/PandoraService.t.sol
+++ b/service_contracts/test/PandoraService.t.sol
@@ -282,6 +282,18 @@ contract PandoraServiceTest is Test {
         );
     }
 
+    function _getSingleMetadataKV(string memory key, string memory value) 
+        internal 
+        pure 
+        returns (string[] memory, bytes[] memory) 
+    {
+        string[] memory keys = new string[](1);
+        bytes[] memory values = new bytes[](1);
+        keys[0] = key;
+        values[0] = abi.encode(value);
+        return (keys, values);
+    }
+
     function testCreateProofSetCreatesRailAndChargesFee() public {
         // First approve the storage provider
         vm.prank(storageProvider);
@@ -289,11 +301,13 @@ contract PandoraServiceTest is Test {
         pdpServiceWithPayments.approveServiceProvider(storageProvider);
         
         // Prepare ExtraData
+        (string[] memory metadataKeys, bytes[] memory metadataValues) = _getSingleMetadataKV("label", "Test Proof Set");
+
         PandoraService.ProofSetCreateData memory createData =
-            PandoraService.ProofSetCreateData({metadata: "Test Proof Set", payer: client, signature: FAKE_SIGNATURE, withCDN: true});
+            PandoraService.ProofSetCreateData({payer: client, metadataKeys: metadataKeys, metadataValues: metadataValues, signature: FAKE_SIGNATURE, withCDN: true});
 
         // Encode the extra data
-        extraData = abi.encode(createData.metadata, createData.payer, createData.withCDN, createData.signature);
+        extraData = abi.encode(createData.payer, createData.metadataKeys, createData.metadataValues, createData.withCDN, createData.signature);
 
         // Client needs to approve the PDP Service to create a payment rail
         vm.startPrank(client);
@@ -339,8 +353,8 @@ contract PandoraServiceTest is Test {
         assertEq(payee, storageProvider, "Payee should be set to storage provider");
 
         // Verify metadata was stored correctly
-        string memory metadata = pdpServiceWithPayments.getProofSetMetadata(newProofSetId);
-        assertEq(metadata, "Test Proof Set", "Metadata should be stored correctly");
+        bytes memory metadata = pdpServiceWithPayments.getProofSetMetadata(newProofSetId, metadataKeys[0]);
+        assertEq(metadata, abi.encode("Test Proof Set"), "Metadata should be stored correctly");
 
         // Verify proof set info
         PandoraService.ProofSetInfo memory proofSetInfo = pdpServiceWithPayments.getProofSet(newProofSetId);
@@ -390,11 +404,13 @@ contract PandoraServiceTest is Test {
         pdpServiceWithPayments.approveServiceProvider(storageProvider);
         
         // Prepare ExtraData
+        (string[] memory metadataKeys, bytes[] memory metadataValues) = _getSingleMetadataKV("label", "Test Proof Set");
+
         PandoraService.ProofSetCreateData memory createData =
-            PandoraService.ProofSetCreateData({metadata: "Test Proof Set", payer: client, signature: FAKE_SIGNATURE, withCDN: false});
+            PandoraService.ProofSetCreateData({payer: client, metadataKeys: metadataKeys, metadataValues: metadataValues, signature: FAKE_SIGNATURE, withCDN: false});
 
         // Encode the extra data
-        extraData = abi.encode(createData.metadata, createData.payer, createData.withCDN, createData.signature);
+        extraData = abi.encode(createData.payer, createData.metadataKeys, createData.metadataValues, createData.withCDN, createData.signature);
 
         // Client needs to approve the PDP Service to create a payment rail
         vm.startPrank(client);
@@ -672,15 +688,18 @@ contract PandoraServiceTest is Test {
         pdpServiceWithPayments.removeServiceProvider(1);
         
         // Prepare extra data
+        (string[] memory metadataKeys, bytes[] memory metadataValues) = _getSingleMetadataKV("label", "Test Proof Set");
+
         PandoraService.ProofSetCreateData memory createData =
             PandoraService.ProofSetCreateData({
-                metadata: "Test Proof Set",
                 payer: client,
+                metadataKeys: metadataKeys,
+                metadataValues: metadataValues,
                 signature: FAKE_SIGNATURE,
                 withCDN: false
             });
         
-        bytes memory encodedData = abi.encode(createData.metadata, createData.payer, createData.withCDN, createData.signature);
+        bytes memory encodedData = abi.encode(createData.payer, createData.metadataKeys, createData.metadataValues, createData.withCDN, createData.signature);
         
         // Setup client payment approval
         vm.startPrank(client);
@@ -724,15 +743,18 @@ contract PandoraServiceTest is Test {
 
     function testNonWhitelistedProviderCannotCreateProofSet() public {
         // Prepare extra data
+        (string[] memory metadataKeys, bytes[] memory metadataValues) = _getSingleMetadataKV("label", "Test Proof Set");
+
         PandoraService.ProofSetCreateData memory createData =
             PandoraService.ProofSetCreateData({
-                metadata: "Test Proof Set",
                 payer: client,
+                metadataKeys: metadataKeys,
+                metadataValues: metadataValues,
                 signature: FAKE_SIGNATURE,
                 withCDN: false
             });
         
-        bytes memory encodedData = abi.encode(createData.metadata, createData.payer, createData.withCDN, createData.signature);
+        bytes memory encodedData = abi.encode(createData.payer, createData.metadataKeys, createData.metadataValues, createData.withCDN, createData.signature);
         
         // Setup client payment approval
         vm.startPrank(client);
@@ -762,15 +784,18 @@ contract PandoraServiceTest is Test {
         pdpServiceWithPayments.approveServiceProvider(sp1);
         
         // Prepare extra data
+        (string[] memory metadataKeys, bytes[] memory metadataValues) = _getSingleMetadataKV("label", "Test Proof Set");
+
         PandoraService.ProofSetCreateData memory createData =
             PandoraService.ProofSetCreateData({
-                metadata: "Test Proof Set",
                 payer: client,
+                metadataKeys: metadataKeys,
+                metadataValues: metadataValues,
                 signature: FAKE_SIGNATURE,
                 withCDN: false
             });
         
-        bytes memory encodedData = abi.encode(createData.metadata, createData.payer, createData.withCDN, createData.signature);
+        bytes memory encodedData = abi.encode(createData.payer, createData.metadataKeys, createData.metadataValues, createData.withCDN, createData.signature);
         
         // Setup client payment approval
         vm.startPrank(client);
@@ -1002,7 +1027,7 @@ contract PandoraServiceTest is Test {
         assertEq(providers.length, 0, "Should return empty array when all providers removed");
     }
     
-    function testGetAllApprovedProvidersNoProviders() public {
+    function testGetAllApprovedProvidersNoProviders() public view {
         // Edge case: No providers have been registered/approved
         PandoraService.ApprovedProviderInfo[] memory providers = pdpServiceWithPayments.getAllApprovedProviders();
         assertEq(providers.length, 0, "Should return empty array when no providers registered");
@@ -1064,7 +1089,12 @@ contract PandoraServiceTest is Test {
 
 
     // ===== Client-Proofset Tracking Tests =====
-    function createProofSetForClient(address provider, address clientAddress, string memory metadata) internal returns (uint256) {
+    function createProofSetForClient(
+        address provider, 
+        address clientAddress, 
+        string[] memory metadataKeys, 
+        bytes[] memory metadataValues
+    ) internal returns (uint256) {
         // Register and approve provider if not already approved
         if (!pdpServiceWithPayments.isProviderApproved(provider)) {
             vm.prank(provider);
@@ -1075,13 +1105,15 @@ contract PandoraServiceTest is Test {
         // Prepare extra data
         PandoraService.ProofSetCreateData memory createData =
             PandoraService.ProofSetCreateData({
-                metadata: metadata,
                 payer: clientAddress,
+                metadataKeys: metadataKeys,
+                metadataValues: metadataValues,
                 withCDN: false,
                 signature: FAKE_SIGNATURE
             });
 
-        bytes memory encodedData = abi.encode(createData.metadata, createData.payer, createData.withCDN, createData.signature);
+        bytes memory encodedData = abi.encode(
+            createData.payer, createData.metadataKeys, createData.metadataValues, createData.withCDN, createData.signature);
 
         // Setup client payment approval if not already done
         vm.startPrank(clientAddress);
@@ -1113,9 +1145,9 @@ contract PandoraServiceTest is Test {
     
     function testGetClientProofSets_SingleProofSet() public {
         // Create a single proof set for the client
-        string memory metadata = "Test metadata";
+        (string[] memory metadataKeys, bytes[] memory metadataValues) = _getSingleMetadataKV("label", "Test Proof Set");
         
-        createProofSetForClient(sp1, client, metadata);
+        createProofSetForClient(sp1, client, metadataKeys, metadataValues);
         
         // Get proof sets
         PandoraService.ProofSetInfo[] memory proofSets = 
@@ -1125,15 +1157,16 @@ contract PandoraServiceTest is Test {
         assertEq(proofSets.length, 1, "Should return one proof set");
         assertEq(proofSets[0].payer, client, "Payer should match");
         assertEq(proofSets[0].payee, sp1, "Payee should match");
-        assertEq(proofSets[0].metadata, metadata, "Metadata should match");
         assertEq(proofSets[0].clientDataSetId, 0, "First dataset ID should be 0");
         assertGt(proofSets[0].railId, 0, "Rail ID should be set");
     }
     
     function testGetClientProofSets_MultipleProofSets() public {
         // Create multiple proof sets for the client
-        createProofSetForClient(sp1, client, "Metadata 1");
-        createProofSetForClient(sp2, client, "Metadata 2");
+        (string[] memory metadataKeys1, bytes[] memory metadataValues1) = _getSingleMetadataKV("label", "Metadata 1");
+        (string[] memory metadataKeys2, bytes[] memory metadataValues2) = _getSingleMetadataKV("label", "Metadata 2");
+        createProofSetForClient(sp1, client, metadataKeys1, metadataValues1);
+        createProofSetForClient(sp2, client, metadataKeys2, metadataValues2);
         
         // Get proof sets
         PandoraService.ProofSetInfo[] memory proofSets = 
@@ -1145,14 +1178,78 @@ contract PandoraServiceTest is Test {
         // Check first proof set
         assertEq(proofSets[0].payer, client, "First proof set payer should match");
         assertEq(proofSets[0].payee, sp1, "First proof set payee should match");
-        assertEq(proofSets[0].metadata, "Metadata 1", "First proof set metadata should match");
         assertEq(proofSets[0].clientDataSetId, 0, "First dataset ID should be 0");
         
         // Check second proof set
         assertEq(proofSets[1].payer, client, "Second proof set payer should match");
         assertEq(proofSets[1].payee, sp2, "Second proof set payee should match");
-        assertEq(proofSets[1].metadata, "Metadata 2", "Second proof set metadata should match");
         assertEq(proofSets[1].clientDataSetId, 1, "Second dataset ID should be 1");
+    }
+
+    function testProofSetMetadataStorage() public {
+        // Create a proof set with metadata
+        (string[] memory metadataKeys, bytes[] memory metadataValues) = _getSingleMetadataKV("label", "Test Metadata");
+        proofSetId = createProofSetForClient(sp1, client, metadataKeys, metadataValues);
+
+        // read metadata and metadata keys from contract
+        bytes memory storedMetadata = pdpServiceWithPayments.getProofSetMetadata(proofSetId, "label");
+        string[] memory storedKeys = pdpServiceWithPayments.getProofSetMetadataKeys(proofSetId);
+
+        // Verify metadata matches
+        assertEq(storedMetadata, abi.encode("Test Metadata"), "Stored metadata should match");
+        assertEq(storedKeys.length, 1, "Should have one metadata key");
+        assertEq(storedKeys[0], "label", "Stored key should match 'label'");
+    }
+
+    function testProofSetMetadataStorageMultipleKeys() public {
+        // Create a proof set with multiple metadata entries
+        string[] memory metadataKeys = new string[](3);
+        bytes[] memory metadataValues = new bytes[](3);
+        
+        metadataKeys[0] = "label";
+        metadataValues[0] = abi.encode("Test Metadata 1");
+        
+        metadataKeys[1] = "description";
+        metadataValues[1] = abi.encode("Test Description");
+        
+        metadataKeys[2] = "version";
+        metadataValues[2] = abi.encode("1.0.0");
+        
+        proofSetId = createProofSetForClient(sp1, client, metadataKeys, metadataValues);
+
+        // read metadata and metadata keys from contract
+        bytes memory storedMetadata1 = pdpServiceWithPayments.getProofSetMetadata(proofSetId, "label");
+        bytes memory storedMetadata2 = pdpServiceWithPayments.getProofSetMetadata(proofSetId, "description");
+        bytes memory storedMetadata3 = pdpServiceWithPayments.getProofSetMetadata(proofSetId, "version");
+        
+        string[] memory storedKeys = pdpServiceWithPayments.getProofSetMetadataKeys(proofSetId);
+
+        // Verify metadata matches
+        assertEq(storedMetadata1, abi.encode("Test Metadata 1"), "Stored label should match");
+        assertEq(storedMetadata2, abi.encode("Test Description"), "Stored description should match");
+        assertEq(storedMetadata3, abi.encode("1.0.0"), "Stored version should match");
+        
+        assertEq(storedKeys.length, 3, "Should have three metadata keys");
+        assertEq(storedKeys[0], "label", "First key should be 'label'");
+        assertEq(storedKeys[1], "description", "Second key should be 'description'");
+        assertEq(storedKeys[2], "version", "Third key should be 'version'");
+    }
+
+    function testProofSetMetadataStorageMultipleProofSets() public {
+        // Create multiple proof sets with metadata
+        (string[] memory metadataKeys1, bytes[] memory metadataValues1) = _getSingleMetadataKV("label", "Proof Set 1");
+        (string[] memory metadataKeys2, bytes[] memory metadataValues2) = _getSingleMetadataKV("label", "Proof Set 2");
+        
+        uint256 proofSetId1 = createProofSetForClient(sp1, client, metadataKeys1, metadataValues1);
+        uint256 proofSetId2 = createProofSetForClient(sp2, client, metadataKeys2, metadataValues2);
+
+        // read metadata for both proof sets
+        bytes memory storedMetadata1 = pdpServiceWithPayments.getProofSetMetadata(proofSetId1, "label");
+        bytes memory storedMetadata2 = pdpServiceWithPayments.getProofSetMetadata(proofSetId2, "label");
+
+        // Verify metadata matches
+        assertEq(storedMetadata1, abi.encode("Proof Set 1"), "Stored metadata for first proof set should match");
+        assertEq(storedMetadata2, abi.encode("Proof Set 2"), "Stored metadata for second proof set should match");
     }
 }
 


### PR DESCRIPTION
## Summary

- Switched proof set metadata to a key-value model (`mapping(uint256 => mapping(string => bytes))`).
- Updated all function and structs to use `metadataKeys[]` and `metadataValues[]` instead of string-based metadata.
- Updated the test suite to cover the new structure.
- Added `testProofSetMetadataStorage`, `testProofSetMetadataStorageMultipleKeys`, and `testProofSetMetadataStorageMultipleProofSets`.

Closes #63 