### PR TITLE
Refactor: Replace String-Based Errors with Custom Errors

### DIFF
--- a/service_contracts/src/Errors.sol
+++ b/service_contracts/src/Errors.sol
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+pragma solidity ^0.8.27;
+
+/// @title Errors
+/// @notice Centralized library for custom error definitions across the protocol
+library Errors {
+    /// @notice Identifies which contract address field was zero when a non-zero address was required
+    /// @dev Used as a parameter to the {ZeroAddress} error for descriptive revert reasons
+    enum AddressField {
+        /// PDPVerifier contract address
+        PDPVerifier,
+        /// Payments contract address
+        Payments,
+        /// USDFC contract address
+        USDFC,
+        /// FilecoinCDN service contract address
+        FilecoinCDN,
+        /// Creator address
+        Creator,
+        /// Payer address
+        Payer,
+        /// Storage provider address
+        StorageProvider
+    }
+
+    /// @notice Enumerates the types of commission rates used in the protocol
+    /// @dev Used as a parameter to {CommissionExceedsMaximum} to specify which commission type exceeded the limit
+    enum CommissionType {
+        /// The operator commission rate
+        Operator,
+        /// The basic service commission rate (applies to non-CDN storage service)
+        BasicService,
+        /// The CDN service commission rate (applies to FilecoinCDN storage service)
+        CDNService
+    }
+
+    /// @notice An expected contract or participant address was the zero address
+    /// @dev Used for parameter validation when a non-zero address is required
+    /// @param field The specific address field that was zero (see enum {AddressField})
+    error ZeroAddress(AddressField field);
+
+    /// @notice Only the PDPVerifier contract can call this function
+    /// @param expected The expected PDPVerifier address
+    /// @param actual The caller address
+    error OnlyPDPVerifierAllowed(address expected, address actual);
+
+    /// @notice Commission basis points exceed the allowed maximum
+    /// @param commissionType The type of commission that exceeded the maximum (see {CommissionType})
+    /// @param max The allowed maximum commission (basis points)
+    /// @param actual The actual commission provided
+    error CommissionExceedsMaximum(CommissionType commissionType, uint256 max, uint256 actual);
+
+    /// @notice The maximum proving period must be greater than zero
+    error MaxProvingPeriodZero();
+
+    /// @notice The challenge window size must be > 0 and less than the max proving period
+    /// @param maxProvingPeriod The maximum allowed proving period
+    /// @param challengeWindowSize The provided challenge window size
+    error InvalidChallengeWindowSize(uint256 maxProvingPeriod, uint256 challengeWindowSize);
+
+    /// @notice This function can only be called by the contract itself during upgrade
+    /// @param expected The expected caller (the contract address)
+    /// @param actual The actual caller address
+    error OnlySelf(address expected, address actual);
+
+    /// @notice Proving period is not initialized for the specified data set
+    /// @param dataSetId The ID of the data set whose proving period was not initialized
+    error ProvingPeriodNotInitialized(uint256 dataSetId);
+
+    /// @notice Storage provider is not approved or whitelisted
+    /// @param provider The address of the unapproved storage provider
+    error StorageProviderNotApproved(address provider);
+
+    /// @notice The signature is invalid (recovered signer did not match expected)
+    /// @param expected The expected signer address
+    /// @param actual The recovered address from the signature
+    error InvalidSignature(address expected, address actual);
+
+    /// @notice Extra data is required but was not provided
+    error ExtraDataRequired();
+
+    /// @notice Data set is not registered with the payment system
+    /// @param dataSetId The ID of the data set
+    error DataSetNotRegistered(uint256 dataSetId);
+
+    /// @notice Only one proof of possession allowed per proving period
+    /// @param dataSetId The data set ID
+    error ProofAlreadySubmitted(uint256 dataSetId);
+
+    /// @notice Challenge count for proof of possession is invalid
+    /// @param dataSetId The dataset for which the challenge count was checked
+    /// @param minExpected The minimum expected challenge count
+    /// @param actual The actual challenge count provided
+    error InvalidChallengeCount(uint256 dataSetId, uint256 minExpected, uint256 actual);
+
+    /// @notice Proving has not yet started for the data set
+    /// @param dataSetId The data set ID
+    error ProvingNotStarted(uint256 dataSetId);
+
+    /// @notice The current proving period has already passed
+    /// @param dataSetId The data set ID
+    /// @param deadline The deadline block number
+    /// @param nowBlock The current block number
+    error ProvingPeriodPassed(uint256 dataSetId, uint256 deadline, uint256 nowBlock);
+
+    // @notice The challenge window is not open yet; too early to submit proof
+    /// @param dataSetId The data set ID
+    /// @param windowStart The start block of the challenge window
+    /// @param nowBlock The current block number
+    error ChallengeWindowTooEarly(uint256 dataSetId, uint256 windowStart, uint256 nowBlock);
+
+    /// @notice The next challenge epoch is invalid (not within the allowed challenge window)
+    /// @param dataSetId The data set ID
+    /// @param minAllowed The earliest allowed challenge epoch (window start)
+    /// @param maxAllowed The latest allowed challenge epoch (window end)
+    /// @param actual The provided challenge epoch
+    error InvalidChallengeEpoch(uint256 dataSetId, uint256 minAllowed, uint256 maxAllowed, uint256 actual);
+
+    /// @notice Only one call to nextProvingPeriod is allowed per proving period
+    /// @param dataSetId The data set ID
+    /// @param periodDeadline The deadline of the previous proving period
+    /// @param nowBlock The current block number
+    error NextProvingPeriodAlreadyCalled(uint256 dataSetId, uint256 periodDeadline, uint256 nowBlock);
+
+    /// @notice Old storage provider address does not match data set payee
+    /// @param dataSetId The data set ID
+    /// @param expected The expected (current) payee address
+    /// @param actual The provided old storage provider address
+    error OldStorageProviderMismatch(uint256 dataSetId, address expected, address actual);
+
+    /// @notice New storage provider is not approved
+    /// @param newProvider The new storage provider address
+    error NewStorageProviderNotApproved(address newProvider);
+
+    /// @notice Data set payment is already terminated
+    /// @param dataSetId The data set ID
+    error DataSetPaymentAlreadyTerminated(uint256 dataSetId);
+
+    /// @notice The specified data set does not exist or is not valid
+    /// @param dataSetId The data set ID that was invalid or unregistered
+    error InvalidDataSetId(uint256 dataSetId);
+
+    /// @notice Only payer or payee can terminate data set payment
+    /// @param dataSetId The data set ID
+    /// @param expectedPayer The payer address
+    /// @param expectedPayee The payee address
+    /// @param caller The actual caller
+    error CallerNotPayerOrPayee(uint256 dataSetId, address expectedPayer, address expectedPayee, address caller);
+
+    /// @notice Data set is beyond its payment end epoch
+    /// @param dataSetId The data set ID
+    /// @param paymentEndEpoch The payment end epoch for the data set
+    /// @param currentBlock The current block number
+    error DataSetPaymentBeyondEndEpoch(uint256 dataSetId, uint256 paymentEndEpoch, uint256 currentBlock);
+
+    /// @notice No PDP payment rail is configured for the given data set
+    /// @param dataSetId The data set ID
+    error NoPDPPaymentRail(uint256 dataSetId);
+
+    /// @notice Division by zero: denominator was zero
+    error DivisionByZero();
+
+    /// @notice Signature has an invalid length
+    /// @param actualLength The length of the provided signature (should be 65)
+    error InvalidSignatureLength(uint256 expectedLength, uint256 actualLength);
+
+    /// @notice Signature uses an unsupported v value (should be 27 or 28)
+    /// @param v The actual v value provided
+    error UnsupportedSignatureV(uint8 v);
+
+    /// @notice The provider is already approved
+    /// @param provider The provider address
+    error ProviderAlreadyApproved(address provider);
+
+    /// @notice Service URL is empty
+    error ServiceURLEmpty();
+
+    /// @notice Service URL is too long
+    /// @param length The length of the provided service URL
+    /// @param maxAllowed The maximum allowed length
+    error ServiceURLTooLong(uint256 length, uint256 maxAllowed);
+
+    /// @notice Peer ID is too long
+    /// @param length The provided peerId length
+    /// @param maxAllowed The maximum allowed length
+    error PeerIdTooLong(uint256 length, uint256 maxAllowed);
+
+    /// @notice Registration is already pending for this provider
+    /// @param provider The provider address
+    error RegistrationAlreadyPending(address provider);
+
+    /// @notice Incorrect registration fee provided
+    /// @param expected The required registration fee
+    /// @param actual The fee sent with the transaction
+    error IncorrectRegistrationFee(uint256 expected, uint256 actual);
+
+    /// @notice Burn failed when sending registration fee to burn address
+    error BurnFailed();
+
+    /// @notice No pending registration found for the provider
+    /// @param provider The provider address
+    error NoPendingRegistrationFound(address provider);
+
+    /// @notice The provider ID is invalid (not in the valid range)
+    /// @param nextServiceProviderId The next available provider ID (for context)
+    /// @param providerId The invalid provider ID
+    error InvalidProviderId(uint256 nextServiceProviderId, uint256 providerId);
+
+    /// @notice No provider found for the given provider ID
+    /// @param providerId The provider ID that was looked up
+    error ProviderNotFound(uint256 providerId);
+
+    /// @notice Provider is not currently approved
+    /// @param provider The provider address
+    error ProviderNotApproved(address provider);
+
+    /// @notice Payment rail is not associated with any data set
+    /// @param railId The rail ID
+    error RailNotAssociated(uint256 railId);
+
+    /// @notice The epoch range is invalid (toEpoch must be > fromEpoch)
+    /// @param fromEpoch The starting epoch (exclusive)
+    /// @param toEpoch The ending epoch (inclusive)
+    error InvalidEpochRange(uint256 fromEpoch, uint256 toEpoch);
+
+    /// @notice Only the Payments contract can call this function
+    /// @param expected The expected payments contract address
+    /// @param actual The caller's address
+    error CallerNotPayments(address expected, address actual);
+
+    /// @notice Only the service contract can terminate the rail
+    error ServiceContractMustTerminateRail();
+
+    /// @notice Data set does not exist for the given rail
+    /// @param railId The rail ID
+    error DataSetNotFoundForRail(uint256 railId);
+}

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -11,6 +11,7 @@ import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
 import {Payments, IValidator} from "@fws-payments/Payments.sol";
+import {Errors} from "./Errors.sol";
 
 /// @title FilecoinWarmStorageService
 /// @notice An implementation of PDP Listener with payment integration.
@@ -201,7 +202,7 @@ contract FilecoinWarmStorageService is
     // Modifier to ensure only the PDP verifier contract can call certain functions
 
     modifier onlyPDPVerifier() {
-        require(msg.sender == pdpVerifierAddress, "Caller is not the PDP verifier");
+        require(msg.sender == pdpVerifierAddress, Errors.OnlyPDPVerifierAllowed(pdpVerifierAddress, msg.sender));
         _;
     }
 
@@ -223,13 +224,21 @@ contract FilecoinWarmStorageService is
         __UUPSUpgradeable_init();
         __EIP712_init("FilecoinWarmStorageService", "1");
 
-        require(_pdpVerifierAddress != address(0), "PDP verifier address cannot be zero");
-        require(_paymentsContractAddress != address(0), "Payments contract address cannot be zero");
-        require(_usdfcTokenAddress != address(0), "USDFC token address cannot be zero");
-        require(_filCDNAddress != address(0), "Filecoin CDN address cannot be zero");
-        require(_initialOperatorCommissionBps <= COMMISSION_MAX_BPS, "Commission exceeds maximum");
-        require(_maxProvingPeriod > 0, "Max proving period must be greater than zero");
-        require(_challengeWindowSize > 0 && _challengeWindowSize < _maxProvingPeriod, "Invalid challenge window size");
+        require(_pdpVerifierAddress != address(0), Errors.ZeroAddress(Errors.AddressField.PDPVerifier));
+        require(_paymentsContractAddress != address(0), Errors.ZeroAddress(Errors.AddressField.Payments));
+        require(_usdfcTokenAddress != address(0), Errors.ZeroAddress(Errors.AddressField.USDFC));
+        require(_filCDNAddress != address(0), Errors.ZeroAddress(Errors.AddressField.FilecoinCDN));
+        require(
+            _initialOperatorCommissionBps <= COMMISSION_MAX_BPS,
+            Errors.CommissionExceedsMaximum(
+                Errors.CommissionType.Operator, COMMISSION_MAX_BPS, _initialOperatorCommissionBps
+            )
+        );
+        require(_maxProvingPeriod > 0, Errors.MaxProvingPeriodZero());
+        require(
+            _challengeWindowSize > 0 && _challengeWindowSize < _maxProvingPeriod,
+            Errors.InvalidChallengeWindowSize(_challengeWindowSize, _maxProvingPeriod)
+        );
 
         pdpVerifierAddress = _pdpVerifierAddress;
         paymentsContractAddress = _paymentsContractAddress;
@@ -263,8 +272,11 @@ contract FilecoinWarmStorageService is
      * @param _challengeWindowSize Number of epochs for the challenge window
      */
     function initializeV2(uint64 _maxProvingPeriod, uint256 _challengeWindowSize) public reinitializer(2) {
-        require(_maxProvingPeriod > 0, "Max proving period must be greater than zero");
-        require(_challengeWindowSize > 0 && _challengeWindowSize < _maxProvingPeriod, "Invalid challenge window size");
+        require(_maxProvingPeriod > 0, Errors.MaxProvingPeriodZero());
+        require(
+            _challengeWindowSize > 0 && _challengeWindowSize < _maxProvingPeriod,
+            Errors.InvalidChallengeWindowSize(_maxProvingPeriod, _challengeWindowSize)
+        );
 
         maxProvingPeriod = _maxProvingPeriod;
         challengeWindowSize = _challengeWindowSize;
@@ -276,7 +288,7 @@ contract FilecoinWarmStorageService is
      * Only callable during proxy upgrade process
      */
     function migrate() public onlyProxy reinitializer(3) {
-        require(msg.sender == address(this), "Only callable by self during upgrade");
+        require(msg.sender == address(this), Errors.OnlySelf(address(this), msg.sender));
         emit ContractUpgraded(VERSION, ERC1967Utils.getImplementation());
     }
 
@@ -287,8 +299,16 @@ contract FilecoinWarmStorageService is
      * @param newCDNCommissionBps New commission rate for CDN service in basis points
      */
     function updateServiceCommission(uint256 newBasicCommissionBps, uint256 newCDNCommissionBps) external onlyOwner {
-        require(newBasicCommissionBps <= COMMISSION_MAX_BPS, "Basic commission exceeds maximum");
-        require(newCDNCommissionBps <= COMMISSION_MAX_BPS, "CDN commission exceeds maximum");
+        require(
+            newBasicCommissionBps <= COMMISSION_MAX_BPS,
+            Errors.CommissionExceedsMaximum(
+                Errors.CommissionType.BasicService, COMMISSION_MAX_BPS, newBasicCommissionBps
+            )
+        );
+        require(
+            newCDNCommissionBps <= COMMISSION_MAX_BPS,
+            Errors.CommissionExceedsMaximum(Errors.CommissionType.CDNService, COMMISSION_MAX_BPS, newCDNCommissionBps)
+        );
         basicServiceCommissionBps = newBasicCommissionBps;
         cdnServiceCommissionBps = newCDNCommissionBps;
     }
@@ -314,7 +334,7 @@ contract FilecoinWarmStorageService is
     // The start of the challenge window for the current proving period
     function thisChallengeWindowStart(uint256 setId) public view returns (uint256) {
         if (provingDeadlines[setId] == NO_PROVING_DEADLINE) {
-            revert("Proving period not yet initialized");
+            revert Errors.ProvingPeriodNotInitialized(setId);
         }
 
         uint256 periodsSkipped;
@@ -332,7 +352,7 @@ contract FilecoinWarmStorageService is
     // Useful for querying before nextProvingPeriod to determine challengeEpoch to submit for nextProvingPeriod
     function nextChallengeWindowStart(uint256 setId) public view returns (uint256) {
         if (provingDeadlines[setId] == NO_PROVING_DEADLINE) {
-            revert("Proving period not yet initialized");
+            revert Errors.ProvingPeriodNotInitialized(setId);
         }
         // If the current period is open this is the next period's challenge window
         if (block.number <= provingDeadlines[setId]) {
@@ -392,27 +412,25 @@ contract FilecoinWarmStorageService is
 
     function dataSetCreated(uint256 dataSetId, address creator, bytes calldata extraData) external onlyPDPVerifier {
         // Decode the extra data to get the metadata, payer address, and signature
-        require(extraData.length > 0, "Extra data required for data set creation");
+        require(extraData.length > 0, Errors.ExtraDataRequired());
         DataSetCreateData memory createData = decodeDataSetCreateData(extraData);
 
         // Validate the addresses
-        require(createData.payer != address(0), "Payer address cannot be zero");
-        require(creator != address(0), "Creator address cannot be zero");
+        require(createData.payer != address(0), Errors.ZeroAddress(Errors.AddressField.Payer));
+        require(creator != address(0), Errors.ZeroAddress(Errors.AddressField.Creator));
 
         // Check if the storage provider is whitelisted
-        require(approvedProvidersMap[creator], "Storage provider not approved");
+        require(approvedProvidersMap[creator], Errors.StorageProviderNotApproved(creator));
 
         // Update client state
         uint256 clientDataSetId = clientDataSetIDs[createData.payer]++;
         clientDataSets[createData.payer].push(dataSetId);
 
         // Verify the client's signature
-        require(
-            verifyCreateDataSetSignature(
-                createData.payer, clientDataSetId, creator, createData.withCDN, createData.signature
-            ),
-            "Invalid signature for data set creation"
+        verifyCreateDataSetSignature(
+            createData.payer, clientDataSetId, creator, createData.withCDN, createData.signature
         );
+
         // Initialize the DataSetInfo struct
         DataSetInfo storage info = dataSetInfo[dataSetId];
         info.payer = createData.payer;
@@ -505,16 +523,15 @@ contract FilecoinWarmStorageService is
     ) external onlyPDPVerifier {
         // Verify the data set exists in our mapping
         DataSetInfo storage info = dataSetInfo[dataSetId];
-        require(info.pdpRailId != 0, "Data set not registered with payment system");
+        require(info.pdpRailId != 0, Errors.DataSetNotRegistered(dataSetId));
         (bytes memory signature) = abi.decode(extraData, (bytes));
 
         // Get the payer address for this data set
         address payer = dataSetInfo[dataSetId].payer;
 
         // Verify the client's signature
-        require(
-            verifyDeleteDataSetSignature(payer, info.clientDataSetId, signature), "Not authorized to delete data set"
-        );
+        verifyDeleteDataSetSignature(payer, info.clientDataSetId, signature);
+
         // TODO Data set deletion logic
     }
 
@@ -535,19 +552,16 @@ contract FilecoinWarmStorageService is
         requirePaymentNotTerminated(dataSetId);
         // Verify the data set exists in our mapping
         DataSetInfo storage info = dataSetInfo[dataSetId];
-        require(info.pdpRailId != 0, "Data set not registered with payment system");
+        require(info.pdpRailId != 0, Errors.DataSetNotRegistered(dataSetId));
 
         // Get the payer address for this data set
         address payer = info.payer;
-        require(extraData.length > 0, "Extra data required for adding pieces");
+        require(extraData.length > 0, Errors.ExtraDataRequired());
         // Decode the extra data
         (bytes memory signature, string memory metadata) = abi.decode(extraData, (bytes, string));
 
         // Verify the signature
-        require(
-            verifyAddPiecesSignature(payer, info.clientDataSetId, pieceData, firstAdded, signature),
-            "Invalid signature for adding pieces"
-        );
+        verifyAddPiecesSignature(payer, info.clientDataSetId, pieceData, firstAdded, signature);
 
         // Store metadata for each new piece
         for (uint256 i = 0; i < pieceData.length; i++) {
@@ -564,20 +578,17 @@ contract FilecoinWarmStorageService is
         requirePaymentNotBeyondEndEpoch(dataSetId);
         // Verify the data set exists in our mapping
         DataSetInfo storage info = dataSetInfo[dataSetId];
-        require(info.pdpRailId != 0, "Data set not registered with payment system");
+        require(info.pdpRailId != 0, Errors.DataSetNotRegistered(dataSetId));
 
         // Get the payer address for this data set
         address payer = info.payer;
 
         // Decode the signature from extraData
-        require(extraData.length > 0, "Extra data required for scheduling removals");
+        require(extraData.length > 0, Errors.ExtraDataRequired());
         bytes memory signature = abi.decode(extraData, (bytes));
 
         // Verify the signature
-        require(
-            verifySchedulePieceRemovalsSignature(payer, info.clientDataSetId, pieceIds, signature),
-            "Invalid signature for scheduling piece removals"
-        );
+        verifySchedulePieceRemovalsSignature(payer, info.clientDataSetId, pieceIds, signature);
 
         // Additional logic for scheduling removals can be added here
     }
@@ -591,22 +602,29 @@ contract FilecoinWarmStorageService is
         uint256 challengeCount
     ) external onlyPDPVerifier {
         requirePaymentNotBeyondEndEpoch(dataSetId);
+
         if (provenThisPeriod[dataSetId]) {
-            revert("Only one proof of possession allowed per proving period. Open a new proving period.");
-        }
-        if (challengeCount < getChallengesPerProof()) {
-            revert("Invalid challenge count < 5");
-        }
-        if (provingDeadlines[dataSetId] == NO_PROVING_DEADLINE) {
-            revert("Proving not yet started");
-        }
-        // check for proof outside of challenge window
-        if (provingDeadlines[dataSetId] < block.number) {
-            revert("Current proving period passed. Open a new proving period.");
+            // revert("Only one proof of possession allowed per proving period. Open a new proving period.");
+            revert Errors.ProofAlreadySubmitted(dataSetId);
         }
 
-        if (provingDeadlines[dataSetId] - challengeWindow() > block.number) {
-            revert("Too early. Wait for challenge window to open");
+        uint256 expectedChallengeCount = getChallengesPerProof();
+        if (challengeCount < expectedChallengeCount) {
+            revert Errors.InvalidChallengeCount(dataSetId, expectedChallengeCount, challengeCount);
+        }
+
+        if (provingDeadlines[dataSetId] == NO_PROVING_DEADLINE) {
+            revert Errors.ProvingNotStarted(dataSetId);
+        }
+
+        // check for proof outside of challenge window
+        if (provingDeadlines[dataSetId] < block.number) {
+            revert Errors.ProvingPeriodPassed(dataSetId, provingDeadlines[dataSetId], block.number);
+        }
+
+        uint256 windowStart = provingDeadlines[dataSetId] - challengeWindow();
+        if (windowStart > block.number) {
+            revert Errors.ChallengeWindowTooEarly(dataSetId, windowStart, block.number);
         }
         provenThisPeriod[dataSetId] = true;
         uint256 currentPeriod = getProvingPeriodForEpoch(dataSetId, block.number);
@@ -628,8 +646,10 @@ contract FilecoinWarmStorageService is
         // initialize state for new data set
         if (provingDeadlines[dataSetId] == NO_PROVING_DEADLINE) {
             uint256 firstDeadline = block.number + getMaxProvingPeriod();
-            if (challengeEpoch < firstDeadline - challengeWindow() || challengeEpoch > firstDeadline) {
-                revert("Next challenge epoch must fall within the next challenge window");
+            uint256 minWindow = firstDeadline - challengeWindow();
+            uint256 maxWindow = firstDeadline;
+            if (challengeEpoch < minWindow || challengeEpoch > maxWindow) {
+                revert Errors.InvalidChallengeEpoch(dataSetId, minWindow, maxWindow, challengeEpoch);
             }
             provingDeadlines[dataSetId] = firstDeadline;
             provenThisPeriod[dataSetId] = false;
@@ -648,7 +668,7 @@ contract FilecoinWarmStorageService is
         // Can only get here if calling nextProvingPeriod multiple times within the same proving period
         uint256 prevDeadline = provingDeadlines[dataSetId] - getMaxProvingPeriod();
         if (block.number <= prevDeadline) {
-            revert("One call to nextProvingPeriod allowed per proving period");
+            revert Errors.NextProvingPeriodAlreadyCalled(dataSetId, prevDeadline, block.number);
         }
 
         uint256 periodsSkipped;
@@ -666,8 +686,11 @@ contract FilecoinWarmStorageService is
             nextDeadline = NO_PROVING_DEADLINE;
         } else {
             nextDeadline = provingDeadlines[dataSetId] + getMaxProvingPeriod() * (periodsSkipped + 1);
-            if (challengeEpoch < nextDeadline - challengeWindow() || challengeEpoch > nextDeadline) {
-                revert("Next challenge epoch must fall within the next challenge window");
+            uint256 windowStart = nextDeadline - challengeWindow();
+            uint256 windowEnd = nextDeadline;
+
+            if (challengeEpoch < windowStart || challengeEpoch > windowEnd) {
+                revert Errors.InvalidChallengeEpoch(dataSetId, windowStart, windowEnd, challengeEpoch);
             }
         }
         uint256 faultPeriods = periodsSkipped;
@@ -711,10 +734,13 @@ contract FilecoinWarmStorageService is
     ) external override onlyPDPVerifier {
         // Verify the data set exists and validate the old storage provider
         DataSetInfo storage info = dataSetInfo[dataSetId];
-        require(info.payee == oldStorageProvider, "Old storage provider mismatch");
-        require(newStorageProvider != address(0), "New storage provider cannot be zero address");
+        require(
+            info.payee == oldStorageProvider,
+            Errors.OldStorageProviderMismatch(dataSetId, info.payee, oldStorageProvider)
+        );
+        require(newStorageProvider != address(0), Errors.ZeroAddress(Errors.AddressField.StorageProvider));
         // New storage provider must be an approved provider
-        require(approvedProvidersMap[newStorageProvider], "New storage provider must be an approved provider");
+        require(approvedProvidersMap[newStorageProvider], Errors.NewStorageProviderNotApproved(newStorageProvider));
 
         // Update the data set payee (storage provider)
         info.payee = newStorageProvider;
@@ -725,14 +751,15 @@ contract FilecoinWarmStorageService is
 
     function terminateDataSetPayment(uint256 dataSetId) external {
         DataSetInfo storage info = dataSetInfo[dataSetId];
-        require(info.pdpRailId != 0, "invalid dataset ID");
+        require(info.pdpRailId != 0, Errors.InvalidDataSetId(dataSetId));
 
         // Check if already terminated
-        require(info.paymentEndEpoch == 0, "dataset payment already terminated");
+        require(info.paymentEndEpoch == 0, Errors.DataSetPaymentAlreadyTerminated(dataSetId));
 
         // Check authorization
         require(
-            msg.sender == info.payer || msg.sender == info.payee, "Only payer or payee can terminate data set payment"
+            msg.sender == info.payer || msg.sender == info.payee,
+            Errors.CallerNotPayerOrPayee(dataSetId, info.payer, info.payee, msg.sender)
         );
 
         Payments payments = Payments(paymentsContractAddress);
@@ -747,8 +774,8 @@ contract FilecoinWarmStorageService is
 
     function requirePaymentNotTerminated(uint256 dataSetId) internal view {
         DataSetInfo storage info = dataSetInfo[dataSetId];
-        require(info.pdpRailId != 0, "invalid dataset ID");
-        require(info.paymentEndEpoch == 0, "data set payment has already been terminated");
+        require(info.pdpRailId != 0, Errors.InvalidDataSetId(dataSetId));
+        require(info.paymentEndEpoch == 0, Errors.DataSetPaymentAlreadyTerminated(dataSetId));
     }
 
     function requirePaymentNotBeyondEndEpoch(uint256 dataSetId) internal view {
@@ -756,14 +783,14 @@ contract FilecoinWarmStorageService is
         if (info.paymentEndEpoch != 0) {
             require(
                 block.number <= info.paymentEndEpoch,
-                "data set is beyond its payment end epoch: remove data set to make progress"
+                Errors.DataSetPaymentBeyondEndEpoch(dataSetId, info.paymentEndEpoch, block.number)
             );
         }
     }
 
     function updatePaymentRates(uint256 dataSetId, uint256 leafCount) internal {
         // Revert if no payment rail is configured for this data set
-        require(dataSetInfo[dataSetId].pdpRailId != 0, "No PDP payment rail configured");
+        require(dataSetInfo[dataSetId].pdpRailId != 0, Errors.NoPDPPaymentRail(dataSetId));
 
         uint256 totalBytes = getDataSetSizeInBytes(leafCount);
         Payments payments = Payments(paymentsContractAddress);
@@ -876,7 +903,7 @@ contract FilecoinWarmStorageService is
         uint256 denominator = TIB_IN_BYTES * EPOCHS_PER_MONTH;
 
         // Ensure denominator is not zero (shouldn't happen with constants)
-        require(denominator > 0, "Denominator cannot be zero");
+        require(denominator > 0, Errors.DivisionByZero());
 
         uint256 ratePerEpoch = numerator / denominator;
 
@@ -1062,7 +1089,6 @@ contract FilecoinWarmStorageService is
      * @param payer The address of the payer who should have signed the message
      * @param clientDataSetId The unique ID for the client's data set
      * @param signature The signature bytes (v, r, s)
-     * @return True if the signature is valid, false otherwise
      */
     function verifyCreateDataSetSignature(
         address payer,
@@ -1070,7 +1096,7 @@ contract FilecoinWarmStorageService is
         address payee,
         bool withCDN,
         bytes memory signature
-    ) internal view returns (bool) {
+    ) internal view {
         // Prepare the message hash that was signed
         bytes32 structHash = keccak256(abi.encode(CREATE_DATA_SET_TYPEHASH, clientDataSetId, withCDN, payee));
         bytes32 digest = _hashTypedDataV4(structHash);
@@ -1078,8 +1104,7 @@ contract FilecoinWarmStorageService is
         // Recover signer address from the signature
         address recoveredSigner = recoverSigner(digest, signature);
 
-        // Check if the recovered signer matches the expected payer
-        return recoveredSigner == payer;
+        require(payer == recoveredSigner, Errors.InvalidSignature(payer, recoveredSigner));
     }
 
     /**
@@ -1088,7 +1113,6 @@ contract FilecoinWarmStorageService is
      * @param clientDataSetId The ID of the data set
      * @param pieceDataArray Array of PieceSignatureData structures
      * @param signature The signature bytes (v, r, s)
-     * @return True if the signature is valid, false otherwise
      */
     function verifyAddPiecesSignature(
         address payer,
@@ -1096,7 +1120,7 @@ contract FilecoinWarmStorageService is
         IPDPTypes.PieceData[] memory pieceDataArray,
         uint256 firstAdded,
         bytes memory signature
-    ) internal view returns (bool) {
+    ) internal view {
         // Hash each PieceData struct
         bytes32[] memory pieceDataHashes = new bytes32[](pieceDataArray.length);
         for (uint256 i = 0; i < pieceDataArray.length; i++) {
@@ -1116,8 +1140,7 @@ contract FilecoinWarmStorageService is
         // Recover signer address from the signature
         address recoveredSigner = recoverSigner(digest, signature);
 
-        // Check if the recovered signer matches the expected payer
-        return recoveredSigner == payer;
+        require(payer == recoveredSigner, Errors.InvalidSignature(payer, recoveredSigner));
     }
 
     /**
@@ -1126,14 +1149,13 @@ contract FilecoinWarmStorageService is
      * @param clientDataSetId The ID of the data set
      * @param pieceIds Array of piece IDs to be removed
      * @param signature The signature bytes (v, r, s)
-     * @return True if the signature is valid, false otherwise
      */
     function verifySchedulePieceRemovalsSignature(
         address payer,
         uint256 clientDataSetId,
         uint256[] memory pieceIds,
         bytes memory signature
-    ) internal view returns (bool) {
+    ) internal view {
         // Prepare the message hash that was signed
         bytes32 structHash = keccak256(
             abi.encode(SCHEDULE_PIECE_REMOVALS_TYPEHASH, clientDataSetId, keccak256(abi.encodePacked(pieceIds)))
@@ -1144,8 +1166,7 @@ contract FilecoinWarmStorageService is
         // Recover signer address from the signature
         address recoveredSigner = recoverSigner(digest, signature);
 
-        // Check if the recovered signer matches the expected payer
-        return recoveredSigner == payer;
+        require(payer == recoveredSigner, Errors.InvalidSignature(payer, recoveredSigner));
     }
 
     /**
@@ -1153,12 +1174,10 @@ contract FilecoinWarmStorageService is
      * @param payer The address of the payer who should have signed the message
      * @param clientDataSetId The ID of the data set
      * @param signature The signature bytes (v, r, s)
-     * @return True if the signature is valid, false otherwise
      */
     function verifyDeleteDataSetSignature(address payer, uint256 clientDataSetId, bytes memory signature)
         internal
         view
-        returns (bool)
     {
         // Prepare the message hash that was signed
         bytes32 structHash = keccak256(abi.encode(DELETE_DATA_SET_TYPEHASH, clientDataSetId));
@@ -1167,8 +1186,7 @@ contract FilecoinWarmStorageService is
         // Recover signer address from the signature
         address recoveredSigner = recoverSigner(digest, signature);
 
-        // Check if the recovered signer matches the expected payer
-        return recoveredSigner == payer;
+        require(payer == recoveredSigner, Errors.InvalidSignature(payer, recoveredSigner));
     }
 
     /**
@@ -1178,7 +1196,7 @@ contract FilecoinWarmStorageService is
      * @return The address that signed the message
      */
     function recoverSigner(bytes32 messageHash, bytes memory signature) internal pure returns (address) {
-        require(signature.length == 65, "Invalid signature length");
+        require(signature.length == 65, Errors.InvalidSignatureLength(65, signature.length));
 
         bytes32 r;
         bytes32 s;
@@ -1196,7 +1214,7 @@ contract FilecoinWarmStorageService is
             v += 27;
         }
 
-        require(v == 27 || v == 28, "Unsupported signature 'v' value, we don't handle rare wrapped case");
+        require(v == 27 || v == 28, Errors.UnsupportedSignatureV(v));
 
         // Recover and return the address
         return ecrecover(messageHash, v, r, s);
@@ -1210,18 +1228,18 @@ contract FilecoinWarmStorageService is
      * @dev Requires exact payment of SP_REGISTRATION_FEE which is burned to f099
      */
     function registerServiceProvider(string calldata serviceURL, bytes calldata peerId) external payable {
-        require(!approvedProvidersMap[msg.sender], "Provider already approved");
-        require(bytes(serviceURL).length > 0, "Provider service URL cannot be empty");
-        require(bytes(serviceURL).length <= 256, "Provider service URL too long (max 256 bytes)");
-        require(peerId.length <= 64, "Peer ID too long (max 64 bytes)");
+        require(!approvedProvidersMap[msg.sender], Errors.ProviderAlreadyApproved(msg.sender));
+        require(bytes(serviceURL).length > 0, Errors.ServiceURLEmpty());
+        require(bytes(serviceURL).length <= 256, Errors.ServiceURLTooLong(bytes(serviceURL).length, 256));
+        require(peerId.length <= 64, Errors.PeerIdTooLong(peerId.length, 64));
 
         // Check if registration is already pending
-        require(pendingProviders[msg.sender].registeredAt == 0, "Registration already pending");
+        require(pendingProviders[msg.sender].registeredAt == 0, Errors.RegistrationAlreadyPending(msg.sender));
 
         // Burn one-time fee to register
-        require(msg.value == SP_REGISTRATION_FEE, "Incorrect registration fee");
+        require(msg.value == SP_REGISTRATION_FEE, Errors.IncorrectRegistrationFee(SP_REGISTRATION_FEE, msg.value));
         (bool sent,) = BURN_ADDRESS.call{value: msg.value}("");
-        require(sent, "Burn failed");
+        require(sent, Errors.BurnFailed());
 
         // Store pending registration
         pendingProviders[msg.sender] = PendingProviderInfo({
@@ -1240,9 +1258,9 @@ contract FilecoinWarmStorageService is
      */
     function approveServiceProvider(address provider) external onlyOwner {
         // Check if not already approved
-        require(!approvedProvidersMap[provider], "Provider already approved");
+        require(!approvedProvidersMap[provider], Errors.ProviderAlreadyApproved(provider));
         // Check if registration exists
-        require(pendingProviders[provider].registeredAt > 0, "No pending registration found");
+        require(pendingProviders[provider].registeredAt > 0, Errors.NoPendingRegistrationFound(provider));
 
         // Get pending registration data
         PendingProviderInfo memory pending = pendingProviders[provider];
@@ -1273,8 +1291,8 @@ contract FilecoinWarmStorageService is
      */
     function rejectServiceProvider(address provider) external onlyOwner {
         // Check if registration exists
-        require(pendingProviders[provider].registeredAt > 0, "No pending registration found");
-        require(!approvedProvidersMap[provider], "Provider already approved");
+        require(pendingProviders[provider].registeredAt > 0, Errors.NoPendingRegistrationFound(provider));
+        require(!approvedProvidersMap[provider], Errors.ProviderAlreadyApproved(provider));
 
         // Update mappings
         approvedProvidersMap[provider] = false;
@@ -1293,15 +1311,18 @@ contract FilecoinWarmStorageService is
      */
     function removeServiceProvider(uint256 providerId) external onlyOwner {
         // Validate provider ID
-        require(providerId > 0 && providerId < nextServiceProviderId, "Invalid provider ID");
+        require(
+            providerId > 0 && providerId < nextServiceProviderId,
+            Errors.InvalidProviderId(nextServiceProviderId, providerId)
+        );
 
         // Get provider info
         ApprovedProviderInfo memory providerInfo = approvedProviders[providerId];
         address providerAddress = providerInfo.storageProvider;
-        require(providerAddress != address(0), "Provider not found");
+        require(providerAddress != address(0), Errors.ProviderNotFound(providerId));
 
         // Check if provider is currently approved
-        require(approvedProvidersMap[providerAddress], "Provider not approved");
+        require(approvedProvidersMap[providerAddress], Errors.ProviderNotApproved(providerAddress));
 
         // Remove from approved mapping
         approvedProvidersMap[providerAddress] = false;
@@ -1322,9 +1343,12 @@ contract FilecoinWarmStorageService is
      * @return The service provider information
      */
     function getApprovedProvider(uint256 providerId) external view returns (ApprovedProviderInfo memory) {
-        require(providerId > 0 && providerId < nextServiceProviderId, "Invalid provider ID");
+        require(
+            providerId > 0 && providerId < nextServiceProviderId,
+            Errors.InvalidProviderId(nextServiceProviderId, providerId)
+        );
         ApprovedProviderInfo memory provider = approvedProviders[providerId];
-        require(provider.storageProvider != address(0), "Provider not found");
+        require(provider.storageProvider != address(0), Errors.ProviderNotFound(providerId));
         return provider;
     }
 
@@ -1399,11 +1423,11 @@ contract FilecoinWarmStorageService is
     ) external override returns (ValidationResult memory result) {
         // Get the data set ID associated with this rail
         uint256 dataSetId = railToDataSet[railId];
-        require(dataSetId != 0, "Rail not associated with any data set");
+        require(dataSetId != 0, Errors.RailNotAssociated(railId));
 
         // Calculate the total number of epochs in the requested range
         uint256 totalEpochsRequested = toEpoch - fromEpoch;
-        require(totalEpochsRequested > 0, "Invalid epoch range");
+        require(totalEpochsRequested > 0, Errors.InvalidEpochRange(fromEpoch, toEpoch));
 
         // If proving wasn't ever activated for this data set, don't pay anything
         if (provingActivationEpoch[dataSetId] == 0) {
@@ -1454,16 +1478,14 @@ contract FilecoinWarmStorageService is
     }
 
     function railTerminated(uint256 railId, address terminator, uint256 endEpoch) external override {
-        require(msg.sender == paymentsContractAddress, "Caller is not the Payments contract");
+        require(msg.sender == paymentsContractAddress, Errors.CallerNotPayments(paymentsContractAddress, msg.sender));
 
         if (terminator != address(this)) {
-            revert(
-                "cannot terminate rail using Payments contract: call `terminateDataSetPayment` on the service contract"
-            );
+            revert Errors.ServiceContractMustTerminateRail();
         }
 
         uint256 dataSetId = railToDataSet[railId];
-        require(dataSetId != 0, "data set does not exist for given rail");
+        require(dataSetId != 0, Errors.DataSetNotFoundForRail(railId));
         DataSetInfo storage info = dataSetInfo[dataSetId];
         if (info.paymentEndEpoch == 0) {
             info.paymentEndEpoch = endEpoch;

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -1208,13 +1208,14 @@ contract FilecoinWarmStorageService is
             s := mload(add(signature, 64))
             v := byte(0, mload(add(signature, 96)))
         }
+        uint8 originalV = v;
 
         // If v is not 27 or 28, adjust it (for some wallets)
         if (v < 27) {
             v += 27;
         }
 
-        require(v == 27 || v == 28, Errors.UnsupportedSignatureV(v));
+        require(v == 27 || v == 28, Errors.UnsupportedSignatureV(originalV));
 
         // Recover and return the address
         return ecrecover(messageHash, v, r, s);

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -1425,9 +1425,7 @@ contract FilecoinWarmStorageServiceTest is Test {
         bytes memory testExtraData = new bytes(0);
         // Call directly as PDPVerifier with wrong old storage provider
         vm.prank(address(mockPDPVerifier));
-        vm.expectRevert(abi.encodeWithSelector(
-            Errors.OldStorageProviderMismatch.selector, 1, sp1, sp2
-        ));
+        vm.expectRevert(abi.encodeWithSelector(Errors.OldStorageProviderMismatch.selector, 1, sp1, sp2));
         pdpServiceWithPayments.storageProviderChanged(testDataSetId, sp2, sp2, testExtraData);
     }
 
@@ -1617,21 +1615,33 @@ contract FilecoinWarmStorageServiceTest is Test {
         pieceIds[0] = 0;
         bytes memory scheduleRemoveData = abi.encode(FAKE_SIGNATURE);
         makeSignaturePass(client);
-        vm.expectRevert(abi.encodeWithSelector(Errors.DataSetPaymentBeyondEndEpoch.selector, dataSetId, info.paymentEndEpoch, block.number));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.DataSetPaymentBeyondEndEpoch.selector, dataSetId, info.paymentEndEpoch, block.number
+            )
+        );
         mockPDPVerifier.piecesScheduledRemove(dataSetId, pieceIds, address(pdpServiceWithPayments), scheduleRemoveData);
         console.log("[OK] piecesScheduledRemove correctly reverted");
 
         // possessionProven
         console.log("Testing possessionProven - should revert (beyond payment end epoch)");
         vm.prank(address(mockPDPVerifier));
-        vm.expectRevert(abi.encodeWithSelector(Errors.DataSetPaymentBeyondEndEpoch.selector, dataSetId, info.paymentEndEpoch, block.number));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.DataSetPaymentBeyondEndEpoch.selector, dataSetId, info.paymentEndEpoch, block.number
+            )
+        );
         pdpServiceWithPayments.possessionProven(dataSetId, 100, 12345, 5);
         console.log("[OK] possessionProven correctly reverted");
 
         // nextProvingPeriod
         console.log("Testing nextProvingPeriod - should revert (beyond payment end epoch)");
         vm.prank(address(mockPDPVerifier));
-        vm.expectRevert(abi.encodeWithSelector(Errors.DataSetPaymentBeyondEndEpoch.selector, dataSetId, info.paymentEndEpoch, block.number));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.DataSetPaymentBeyondEndEpoch.selector, dataSetId, info.paymentEndEpoch, block.number
+            )
+        );
         pdpServiceWithPayments.nextProvingPeriod(dataSetId, block.number + maxProvingPeriod, 100, "");
         console.log("[OK] nextProvingPeriod correctly reverted");
 


### PR DESCRIPTION
## Description

This PR refactors the `FilecoinWarmStorageService` contract and related code to replace all legacy require/revert statements using string messages with centralized custom errors.

## Key Changes

- Added: Centralized Errors library with parameterized custom errors
- Refactored: All contract logic now uses custom errors instead of string messages
- Test: Updated/modified tests to assert on custom error types instead of strings

## Results

- Runtime size reduced by `3233 bytes`:
   - Before: `28415 bytes`
   - After: `25182 bytes`
- Init size reduced by `3233 bytes`:
   - Before: `28651 bytes`
   - After: `25418 bytes`
- Runtime margin: `-606 bytes` (over EIP-170 limit)

Note: We need to further reduce runtime size by 606 bytes to comply with the [EIP-170](https://eips.ethereum.org/EIPS/eip-170) contract code size limit (24,576 bytes). This PR partially addresses #91, but does not close it.
