### PR TITLE
Check Contract Size: Handle Forge Build Error

### DIFF
--- a/service_contracts/tools/check-contract-size.sh
+++ b/service_contracts/tools/check-contract-size.sh
@@ -48,6 +48,13 @@ if ! jq empty contract_sizes.json 2>/dev/null; then
     exit 1
 fi
 
+if jq -e '. == {}' contract_sizes.json >/dev/null; then
+    echo "forge did not find any contracts. forge build:"
+    # This usually means build failure
+    forge build
+    exit 1
+fi
+
 json=$(cat contract_sizes.json)
 
 # Filter JSON: keep only contracts/libraries from src/


### PR DESCRIPTION

Reviewer @rvagg
CC @pali101
Consider the behavior of the contract size tool when the build fails.
previous output:
```
All contracts are within the EIP-170 runtime and EIP-3860 init code size limits.
```
new output:
```
forge did not find any contracts. forge build:
[⠊] Compiling...
[⠰] Compiling 79 files with Solc 0.8.27
[⠔] Solc 0.8.27 finished in 360.09ms
Error: Compiler run failed:
Error (2314): Expected identifier but got 'uint8'
  --> test/FilecoinWarmStorageService.t.sol:19:11:
     |
     19 |     uint8 uint8 private _decimals = 6;
        |           ^^^^^
```
#### Changes
* check for empty output dictionary