### PR TITLE
fix: no double-multiplication of pricing values

### DIFF
--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -989,9 +989,8 @@ contract FilecoinWarmStorageService is
      */
     function getServicePrice() external view returns (ServicePricing memory pricing) {
         pricing = ServicePricing({
-            pricePerTiBPerMonthNoCDN: STORAGE_PRICE_PER_TIB_PER_MONTH * (10 ** uint256(tokenDecimals)),
-            pricePerTiBPerMonthWithCDN: (STORAGE_PRICE_PER_TIB_PER_MONTH + CDN_PRICE_PER_TIB_PER_MONTH)
-                * (10 ** uint256(tokenDecimals)),
+            pricePerTiBPerMonthNoCDN: STORAGE_PRICE_PER_TIB_PER_MONTH,
+            pricePerTiBPerMonthWithCDN: STORAGE_PRICE_PER_TIB_PER_MONTH + CDN_PRICE_PER_TIB_PER_MONTH,
             tokenAddress: usdfcTokenAddress,
             epochsPerMonth: EPOCHS_PER_MONTH
         });
@@ -1003,7 +1002,7 @@ contract FilecoinWarmStorageService is
      * @return spPayment SP payment (per TiB per month)
      */
     function getEffectiveRates() external view returns (uint256 serviceFee, uint256 spPayment) {
-        uint256 total = STORAGE_PRICE_PER_TIB_PER_MONTH * (10 ** uint256(tokenDecimals));
+        uint256 total = STORAGE_PRICE_PER_TIB_PER_MONTH;
 
         serviceFee = (total * serviceCommissionBps) / COMMISSION_MAX_BPS;
         spPayment = total - serviceFee;

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -543,6 +543,46 @@ contract FilecoinWarmStorageServiceTest is Test {
         assertEq(pdpServiceWithPayments.challengeWindow(), 60, "Challenge window should be 60 epochs");
     }
 
+    // ===== Pricing Tests =====
+
+    function testGetServicePriceValues() public view {
+        // Test the values returned by getServicePrice
+        FilecoinWarmStorageService.ServicePricing memory pricing = pdpServiceWithPayments.getServicePrice();
+
+        uint256 decimals = 6; // MockUSDFC uses 6 decimals in tests
+        uint256 expectedNoCDN = 2 * 10 ** decimals; // 2 USDFC with 6 decimals
+        uint256 expectedWithCDN = 25 * 10 ** (decimals - 1); // 2.5 USDFC with 6 decimals
+
+        assertEq(pricing.pricePerTiBPerMonthNoCDN, expectedNoCDN, "No CDN price should be 2 * 10^decimals");
+        assertEq(pricing.pricePerTiBPerMonthWithCDN, expectedWithCDN, "With CDN price should be 2.5 * 10^decimals");
+        assertEq(pricing.tokenAddress, address(mockUSDFC), "Token address should match USDFC");
+        assertEq(pricing.epochsPerMonth, 86400, "Epochs per month should be 86400");
+
+        // Verify the values are in expected range
+        assert(pricing.pricePerTiBPerMonthNoCDN < 10 ** 8); // Less than 10^8
+        assert(pricing.pricePerTiBPerMonthWithCDN < 10 ** 8); // Less than 10^8
+    }
+
+    function testGetEffectiveRatesValues() public view {
+        // Test the values returned by getEffectiveRates
+        (uint256 serviceFee, uint256 spPayment) = pdpServiceWithPayments.getEffectiveRates();
+
+        uint256 decimals = 6; // MockUSDFC uses 6 decimals in tests
+        // Total is 2 USDFC with 6 decimals
+        uint256 expectedTotal = 2 * 10 ** decimals;
+
+        // Test setup uses 0% commission
+        uint256 expectedServiceFee = 0; // 0% commission
+        uint256 expectedSpPayment = expectedTotal; // 100% goes to SP
+
+        assertEq(serviceFee, expectedServiceFee, "Service fee should be 0 with 0% commission");
+        assertEq(spPayment, expectedSpPayment, "SP payment should be 2 * 10^6");
+        assertEq(serviceFee + spPayment, expectedTotal, "Total should equal 2 * 10^6");
+
+        // Verify the values are in expected range
+        assert(serviceFee + spPayment < 10 ** 8); // Less than 10^8
+    }
+
     // ===== Service Provider Registry Tests =====
 
     function testRegisterServiceProvider() public {


### PR DESCRIPTION
$2 quintillion per TiB for storage anyone? (2,000,000,000,000,000,000 USD per TiB/month)

#66 introduced the multiplication in the constructor, they were previously un-multiplied constants, so now we have double multiplication.