### PR TITLE
fix: make deploy scripts match current contracts

### DIFF
--- a/service_contracts/tools/deploy-all-warm-storage-calibnet.sh
+++ b/service_contracts/tools/deploy-all-warm-storage-calibnet.sh
@@ -33,14 +33,30 @@ USDFC_TOKEN_ADDRESS="0xb3042734b608a1B16e9e86B374A3f3e389B4cDf0"    # USDFC toke
 MAX_PROVING_PERIOD="${MAX_PROVING_PERIOD:-30}"                      # Default 30 epochs (15 minutes on calibnet)
 CHALLENGE_WINDOW_SIZE="${CHALLENGE_WINDOW_SIZE:-15}"                # Default 15 epochs
 
+# Validate that the configuration will work with PDPVerifier's challengeFinality
+# The calculation: (MAX_PROVING_PERIOD - CHALLENGE_WINDOW_SIZE) + (CHALLENGE_WINDOW_SIZE/2) must be >= CHALLENGE_FINALITY
+# This ensures initChallengeWindowStart() + buffer will meet PDPVerifier requirements
+MIN_REQUIRED=$((CHALLENGE_FINALITY + CHALLENGE_WINDOW_SIZE / 2))
+if [ "$MAX_PROVING_PERIOD" -lt "$MIN_REQUIRED" ]; then
+    echo "Error: MAX_PROVING_PERIOD ($MAX_PROVING_PERIOD) is too small for CHALLENGE_FINALITY ($CHALLENGE_FINALITY)"
+    echo "       MAX_PROVING_PERIOD must be at least $MIN_REQUIRED (CHALLENGE_FINALITY + CHALLENGE_WINDOW_SIZE/2)"
+    echo "       Either increase MAX_PROVING_PERIOD or decrease CHALLENGE_FINALITY"
+    exit 1
+fi
+
+echo "Configuration validation passed:"
+echo "  CHALLENGE_FINALITY=$CHALLENGE_FINALITY"
+echo "  MAX_PROVING_PERIOD=$MAX_PROVING_PERIOD"
+echo "  CHALLENGE_WINDOW_SIZE=$CHALLENGE_WINDOW_SIZE"
+
 ADDR=$(cast wallet address --keystore "$KEYSTORE" --password "$PASSWORD")
 echo "Deploying contracts from address $ADDR"
- 
+
 NONCE="$(cast nonce --rpc-url "$RPC_URL" "$ADDR")"
 
 # Step 1: Deploy PDPVerifier implementation
 echo "Deploying PDPVerifier implementation..."
-VERIFIER_IMPLEMENTATION_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 lib/pdp/src/PDPVerifier.sol:PDPVerifier --optimizer-runs 1 --via-ir | grep "Deployed to" | awk '{print $3}')
+VERIFIER_IMPLEMENTATION_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 lib/pdp/src/PDPVerifier.sol:PDPVerifier | grep "Deployed to" | awk '{print $3}')
 if [ -z "$VERIFIER_IMPLEMENTATION_ADDRESS" ]; then
     echo "Error: Failed to extract PDPVerifier contract address"
     exit 1
@@ -51,7 +67,7 @@ NONCE=$(expr $NONCE + "1")
 # Step 2: Deploy PDPVerifier proxy
 echo "Deploying PDPVerifier proxy..."
 INIT_DATA=$(cast calldata "initialize(uint256)" $CHALLENGE_FINALITY)
-PDP_VERIFIER_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 lib/pdp/src/ERC1967Proxy.sol:MyERC1967Proxy --constructor-args $VERIFIER_IMPLEMENTATION_ADDRESS $INIT_DATA --optimizer-runs 1 --via-ir | grep "Deployed to" | awk '{print $3}')
+PDP_VERIFIER_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 lib/pdp/src/ERC1967Proxy.sol:MyERC1967Proxy --constructor-args $VERIFIER_IMPLEMENTATION_ADDRESS $INIT_DATA | grep "Deployed to" | awk '{print $3}')
 if [ -z "$PDP_VERIFIER_ADDRESS" ]; then
     echo "Error: Failed to extract PDPVerifier proxy address"
     exit 1
@@ -61,7 +77,7 @@ NONCE=$(expr $NONCE + "1")
 
 # Step 3: Deploy Payments implementation
 echo "Deploying Payments implementation..."
-PAYMENTS_IMPLEMENTATION_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 lib/fws-payments/src/Payments.sol:Payments --optimizer-runs 1 --via-ir | grep "Deployed to" | awk '{print $3}')
+PAYMENTS_IMPLEMENTATION_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 lib/fws-payments/src/Payments.sol:Payments | grep "Deployed to" | awk '{print $3}')
 if [ -z "$PAYMENTS_IMPLEMENTATION_ADDRESS" ]; then
     echo "Error: Failed to extract Payments contract address"
     exit 1
@@ -72,7 +88,7 @@ NONCE=$(expr $NONCE + "1")
 # Step 4: Deploy Payments proxy
 echo "Deploying Payments proxy..."
 PAYMENTS_INIT_DATA=$(cast calldata "initialize()")
-PAYMENTS_CONTRACT_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 lib/pdp/src/ERC1967Proxy.sol:MyERC1967Proxy --constructor-args $PAYMENTS_IMPLEMENTATION_ADDRESS $PAYMENTS_INIT_DATA --optimizer-runs 1 --via-ir | grep "Deployed to" | awk '{print $3}')
+PAYMENTS_CONTRACT_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 lib/pdp/src/ERC1967Proxy.sol:MyERC1967Proxy --constructor-args $PAYMENTS_IMPLEMENTATION_ADDRESS $PAYMENTS_INIT_DATA | grep "Deployed to" | awk '{print $3}')
 if [ -z "$PAYMENTS_CONTRACT_ADDRESS" ]; then
     echo "Error: Failed to extract Payments proxy address"
     exit 1
@@ -82,7 +98,7 @@ NONCE=$(expr $NONCE + "1")
 
 # Step 5: Deploy FilecoinWarmStorageService implementation
 echo "Deploying FilecoinWarmStorageService implementation..."
-SERVICE_PAYMENTS_IMPLEMENTATION_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 src/FilecoinWarmStorageService.sol:FilecoinWarmStorageService --constructor-args $PDP_VERIFIER_ADDRESS $PAYMENTS_CONTRACT_ADDRESS $USDFC_TOKEN_ADDRESS $FILCDN_WALLET --optimizer-runs 1 --via-ir  | grep "Deployed to" | awk '{print $3}')
+SERVICE_PAYMENTS_IMPLEMENTATION_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 src/FilecoinWarmStorageService.sol:FilecoinWarmStorageService --constructor-args $PDP_VERIFIER_ADDRESS $PAYMENTS_CONTRACT_ADDRESS $USDFC_TOKEN_ADDRESS $FILCDN_WALLET | grep "Deployed to" | awk '{print $3}')
 if [ -z "$SERVICE_PAYMENTS_IMPLEMENTATION_ADDRESS" ]; then
     echo "Error: Failed to extract FilecoinWarmStorageService contract address"
     exit 1
@@ -94,7 +110,7 @@ NONCE=$(expr $NONCE + "1")
 echo "Deploying FilecoinWarmStorageService proxy..."
 # Initialize with PDPVerifier address, payments contract address, USDFC token address, commission rate, max proving period, and challenge window size
 INIT_DATA=$(cast calldata "initialize(uint64,uint256)"  $MAX_PROVING_PERIOD $CHALLENGE_WINDOW_SIZE)
-WARM_STORAGE_SERVICE_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 lib/pdp/src/ERC1967Proxy.sol:MyERC1967Proxy --constructor-args $SERVICE_PAYMENTS_IMPLEMENTATION_ADDRESS $INIT_DATA --optimizer-runs 1 --via-ir | grep "Deployed to" | awk '{print $3}')
+WARM_STORAGE_SERVICE_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 lib/pdp/src/ERC1967Proxy.sol:MyERC1967Proxy --constructor-args $SERVICE_PAYMENTS_IMPLEMENTATION_ADDRESS $INIT_DATA | grep "Deployed to" | awk '{print $3}')
 if [ -z "$WARM_STORAGE_SERVICE_ADDRESS" ]; then
     echo "Error: Failed to extract FilecoinWarmStorageService proxy address"
     exit 1
@@ -108,7 +124,7 @@ echo "PDPVerifier Implementation: $VERIFIER_IMPLEMENTATION_ADDRESS"
 echo "PDPVerifier Proxy: $PDP_VERIFIER_ADDRESS"
 echo "Payments Implementation: $PAYMENTS_IMPLEMENTATION_ADDRESS"
 echo "Payments Proxy: $PAYMENTS_CONTRACT_ADDRESS"
-echo "FilecoinWarmStorageService Implementation: $SERVICE_PAYMENTS_IMPLEMENTATION_ADDRESS" 
+echo "FilecoinWarmStorageService Implementation: $SERVICE_PAYMENTS_IMPLEMENTATION_ADDRESS"
 echo "FilecoinWarmStorageService Proxy: $WARM_STORAGE_SERVICE_ADDRESS"
 echo "=========================="
 echo ""

--- a/service_contracts/tools/deploy-all-warm-storage-calibnet.sh
+++ b/service_contracts/tools/deploy-all-warm-storage-calibnet.sh
@@ -28,7 +28,6 @@ if [ -z "$FILCDN_WALLET" ]; then
     FILCDN_WALLET="0xff0000000000000000000000000000000002870c"
 fi
 USDFC_TOKEN_ADDRESS="0xb3042734b608a1B16e9e86B374A3f3e389B4cDf0"    # USDFC token address
-OPERATOR_COMMISSION_BPS=100                                         # 1% commission in basis points
 
 # Proving period configuration - use defaults if not set
 MAX_PROVING_PERIOD="${MAX_PROVING_PERIOD:-30}"                      # Default 30 epochs (15 minutes on calibnet)
@@ -83,7 +82,7 @@ NONCE=$(expr $NONCE + "1")
 
 # Step 5: Deploy FilecoinWarmStorageService implementation
 echo "Deploying FilecoinWarmStorageService implementation..."
-SERVICE_PAYMENTS_IMPLEMENTATION_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 src/FilecoinWarmStorageService.sol:FilecoinWarmStorageService --constructor-args $PDP_VERIFIER_ADDRESS $PAYMENTS_CONTRACT_ADDRESS $USDFC_TOKEN_ADDRESS $FILCDN_WALLET $OPERATOR_COMMISSION_BPS --optimizer-runs 1 --via-ir  | grep "Deployed to" | awk '{print $3}')
+SERVICE_PAYMENTS_IMPLEMENTATION_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 src/FilecoinWarmStorageService.sol:FilecoinWarmStorageService --constructor-args $PDP_VERIFIER_ADDRESS $PAYMENTS_CONTRACT_ADDRESS $USDFC_TOKEN_ADDRESS $FILCDN_WALLET --optimizer-runs 1 --via-ir  | grep "Deployed to" | awk '{print $3}')
 if [ -z "$SERVICE_PAYMENTS_IMPLEMENTATION_ADDRESS" ]; then
     echo "Error: Failed to extract FilecoinWarmStorageService contract address"
     exit 1
@@ -114,6 +113,6 @@ echo "FilecoinWarmStorageService Proxy: $WARM_STORAGE_SERVICE_ADDRESS"
 echo "=========================="
 echo ""
 echo "USDFC token address: $USDFC_TOKEN_ADDRESS"
-echo "Operator commission rate: $OPERATOR_COMMISSION_BPS basis points (${OPERATOR_COMMISSION_BPS})"
+echo "FilCDN wallet address: $FILCDN_WALLET"
 echo "Max proving period: $MAX_PROVING_PERIOD epochs"
 echo "Challenge window size: $CHALLENGE_WINDOW_SIZE epochs"

--- a/service_contracts/tools/deploy-warm-storage-calibnet.sh
+++ b/service_contracts/tools/deploy-warm-storage-calibnet.sh
@@ -34,7 +34,6 @@ fi
 
 # Fixed constants for initialization
 USDFC_TOKEN_ADDRESS="0xb3042734b608a1B16e9e86B374A3f3e389B4cDf0"    # USDFC token address
-OPERATOR_COMMISSION_BPS="100"                                         # 1% commission in basis points
 
 # Proving period configuration - use defaults if not set
 MAX_PROVING_PERIOD="${MAX_PROVING_PERIOD:-30}"                      # Default 30 epochs (15 minutes on calibnet)
@@ -47,7 +46,7 @@ NONCE="$(cast nonce --rpc-url "$RPC_URL" "$ADDR")"
 
 # Deploy FilecoinWarmStorageService implementation
 echo "Deploying FilecoinWarmStorageService implementation..."
-SERVICE_PAYMENTS_IMPLEMENTATION_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 src/FilecoinWarmStorageService.sol:FilecoinWarmStorageService --constructor-args $PDP_VERIFIER_ADDRESS $PAYMENTS_CONTRACT_ADDRESS $USDFC_TOKEN_ADDRESS $FILCDN_ADDRESS $OPERATOR_COMMISSION_BPS  --optimizer-runs 1 --via-ir | grep "Deployed to" | awk '{print $3}')
+SERVICE_PAYMENTS_IMPLEMENTATION_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 src/FilecoinWarmStorageService.sol:FilecoinWarmStorageService --constructor-args $PDP_VERIFIER_ADDRESS $PAYMENTS_CONTRACT_ADDRESS $USDFC_TOKEN_ADDRESS $FILCDN_ADDRESS --optimizer-runs 1 --via-ir | grep "Deployed to" | awk '{print $3}')
 if [ -z "$SERVICE_PAYMENTS_IMPLEMENTATION_ADDRESS" ]; then
     echo "Error: Failed to extract FilecoinWarmStorageService contract address"
     exit 1

--- a/service_contracts/tools/deploy-warm-storage-calibnet.sh
+++ b/service_contracts/tools/deploy-warm-storage-calibnet.sh
@@ -39,14 +39,37 @@ USDFC_TOKEN_ADDRESS="0xb3042734b608a1B16e9e86B374A3f3e389B4cDf0"    # USDFC toke
 MAX_PROVING_PERIOD="${MAX_PROVING_PERIOD:-30}"                      # Default 30 epochs (15 minutes on calibnet)
 CHALLENGE_WINDOW_SIZE="${CHALLENGE_WINDOW_SIZE:-15}"                # Default 15 epochs
 
+# Query the actual challengeFinality from PDPVerifier
+echo "Querying PDPVerifier's challengeFinality..."
+CHALLENGE_FINALITY=$(cast call $PDP_VERIFIER_ADDRESS "getChallengeFinality()" --rpc-url "$RPC_URL" | cast --to-dec)
+echo "PDPVerifier challengeFinality: $CHALLENGE_FINALITY"
+
+# Validate that the configuration will work with PDPVerifier's challengeFinality
+# The calculation: (MAX_PROVING_PERIOD - CHALLENGE_WINDOW_SIZE) + (CHALLENGE_WINDOW_SIZE/2) must be >= CHALLENGE_FINALITY
+# This ensures initChallengeWindowStart() + buffer will meet PDPVerifier requirements
+MIN_REQUIRED=$((CHALLENGE_FINALITY + CHALLENGE_WINDOW_SIZE / 2))
+if [ "$MAX_PROVING_PERIOD" -lt "$MIN_REQUIRED" ]; then
+    echo "Error: MAX_PROVING_PERIOD ($MAX_PROVING_PERIOD) is too small for PDPVerifier's challengeFinality ($CHALLENGE_FINALITY)"
+    echo "       MAX_PROVING_PERIOD must be at least $MIN_REQUIRED (CHALLENGE_FINALITY + CHALLENGE_WINDOW_SIZE/2)"
+    echo "       To fix: Set MAX_PROVING_PERIOD to at least $MIN_REQUIRED"
+    echo ""
+    echo "       Example: MAX_PROVING_PERIOD=$MIN_REQUIRED CHALLENGE_WINDOW_SIZE=$CHALLENGE_WINDOW_SIZE ./deploy-warm-storage-calibnet.sh"
+    exit 1
+fi
+
+echo "Configuration validation passed:"
+echo "  PDPVerifier challengeFinality: $CHALLENGE_FINALITY"
+echo "  MAX_PROVING_PERIOD: $MAX_PROVING_PERIOD epochs"
+echo "  CHALLENGE_WINDOW_SIZE: $CHALLENGE_WINDOW_SIZE epochs"
+
 ADDR=$(cast wallet address --keystore "$KEYSTORE" --password "$PASSWORD")
 echo "Deploying contracts from address $ADDR"
- 
+
 NONCE="$(cast nonce --rpc-url "$RPC_URL" "$ADDR")"
 
 # Deploy FilecoinWarmStorageService implementation
 echo "Deploying FilecoinWarmStorageService implementation..."
-SERVICE_PAYMENTS_IMPLEMENTATION_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 src/FilecoinWarmStorageService.sol:FilecoinWarmStorageService --constructor-args $PDP_VERIFIER_ADDRESS $PAYMENTS_CONTRACT_ADDRESS $USDFC_TOKEN_ADDRESS $FILCDN_ADDRESS --optimizer-runs 1 --via-ir | grep "Deployed to" | awk '{print $3}')
+SERVICE_PAYMENTS_IMPLEMENTATION_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 src/FilecoinWarmStorageService.sol:FilecoinWarmStorageService --constructor-args $PDP_VERIFIER_ADDRESS $PAYMENTS_CONTRACT_ADDRESS $USDFC_TOKEN_ADDRESS $FILCDN_ADDRESS | grep "Deployed to" | awk '{print $3}')
 if [ -z "$SERVICE_PAYMENTS_IMPLEMENTATION_ADDRESS" ]; then
     echo "Error: Failed to extract FilecoinWarmStorageService contract address"
     exit 1
@@ -58,7 +81,7 @@ NONCE=$(expr $NONCE + "1")
 echo "Deploying FilecoinWarmStorageService proxy..."
 # Initialize with PDPVerifier address, payments contract address, USDFC token address, commission rate, max proving period, and challenge window size
 INIT_DATA=$(cast calldata "initialize(uint64,uint256)" $MAX_PROVING_PERIOD $CHALLENGE_WINDOW_SIZE)
-WARM_STORAGE_SERVICE_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 lib/pdp/src/ERC1967Proxy.sol:MyERC1967Proxy --constructor-args $SERVICE_PAYMENTS_IMPLEMENTATION_ADDRESS $INIT_DATA --optimizer-runs 1 --via-ir | grep "Deployed to" | awk '{print $3}')
+WARM_STORAGE_SERVICE_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 lib/pdp/src/ERC1967Proxy.sol:MyERC1967Proxy --constructor-args $SERVICE_PAYMENTS_IMPLEMENTATION_ADDRESS $INIT_DATA | grep "Deployed to" | awk '{print $3}')
 if [ -z "$WARM_STORAGE_SERVICE_ADDRESS" ]; then
     echo "Error: Failed to extract FilecoinWarmStorageService proxy address"
     exit 1
@@ -68,13 +91,13 @@ echo "FilecoinWarmStorageService proxy deployed at: $WARM_STORAGE_SERVICE_ADDRES
 # Summary of deployed contracts
 echo ""
 echo "=== DEPLOYMENT SUMMARY ==="
-echo "FilecoinWarmStorageService Implementation: $SERVICE_PAYMENTS_IMPLEMENTATION_ADDRESS" 
+echo "FilecoinWarmStorageService Implementation: $SERVICE_PAYMENTS_IMPLEMENTATION_ADDRESS"
 echo "FilecoinWarmStorageService Proxy: $WARM_STORAGE_SERVICE_ADDRESS"
 echo "=========================="
 echo ""
 echo "USDFC token address: $USDFC_TOKEN_ADDRESS"
 echo "PDPVerifier address: $PDP_VERIFIER_ADDRESS"
 echo "Payments contract address: $PAYMENTS_CONTRACT_ADDRESS"
-echo "Operator commission rate: $OPERATOR_COMMISSION_BPS basis points (${OPERATOR_COMMISSION_BPS})"
+echo "FilCDN wallet address: $FILCDN_ADDRESS"
 echo "Max proving period: $MAX_PROVING_PERIOD epochs"
 echo "Challenge window size: $CHALLENGE_WINDOW_SIZE epochs"

--- a/service_contracts/tools/deploy-warm-storage-implementation-only.sh
+++ b/service_contracts/tools/deploy-warm-storage-implementation-only.sh
@@ -25,9 +25,33 @@ echo "Deploying from address: $ADDR"
 # Get current nonce
 NONCE="$(cast nonce --rpc-url "$RPC_URL" "$ADDR")"
 
+# Get required addresses from environment or use defaults
+if [ -z "$PDP_VERIFIER_ADDRESS" ]; then
+  echo "Error: PDP_VERIFIER_ADDRESS is not set"
+  exit 1
+fi
+
+if [ -z "$PAYMENTS_CONTRACT_ADDRESS" ]; then
+  echo "Error: PAYMENTS_CONTRACT_ADDRESS is not set"
+  exit 1
+fi
+
+if [ -z "$FILCDN_ADDRESS" ]; then
+  echo "Warning: FILCDN_ADDRESS not set, using default"
+  FILCDN_ADDRESS="0xff0000000000000000000000000000000002870c"
+fi
+
+USDFC_TOKEN_ADDRESS="0xb3042734b608a1B16e9e86B374A3f3e389B4cDf0"    # USDFC token address on calibnet
+
 # Deploy FilecoinWarmStorageService implementation
 echo "Deploying FilecoinWarmStorageService implementation..."
-WARM_STORAGE_IMPLEMENTATION_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 src/FilecoinWarmStorageService.sol:FilecoinWarmStorageService --optimizer-runs 1 --via-ir | grep "Deployed to" | awk '{print $3}')
+echo "Constructor arguments:"
+echo "  PDPVerifier: $PDP_VERIFIER_ADDRESS"
+echo "  Payments: $PAYMENTS_CONTRACT_ADDRESS"
+echo "  USDFC Token: $USDFC_TOKEN_ADDRESS"
+echo "  FilCDN: $FILCDN_ADDRESS"
+
+WARM_STORAGE_IMPLEMENTATION_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 src/FilecoinWarmStorageService.sol:FilecoinWarmStorageService --constructor-args $PDP_VERIFIER_ADDRESS $PAYMENTS_CONTRACT_ADDRESS $USDFC_TOKEN_ADDRESS $FILCDN_ADDRESS --optimizer-runs 1 --via-ir | grep "Deployed to" | awk '{print $3}')
 
 if [ -z "$WARM_STORAGE_IMPLEMENTATION_ADDRESS" ]; then
     echo "Error: Failed to deploy FilecoinWarmStorageService implementation"

--- a/service_contracts/tools/deploy-warm-storage-implementation-only.sh
+++ b/service_contracts/tools/deploy-warm-storage-implementation-only.sh
@@ -51,7 +51,7 @@ echo "  Payments: $PAYMENTS_CONTRACT_ADDRESS"
 echo "  USDFC Token: $USDFC_TOKEN_ADDRESS"
 echo "  FilCDN: $FILCDN_ADDRESS"
 
-WARM_STORAGE_IMPLEMENTATION_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 src/FilecoinWarmStorageService.sol:FilecoinWarmStorageService --constructor-args $PDP_VERIFIER_ADDRESS $PAYMENTS_CONTRACT_ADDRESS $USDFC_TOKEN_ADDRESS $FILCDN_ADDRESS --optimizer-runs 1 --via-ir | grep "Deployed to" | awk '{print $3}')
+WARM_STORAGE_IMPLEMENTATION_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 src/FilecoinWarmStorageService.sol:FilecoinWarmStorageService --constructor-args $PDP_VERIFIER_ADDRESS $PAYMENTS_CONTRACT_ADDRESS $USDFC_TOKEN_ADDRESS $FILCDN_ADDRESS | grep "Deployed to" | awk '{print $3}')
 
 if [ -z "$WARM_STORAGE_IMPLEMENTATION_ADDRESS" ]; then
     echo "Error: Failed to deploy FilecoinWarmStorageService implementation"
@@ -66,17 +66,17 @@ echo ""
 # If proxy address is provided, perform the upgrade
 if [ -n "$WARM_STORAGE_PROXY_ADDRESS" ]; then
     echo "Proxy address provided: $WARM_STORAGE_PROXY_ADDRESS"
-    
+
     # First check if we're the owner
     echo "Checking proxy ownership..."
     PROXY_OWNER=$(cast call "$WARM_STORAGE_PROXY_ADDRESS" "owner()(address)" --rpc-url "$RPC_URL" 2>/dev/null || echo "")
-    
+
     if [ -z "$PROXY_OWNER" ]; then
         echo "Warning: Could not determine proxy owner. Attempting upgrade anyway..."
     else
         echo "Proxy owner: $PROXY_OWNER"
         echo "Your address: $ADDR"
-        
+
         if [ "$PROXY_OWNER" != "$ADDR" ]; then
             echo ""
             echo "⚠️  WARNING: You are not the owner of this proxy!"
@@ -92,12 +92,12 @@ if [ -n "$WARM_STORAGE_PROXY_ADDRESS" ]; then
             exit 1
         fi
     fi
-    
+
     echo "Performing proxy upgrade..."
-    
+
     # Increment nonce for next transaction
     NONCE=$(expr $NONCE + "1")
-    
+
     # Call upgradeToAndCall on the proxy (works better on Filecoin)
     TX_HASH=$(cast send "$WARM_STORAGE_PROXY_ADDRESS" "upgradeToAndCall(address,bytes)" "$WARM_STORAGE_IMPLEMENTATION_ADDRESS" 0x \
         --rpc-url "$RPC_URL" \
@@ -106,7 +106,7 @@ if [ -n "$WARM_STORAGE_PROXY_ADDRESS" ]; then
         --nonce "$NONCE" \
         --chain-id 314159 \
         --json | jq -r '.transactionHash')
-    
+
     if [ -z "$TX_HASH" ]; then
         echo "Error: Failed to send upgrade transaction"
         echo "The transaction may have failed due to:"
@@ -115,18 +115,18 @@ if [ -n "$WARM_STORAGE_PROXY_ADDRESS" ]; then
         echo "- Implementation address is invalid"
         exit 1
     fi
-    
+
     echo "Upgrade transaction sent: $TX_HASH"
     echo "Waiting for confirmation..."
-    
+
     # Wait for transaction receipt
     cast receipt --rpc-url "$RPC_URL" "$TX_HASH" --confirmations 1 > /dev/null
-    
+
     # Verify the upgrade by checking the implementation address
     echo "Verifying upgrade (waiting for Filecoin 30s block time)..."
     sleep 35
     NEW_IMPL=$(cast rpc eth_getStorageAt "$WARM_STORAGE_PROXY_ADDRESS" 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc latest --rpc-url "$RPC_URL" | sed 's/"//g' | sed 's/0x000000000000000000000000/0x/')
-    
+
     if [ "$NEW_IMPL" = "$WARM_STORAGE_IMPLEMENTATION_ADDRESS" ]; then
         echo "✅ Upgrade successful! Proxy now points to: $WARM_STORAGE_IMPLEMENTATION_ADDRESS"
     else


### PR DESCRIPTION
Some simple updates to match current constructor and other changes in the contracts. Thankfully too many constructor arguments isn't a fatal thing in `forge create`, it'll just ignore them, so this goes unnoticed mainly.