### PR TITLE
feat: rename datset termination and emit events for dataset termination and add extradata

### DIFF
--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -1478,7 +1478,7 @@ contract FilecoinWarmStorageServiceTest is Test {
 
     // ============= Data Set Payment Termination Tests =============
 
-    function testTerminateDataSetPaymentLifecycle() public {
+    function testTerminateServiceLifecycle() public {
         console.log("=== Test: Data Set Payment Termination Lifecycle ===");
 
         // 1. Setup: Create a dataset with CDN enabled.
@@ -1545,7 +1545,7 @@ contract FilecoinWarmStorageServiceTest is Test {
         console.log("\n3. Terminating payment rails");
         console.log("Current block:", block.number);
         vm.prank(client); // client terminates
-        pdpServiceWithPayments.terminateDataSetPayment(dataSetId);
+        pdpServiceWithPayments.terminateService(dataSetId, "");
 
         // 4. Assertions
         // Check paymentEndEpoch is set


### PR DESCRIPTION
Closes https://github.com/FilOzone/filecoin-services/issues/95 AND https://github.com/FilOzone/filecoin-services/issues/96.

- Once a service for a dataset is terminated, all it's payment rails are terminated. After this, SP can only remove pieces from a dataset upto the rail end epoch. Adding pieces will fail after a data set is terminated.
- SP can continue submitting proofs for a dataset after temrination all the way to `endEpoch` to continue to get paid for epochs between [termination epoch, end epoch].
 - After the rail end epoch, all calls including submitting proofs and removing pieces will ALSO revert with a meaningful error message asking the SP to delete the proofset on the `PDPVerifier`.
 - We also emit meaningful events here for dataset and rail termination.
 
 Note that SP is responsible for calling `deleteProofset` on the `PDPVerifier` after a dataset service is beyond it's `endEpoch`. It can either listen to dataset termination events or rail termination events to schedule this. 