### PR TITLE
feat: remove service provider registry as we're moving it to it's own contract

### DIFF
--- a/service_contracts/src/Errors.sol
+++ b/service_contracts/src/Errors.sol
@@ -63,10 +63,6 @@ library Errors {
     /// @param dataSetId The ID of the data set whose proving period was not initialized
     error ProvingPeriodNotInitialized(uint256 dataSetId);
 
-    /// @notice Service provider is not approved or whitelisted
-    /// @param provider The address of the unapproved service provider
-    error ServiceProviderNotApproved(address provider);
-
     /// @notice The signature is invalid (recovered signer did not match expected)
     /// @param expected The expected signer address
     /// @param actual The recovered address from the signature
@@ -124,10 +120,6 @@ library Errors {
     /// @param actual The provided old service provider address
     error OldServiceProviderMismatch(uint256 dataSetId, address expected, address actual);
 
-    /// @notice New service provider is not approved
-    /// @param newProvider The new service provider address
-    error NewServiceProviderNotApproved(address newProvider);
-
     /// @notice Data set payment is already terminated
     /// @param dataSetId The data set ID
     error DataSetPaymentAlreadyTerminated(uint256 dataSetId);
@@ -163,52 +155,6 @@ library Errors {
     /// @notice Signature uses an unsupported v value (should be 27 or 28)
     /// @param v The actual v value provided
     error UnsupportedSignatureV(uint8 v);
-
-    /// @notice The provider is already approved
-    /// @param provider The provider address
-    error ProviderAlreadyApproved(address provider);
-
-    /// @notice Service URL is empty
-    error ServiceURLEmpty();
-
-    /// @notice Service URL is too long
-    /// @param length The length of the provided service URL
-    /// @param maxAllowed The maximum allowed length
-    error ServiceURLTooLong(uint256 length, uint256 maxAllowed);
-
-    /// @notice Peer ID is too long
-    /// @param length The provided peerId length
-    /// @param maxAllowed The maximum allowed length
-    error PeerIdTooLong(uint256 length, uint256 maxAllowed);
-
-    /// @notice Registration is already pending for this provider
-    /// @param provider The provider address
-    error RegistrationAlreadyPending(address provider);
-
-    /// @notice Incorrect registration fee provided
-    /// @param expected The required registration fee
-    /// @param actual The fee sent with the transaction
-    error IncorrectRegistrationFee(uint256 expected, uint256 actual);
-
-    /// @notice Burn failed when sending registration fee to burn address
-    error BurnFailed();
-
-    /// @notice No pending registration found for the provider
-    /// @param provider The provider address
-    error NoPendingRegistrationFound(address provider);
-
-    /// @notice The provider ID is invalid (not in the valid range)
-    /// @param nextServiceProviderId The next available provider ID (for context)
-    /// @param providerId The invalid provider ID
-    error InvalidProviderId(uint256 nextServiceProviderId, uint256 providerId);
-
-    /// @notice No provider found for the given provider ID
-    /// @param providerId The provider ID that was looked up
-    error ProviderNotFound(uint256 providerId);
-
-    /// @notice Provider is not currently approved
-    /// @param provider The provider address
-    error ProviderNotApproved(address provider);
 
     /// @notice Payment rail is not associated with any data set
     /// @param railId The rail ID

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -703,7 +703,6 @@ contract FilecoinWarmStorageServiceTest is Test {
         // Create a data set with sp1 as the service provider
         uint256 testDataSetId = createDataSetForServiceProviderTest(sp1, client, "Test Data Set");
         address newProvider = address(0x9999);
-        // Service provider change should succeed without approval
         bytes memory testExtraData = new bytes(0);
         vm.prank(newProvider);
         mockPDPVerifier.changeDataSetServiceProvider(

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -205,19 +205,12 @@ contract FilecoinWarmStorageServiceTest is Test {
     address public serviceProvider;
     address public filCDN;
 
-    // Additional test accounts for registry tests
     address public sp1;
     address public sp2;
     address public sp3;
 
     // Test parameters
     bytes public extraData;
-
-    // Test URLs and peer IDs for registry
-    string public validServiceUrl = "https://sp1.example.com";
-    string public validServiceUrl2 = "http://sp2.example.com:8080";
-    bytes public validPeerId = hex"122019e5f1b0e1e7c1c1b1a1b1c1d1e1f1010203040506070809";
-    bytes public validPeerId2 = hex"122019e5f1b0e1e7c1c1b1a1b1c1d1e1f1010203040506070810";
 
     // Events from Payments contract to verify
     event RailCreated(
@@ -230,12 +223,6 @@ contract FilecoinWarmStorageServiceTest is Test {
         address serviceFeeRecipient,
         uint256 commissionRateBps
     );
-
-    // Registry events to verify
-    event ProviderRegistered(address indexed provider, string serviceURL, bytes peerId);
-    event ProviderApproved(address indexed provider, uint256 indexed providerId);
-    event ProviderRejected(address indexed provider);
-    event ProviderRemoved(address indexed provider, uint256 indexed providerId);
 
     // Service provider change event to verify
     event DataSetServiceProviderChanged(
@@ -338,13 +325,6 @@ contract FilecoinWarmStorageServiceTest is Test {
     }
 
     function testCreateDataSetCreatesRailAndChargesFee() public {
-        // First approve the service provider
-        vm.prank(serviceProvider);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(
-            "https://sp.example.com/pdp", "https://sp.example.com/retrieve"
-        );
-        pdpServiceWithPayments.approveServiceProvider(serviceProvider);
-
         // Prepare ExtraData
         FilecoinWarmStorageService.DataSetCreateData memory createData = FilecoinWarmStorageService.DataSetCreateData({
             metadata: "Test Data Set",
@@ -464,13 +444,6 @@ contract FilecoinWarmStorageServiceTest is Test {
     }
 
     function testCreateDataSetNoCDN() public {
-        // First approve the service provider
-        vm.prank(serviceProvider);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(
-            "https://sp.example.com/pdp", "https://sp.example.com/retrieve"
-        );
-        pdpServiceWithPayments.approveServiceProvider(serviceProvider);
-
         // Prepare ExtraData
         FilecoinWarmStorageService.DataSetCreateData memory createData = FilecoinWarmStorageService.DataSetCreateData({
             metadata: "Test Data Set",
@@ -583,628 +556,11 @@ contract FilecoinWarmStorageServiceTest is Test {
         assert(serviceFee + spPayment < 10 ** 8); // Less than 10^8
     }
 
-    // ===== Service Provider Registry Tests =====
-
-    function testRegisterServiceProvider() public {
-        vm.startPrank(sp1);
-
-        vm.expectEmit(true, false, false, true);
-        emit ProviderRegistered(sp1, validServiceUrl, validPeerId);
-
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl, validPeerId);
-
-        vm.stopPrank();
-
-        // Verify pending registration
-        FilecoinWarmStorageService.PendingProviderInfo memory pending = pdpServiceWithPayments.getPendingProvider(sp1);
-        assertEq(pending.serviceURL, validServiceUrl, "Provider service URL should match");
-        assertEq(pending.peerId, validPeerId, "Peer ID should match");
-        assertEq(pending.registeredAt, block.number, "Registration epoch should match");
-    }
-
-    function testCannotRegisterTwiceWhilePending() public {
-        vm.startPrank(sp1);
-
-        // First registration
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl, validPeerId);
-
-        // Try to register again
-        vm.expectRevert(abi.encodeWithSelector(Errors.RegistrationAlreadyPending.selector, sp1));
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl2, validPeerId2);
-
-        vm.stopPrank();
-    }
-
-    function testCannotRegisterIfAlreadyApproved() public {
-        // Register and approve SP1
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl, validPeerId);
-
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-
-        // Try to register again
-        vm.prank(sp1);
-        vm.expectRevert(abi.encodeWithSelector(Errors.ProviderAlreadyApproved.selector, sp1));
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl2, validPeerId2);
-    }
-
-    function testApproveServiceProvider() public {
-        // SP registers
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl, validPeerId);
-
-        // Get the registration block from pending info
-        FilecoinWarmStorageService.PendingProviderInfo memory pendingInfo =
-            pdpServiceWithPayments.getPendingProvider(sp1);
-        uint256 registrationBlock = pendingInfo.registeredAt;
-
-        vm.roll(block.number + 10); // Advance blocks
-        uint256 approvalBlock = block.number;
-
-        // Owner approves
-        vm.expectEmit(true, true, false, false);
-        emit ProviderApproved(sp1, 1);
-
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-
-        // Verify approval
-        assertTrue(pdpServiceWithPayments.getProviderIdByAddress(sp1) != 0, "SP should be approved");
-        assertEq(pdpServiceWithPayments.getProviderIdByAddress(sp1), 1, "SP should have ID 1");
-
-        // Verify SP info
-        FilecoinWarmStorageService.ApprovedProviderInfo memory info = pdpServiceWithPayments.getApprovedProvider(1);
-        assertEq(info.serviceProvider, sp1, "Service provider should match");
-        assertEq(info.serviceURL, validServiceUrl, "Provider service URL should match");
-        assertEq(info.peerId, validPeerId, "Peer ID should match");
-        assertEq(info.registeredAt, registrationBlock, "Registration epoch should match");
-        assertEq(info.approvedAt, approvalBlock, "Approval epoch should match");
-
-        // Verify pending registration cleared
-        FilecoinWarmStorageService.PendingProviderInfo memory pending = pdpServiceWithPayments.getPendingProvider(sp1);
-        assertEq(pending.registeredAt, 0, "Pending registration should be cleared");
-    }
-
-    function testApproveMultipleProviders() public {
-        // Multiple SPs register
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl, validPeerId);
-
-        vm.prank(sp2);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl2, validPeerId2);
-
-        // Approve both
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-        pdpServiceWithPayments.approveServiceProvider(sp2);
-
-        // Verify IDs assigned sequentially
-        assertEq(pdpServiceWithPayments.getProviderIdByAddress(sp1), 1, "SP1 should have ID 1");
-        assertEq(pdpServiceWithPayments.getProviderIdByAddress(sp2), 2, "SP2 should have ID 2");
-    }
-
-    function testOnlyOwnerCanApprove() public {
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl, validPeerId);
-
-        vm.prank(sp2);
-        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, sp2));
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-    }
-
-    function testCannotApproveNonExistentRegistration() public {
-        vm.expectRevert(abi.encodeWithSelector(Errors.NoPendingRegistrationFound.selector, sp1));
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-    }
-
-    function testCannotApproveAlreadyApprovedProvider() public {
-        // Register and approve
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl, validPeerId);
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-
-        // Try to approve again (would need to re-register first, but we test the check)
-        vm.expectRevert(abi.encodeWithSelector(Errors.ProviderAlreadyApproved.selector, sp1));
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-    }
-
-    function testRejectServiceProvider() public {
-        // SP registers
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl, validPeerId);
-
-        // Owner rejects
-        vm.expectEmit(true, false, false, false);
-        emit ProviderRejected(sp1);
-
-        pdpServiceWithPayments.rejectServiceProvider(sp1);
-
-        // Verify not approved
-        assertTrue(pdpServiceWithPayments.getProviderIdByAddress(sp1) == 0, "SP should not be approved");
-        assertEq(pdpServiceWithPayments.getProviderIdByAddress(sp1), 0, "SP should have no ID");
-
-        // Verify pending registration cleared
-        FilecoinWarmStorageService.PendingProviderInfo memory pending = pdpServiceWithPayments.getPendingProvider(sp1);
-        assertEq(pending.registeredAt, 0, "Pending registration should be cleared");
-    }
-
-    function testCanReregisterAfterRejection() public {
-        // Register and reject
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl, validPeerId);
-        pdpServiceWithPayments.rejectServiceProvider(sp1);
-
-        // Register again with different URLs
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl2, validPeerId2);
-
-        // Verify new registration
-        FilecoinWarmStorageService.PendingProviderInfo memory pending = pdpServiceWithPayments.getPendingProvider(sp1);
-        assertTrue(pending.registeredAt > 0, "New pending registration should exist");
-        assertEq(pending.serviceURL, validServiceUrl2, "New provider service URL should match");
-    }
-
-    function testOnlyOwnerCanReject() public {
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl, validPeerId);
-
-        vm.prank(sp2);
-        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, sp2));
-        pdpServiceWithPayments.rejectServiceProvider(sp1);
-    }
-
-    function testCannotRejectNonExistentRegistration() public {
-        vm.expectRevert(abi.encodeWithSelector(Errors.NoPendingRegistrationFound.selector, sp1));
-        pdpServiceWithPayments.rejectServiceProvider(sp1);
-    }
-
-    // ===== Removal Tests =====
-
-    function testRemoveServiceProvider() public {
-        // Register and approve SP
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl, validPeerId);
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-
-        // Verify SP is approved
-        assertTrue(pdpServiceWithPayments.getProviderIdByAddress(sp1) != 0, "SP should be approved");
-        assertEq(pdpServiceWithPayments.getProviderIdByAddress(sp1), 1, "SP should have ID 1");
-
-        // Owner removes the provider
-        vm.expectEmit(true, true, false, false);
-        emit ProviderRemoved(sp1, 1);
-
-        pdpServiceWithPayments.removeServiceProvider(1);
-
-        // Verify SP is no longer approved
-        assertTrue(pdpServiceWithPayments.getProviderIdByAddress(sp1) == 0, "SP should not be approved");
-        assertEq(pdpServiceWithPayments.getProviderIdByAddress(sp1), 0, "SP should have no ID");
-    }
-
-    function testOnlyOwnerCanRemove() public {
-        // Register and approve SP
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl, validPeerId);
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-
-        // Try to remove as non-owner
-        vm.prank(sp2);
-        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, sp2));
-        pdpServiceWithPayments.removeServiceProvider(1);
-    }
-
-    function testRemovedProviderCannotCreateDataSet() public {
-        // Register and approve SP
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl, validPeerId);
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-
-        // Remove the provider
-        pdpServiceWithPayments.removeServiceProvider(1);
-
-        // Prepare extra data
-        FilecoinWarmStorageService.DataSetCreateData memory createData = FilecoinWarmStorageService.DataSetCreateData({
-            metadata: "Test Data Set",
-            payer: client,
-            signature: FAKE_SIGNATURE,
-            withCDN: false
-        });
-
-        bytes memory encodedData =
-            abi.encode(createData.metadata, createData.payer, createData.withCDN, createData.signature);
-
-        // Setup client payment approval
-        vm.startPrank(client);
-        payments.setOperatorApproval(
-            address(mockUSDFC), address(pdpServiceWithPayments), true, 1000e6, 1000e6, 365 days
-        );
-        mockUSDFC.approve(address(payments), 10e6);
-        payments.deposit(address(mockUSDFC), client, 10e6);
-        vm.stopPrank();
-
-        // Try to create data set as removed SP
-        makeSignaturePass(client);
-        vm.prank(sp1);
-        vm.expectRevert();
-        mockPDPVerifier.createDataSet(address(pdpServiceWithPayments), encodedData);
-    }
-
-    function testCanReregisterAfterRemoval() public {
-        // Register and approve SP
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl, validPeerId);
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-
-        // Remove the provider
-        pdpServiceWithPayments.removeServiceProvider(1);
-
-        // Should be able to register again
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl2, validPeerId2);
-
-        // Verify new registration
-        FilecoinWarmStorageService.PendingProviderInfo memory pending = pdpServiceWithPayments.getPendingProvider(sp1);
-        assertTrue(pending.registeredAt > 0, "New pending registration should exist");
-        assertEq(pending.serviceURL, validServiceUrl2, "New provider service URL should match");
-    }
-
-    function testNonWhitelistedProviderCannotCreateDataSet() public {
-        // Prepare extra data
-        FilecoinWarmStorageService.DataSetCreateData memory createData = FilecoinWarmStorageService.DataSetCreateData({
-            metadata: "Test Data Set",
-            payer: client,
-            signature: FAKE_SIGNATURE,
-            withCDN: false
-        });
-
-        bytes memory encodedData =
-            abi.encode(createData.metadata, createData.payer, createData.withCDN, createData.signature);
-
-        // Setup client payment approval
-        vm.startPrank(client);
-        payments.setOperatorApproval(
-            address(mockUSDFC), address(pdpServiceWithPayments), true, 1000e6, 1000e6, 365 days
-        );
-        mockUSDFC.approve(address(payments), 10e6);
-        payments.deposit(address(mockUSDFC), client, 10e6);
-        vm.stopPrank();
-
-        // Try to create data set as non-approved SP
-        makeSignaturePass(client);
-        vm.prank(sp1);
-        vm.expectRevert();
-        mockPDPVerifier.createDataSet(address(pdpServiceWithPayments), encodedData);
-    }
-
-    function testWhitelistedProviderCanCreateDataSet() public {
-        // Register and approve SP
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl, validPeerId);
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-
-        // Prepare extra data
-        FilecoinWarmStorageService.DataSetCreateData memory createData = FilecoinWarmStorageService.DataSetCreateData({
-            metadata: "Test Data Set",
-            payer: client,
-            signature: FAKE_SIGNATURE,
-            withCDN: false
-        });
-
-        bytes memory encodedData =
-            abi.encode(createData.metadata, createData.payer, createData.withCDN, createData.signature);
-
-        // Setup client payment approval
-        vm.startPrank(client);
-        payments.setOperatorApproval(
-            address(mockUSDFC), address(pdpServiceWithPayments), true, 1000e6, 1000e6, 365 days
-        );
-        mockUSDFC.approve(address(payments), 10e6);
-        payments.deposit(address(mockUSDFC), client, 10e6);
-        vm.stopPrank();
-
-        // Create data set as approved SP
-        makeSignaturePass(client);
-        vm.prank(sp1);
-        uint256 newDataSetId = mockPDPVerifier.createDataSet(address(pdpServiceWithPayments), encodedData);
-
-        // Verify data set was created
-        assertTrue(newDataSetId > 0, "Data set should be created");
-    }
-
-    function testGetApprovedProvider() public {
-        // Register and approve
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl, validPeerId);
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-
-        // Get provider info
-        FilecoinWarmStorageService.ApprovedProviderInfo memory info = pdpServiceWithPayments.getApprovedProvider(1);
-        assertEq(info.serviceProvider, sp1, "Service provider should match");
-        assertEq(info.serviceURL, validServiceUrl, "Provider service URL should match");
-    }
-
-    function testGetApprovedProviderInvalidId() public {
-        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidProviderId.selector, 1, 0));
-        pdpServiceWithPayments.getApprovedProvider(0);
-
-        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidProviderId.selector, 1, 1));
-        pdpServiceWithPayments.getApprovedProvider(1); // No providers approved yet
-
-        // Approve one provider
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl, validPeerId);
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-
-        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidProviderId.selector, 2, 2));
-        pdpServiceWithPayments.getApprovedProvider(2); // Only ID 1 exists
-    }
-
-    function testIsProviderApproved() public {
-        assertTrue(pdpServiceWithPayments.getProviderIdByAddress(sp1) == 0, "Should not be approved initially");
-
-        // Register and approve
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl, validPeerId);
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-
-        assertTrue(pdpServiceWithPayments.getProviderIdByAddress(sp1) != 0, "Should be approved after approval");
-    }
-
-    function testGetPendingProvider() public {
-        // No pending registration
-        FilecoinWarmStorageService.PendingProviderInfo memory pending = pdpServiceWithPayments.getPendingProvider(sp1);
-        assertEq(pending.registeredAt, 0, "Should have no pending registration");
-
-        // Register
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl, validPeerId);
-
-        // Check pending
-        pending = pdpServiceWithPayments.getPendingProvider(sp1);
-        assertTrue(pending.registeredAt > 0, "Should have pending registration");
-        assertEq(pending.serviceURL, validServiceUrl, "Provider service URL should match");
-    }
-
-    function testGetProviderIdByAddress() public {
-        assertEq(pdpServiceWithPayments.getProviderIdByAddress(sp1), 0, "Should have no ID initially");
-
-        // Register and approve
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl, validPeerId);
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-
-        assertEq(pdpServiceWithPayments.getProviderIdByAddress(sp1), 1, "Should have ID 1 after approval");
-    }
-
-    // Additional comprehensive tests for removeServiceProvider
-
-    function testRemoveServiceProviderAfterReregistration() public {
-        // Register and approve SP
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl, validPeerId);
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-
-        // Remove the provider
-        pdpServiceWithPayments.removeServiceProvider(1);
-
-        // SP re-registers with different URLs
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl2, validPeerId2);
-
-        // Approve again
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-        assertEq(pdpServiceWithPayments.getProviderIdByAddress(sp1), 2, "SP should have new ID 2");
-
-        // Remove again
-        pdpServiceWithPayments.removeServiceProvider(2);
-        assertTrue(pdpServiceWithPayments.getProviderIdByAddress(sp1) == 0, "SP should not be approved");
-    }
-
-    function testRemoveMultipleProviders() public {
-        // Register and approve multiple SPs
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl, validPeerId);
-
-        vm.prank(sp2);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl2, validPeerId2);
-
-        vm.prank(sp3);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(
-            "https://sp3.example.com", hex"122019e5f1b0e1e7c1c1b1a1b1c1d1e1f1010203040506070811"
-        );
-
-        // Approve all
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-        pdpServiceWithPayments.approveServiceProvider(sp2);
-        pdpServiceWithPayments.approveServiceProvider(sp3);
-
-        // Remove sp2
-        pdpServiceWithPayments.removeServiceProvider(2);
-
-        // Verify sp1 and sp3 are still approved
-        assertTrue(pdpServiceWithPayments.getProviderIdByAddress(sp1) != 0, "SP1 should still be approved");
-        assertTrue(pdpServiceWithPayments.getProviderIdByAddress(sp3) != 0, "SP3 should still be approved");
-        assertTrue(pdpServiceWithPayments.getProviderIdByAddress(sp2) == 0, "SP2 should not be approved");
-
-        // Verify IDs
-        assertEq(pdpServiceWithPayments.getProviderIdByAddress(sp1), 1, "SP1 should still have ID 1");
-        assertEq(pdpServiceWithPayments.getProviderIdByAddress(sp2), 0, "SP2 should have no ID");
-        assertEq(pdpServiceWithPayments.getProviderIdByAddress(sp3), 3, "SP3 should still have ID 3");
-    }
-
-    function testRemoveProviderWithPendingRegistration() public {
-        // Register and approve SP
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl, validPeerId);
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-
-        // Remove the provider
-        pdpServiceWithPayments.removeServiceProvider(1);
-
-        // SP tries to register again while removed
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl2, validPeerId2);
-
-        // Verify SP has pending registration but is not approved
-        assertTrue(pdpServiceWithPayments.getProviderIdByAddress(sp1) == 0, "SP should not be approved");
-        FilecoinWarmStorageService.PendingProviderInfo memory pending = pdpServiceWithPayments.getPendingProvider(sp1);
-        assertTrue(pending.registeredAt > 0, "Should have pending registration");
-        assertEq(pending.serviceURL, validServiceUrl2, "Pending URL should match new registration");
-    }
-
-    function testRemoveProviderInvalidId() public {
-        // Try to remove with ID 0
-        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidProviderId.selector, 1, 0));
-        pdpServiceWithPayments.removeServiceProvider(0);
-
-        // Try to remove with non-existent ID
-        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidProviderId.selector, 1, 999));
-        pdpServiceWithPayments.removeServiceProvider(999);
-    }
-
-    function testCannotRemoveAlreadyRemovedProvider() public {
-        // Register and approve SP
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl, validPeerId);
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-
-        // Remove the provider
-        pdpServiceWithPayments.removeServiceProvider(1);
-
-        // Try to remove again
-        vm.expectRevert(abi.encodeWithSelector(Errors.ProviderNotFound.selector, 1));
-        pdpServiceWithPayments.removeServiceProvider(1);
-    }
-
-    function testGetAllApprovedProvidersAfterRemoval() public {
-        // Register and approve three providers
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl, validPeerId);
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-
-        vm.prank(sp2);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl2, validPeerId2);
-        pdpServiceWithPayments.approveServiceProvider(sp2);
-
-        vm.prank(sp3);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(
-            "https://sp3.example.com", hex"122019e5f1b0e1e7c1c1b1a1b1c1d1e1f1010203040506070811"
-        );
-        pdpServiceWithPayments.approveServiceProvider(sp3);
-
-        // Verify all three are approved
-        FilecoinWarmStorageService.ApprovedProviderInfo[] memory providers =
-            pdpServiceWithPayments.getAllApprovedProviders();
-        assertEq(providers.length, 3, "Should have three approved providers");
-        assertEq(providers[0].serviceProvider, sp1, "First provider should be sp1");
-        assertEq(providers[1].serviceProvider, sp2, "Second provider should be sp2");
-        assertEq(providers[2].serviceProvider, sp3, "Third provider should be sp3");
-
-        // Remove the middle provider (sp2 with ID 2)
-        pdpServiceWithPayments.removeServiceProvider(2);
-
-        // Get all approved providers again - should only return active providers
-        providers = pdpServiceWithPayments.getAllApprovedProviders();
-
-        // Should only have 2 elements now (removed provider filtered out)
-        assertEq(providers.length, 2, "Array should only contain active providers");
-        assertEq(providers[0].serviceProvider, sp1, "First provider should still be sp1");
-        assertEq(providers[1].serviceProvider, sp3, "Second provider should be sp3 (sp2 filtered out)");
-
-        // Verify the URLs are correct for remaining providers
-        assertEq(providers[0].serviceURL, validServiceUrl, "SP1 provider service URL should be correct");
-        assertEq(providers[1].serviceURL, "https://sp3.example.com", "SP3 provider service URL should be correct");
-
-        // Edge case 1: Remove all providers
-        pdpServiceWithPayments.removeServiceProvider(1);
-        pdpServiceWithPayments.removeServiceProvider(3);
-
-        providers = pdpServiceWithPayments.getAllApprovedProviders();
-        assertEq(providers.length, 0, "Should return empty array when all providers removed");
-    }
-
-    function testGetAllApprovedProvidersNoProviders() public {
-        // Edge case: No providers have been registered/approved
-        FilecoinWarmStorageService.ApprovedProviderInfo[] memory providers =
-            pdpServiceWithPayments.getAllApprovedProviders();
-        assertEq(providers.length, 0, "Should return empty array when no providers registered");
-    }
-
-    function testGetAllApprovedProvidersSingleProvider() public {
-        // Edge case: Only one approved provider
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(validServiceUrl, validPeerId);
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-
-        FilecoinWarmStorageService.ApprovedProviderInfo[] memory providers =
-            pdpServiceWithPayments.getAllApprovedProviders();
-        assertEq(providers.length, 1, "Should have one approved provider");
-        assertEq(providers[0].serviceProvider, sp1, "Provider should be sp1");
-        assertEq(providers[0].serviceURL, validServiceUrl, "Provider service URL should match");
-
-        // Remove the single provider
-        pdpServiceWithPayments.removeServiceProvider(1);
-
-        providers = pdpServiceWithPayments.getAllApprovedProviders();
-        assertEq(providers.length, 0, "Should return empty array after removing single provider");
-    }
-
-    function testGetAllApprovedProvidersManyRemoved() public {
-        // Edge case: Many providers removed, only few remain
-        // Register and approve 5 providers
-        address[5] memory sps = [address(0xf10), address(0xf11), address(0xf12), address(0xf13), address(0xf14)];
-        string[5] memory serviceUrls = [
-            "https://sp1.example.com",
-            "https://sp2.example.com",
-            "https://sp3.example.com",
-            "https://sp4.example.com",
-            "https://sp5.example.com"
-        ];
-
-        bytes[5] memory peerIds;
-        peerIds[0] = hex"122019e5f1b0e1e7c1c1b1a1b1c1d1e1f1010203040506070801";
-        peerIds[1] = hex"122019e5f1b0e1e7c1c1b1a1b1c1d1e1f1010203040506070802";
-        peerIds[2] = hex"122019e5f1b0e1e7c1c1b1a1b1c1d1e1f1010203040506070803";
-        peerIds[3] = hex"122019e5f1b0e1e7c1c1b1a1b1c1d1e1f1010203040506070804";
-        peerIds[4] = hex"122019e5f1b0e1e7c1c1b1a1b1c1d1e1f1010203040506070805";
-
-        for (uint256 i = 0; i < 5; i++) {
-            vm.prank(sps[i]);
-            pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(serviceUrls[i], peerIds[i]);
-            pdpServiceWithPayments.approveServiceProvider(sps[i]);
-        }
-
-        // Verify all 5 are approved
-        FilecoinWarmStorageService.ApprovedProviderInfo[] memory providers =
-            pdpServiceWithPayments.getAllApprovedProviders();
-        assertEq(providers.length, 5, "Should have five approved providers");
-
-        // Remove providers 1, 3, and 4 (keeping 2 and 5)
-        pdpServiceWithPayments.removeServiceProvider(1);
-        pdpServiceWithPayments.removeServiceProvider(3);
-        pdpServiceWithPayments.removeServiceProvider(4);
-
-        // Should only return providers 2 and 5
-        providers = pdpServiceWithPayments.getAllApprovedProviders();
-        assertEq(providers.length, 2, "Should only have two active providers");
-        assertEq(providers[0].serviceProvider, sps[1], "First active provider should be sp2");
-        assertEq(providers[1].serviceProvider, sps[4], "Second active provider should be sp5");
-        assertEq(providers[0].serviceURL, serviceUrls[1], "SP2 URL should match");
-        assertEq(providers[1].serviceURL, serviceUrls[4], "SP5 URL should match");
-    }
-
     // ===== Client-Data Set Tracking Tests =====
     function createDataSetForClient(address provider, address clientAddress, string memory metadata)
         internal
         returns (uint256)
     {
-        // Register and approve provider if not already approved
-        if (pdpServiceWithPayments.getProviderIdByAddress(provider) == 0) {
-            vm.prank(provider);
-            pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(
-                "https://provider.example.com", hex"122019e5f1b0e1e7c1c1b1a1b1c1d1e1f1010203040506070850"
-            );
-            pdpServiceWithPayments.approveServiceProvider(provider);
-        }
-
         // Prepare extra data
         FilecoinWarmStorageService.DataSetCreateData memory createData = FilecoinWarmStorageService.DataSetCreateData({
             metadata: metadata,
@@ -1294,15 +650,6 @@ contract FilecoinWarmStorageServiceTest is Test {
         internal
         returns (uint256)
     {
-        // Register and approve provider if not already approved
-        if (pdpServiceWithPayments.getProviderIdByAddress(provider) == 0) {
-            vm.prank(provider);
-            pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(
-                "https://provider.example.com/pdp", "https://provider.example.com/retrieve"
-            );
-            pdpServiceWithPayments.approveServiceProvider(provider);
-        }
-
         // Prepare extra data
         FilecoinWarmStorageService.DataSetCreateData memory createData = FilecoinWarmStorageService.DataSetCreateData({
             metadata: metadata,
@@ -1334,24 +681,8 @@ contract FilecoinWarmStorageServiceTest is Test {
      * @dev Verifies only the data set's payee is updated, event is emitted, and registry state is unchanged.
      */
     function testServiceProviderChangedSuccessDecoupled() public {
-        // Register and approve two providers
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(
-            "https://sp1.example.com/pdp", "https://sp1.example.com/retrieve"
-        );
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-        vm.prank(sp2);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(
-            "https://sp2.example.com/pdp", "https://sp2.example.com/retrieve"
-        );
-        pdpServiceWithPayments.approveServiceProvider(sp2);
-
         // Create a data set with sp1 as the service provider
         uint256 testDataSetId = createDataSetForServiceProviderTest(sp1, client, "Test Data Set");
-
-        // Registry state before
-        uint256 sp1IdBefore = pdpServiceWithPayments.getProviderIdByAddress(sp1);
-        uint256 sp2IdBefore = pdpServiceWithPayments.getProviderIdByAddress(sp2);
 
         // Change service provider from sp1 to sp2
         bytes memory testExtraData = new bytes(0);
@@ -1363,47 +694,30 @@ contract FilecoinWarmStorageServiceTest is Test {
         // Only the data set's payee is updated
         FilecoinWarmStorageService.DataSetInfo memory dataSet = pdpServiceWithPayments.getDataSet(testDataSetId);
         assertEq(dataSet.payee, sp2, "Payee should be updated to new service provider");
-
-        // Registry state is unchanged
-        assertEq(pdpServiceWithPayments.getProviderIdByAddress(sp1), sp1IdBefore, "sp1 provider ID unchanged");
-        assertEq(pdpServiceWithPayments.getProviderIdByAddress(sp2), sp2IdBefore, "sp2 provider ID unchanged");
     }
 
     /**
      * @notice Test service provider change reverts if new service provider is not an approved provider
      */
-    function testServiceProviderChangedRevertsIfNewServiceProviderNotApproved() public {
-        // Register and approve sp1
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(
-            "https://sp1.example.com/pdp", "https://sp1.example.com/retrieve"
-        );
-        pdpServiceWithPayments.approveServiceProvider(sp1);
+    function testServiceProviderChangedNoLongerChecksApproval() public {
         // Create a data set with sp1 as the service provider
         uint256 testDataSetId = createDataSetForServiceProviderTest(sp1, client, "Test Data Set");
-        // Use an unapproved address for the new service provider
-        address unapproved = address(0x9999);
-        assertTrue(pdpServiceWithPayments.getProviderIdByAddress(unapproved) == 0, "Unapproved should not be approved");
-        // Attempt service provider change
+        address newProvider = address(0x9999);
+        // Service provider change should succeed without approval
         bytes memory testExtraData = new bytes(0);
-        vm.prank(unapproved);
-        vm.expectRevert(abi.encodeWithSelector(Errors.NewServiceProviderNotApproved.selector, unapproved));
+        vm.prank(newProvider);
         mockPDPVerifier.changeDataSetServiceProvider(
-            testDataSetId, unapproved, address(pdpServiceWithPayments), testExtraData
+            testDataSetId, newProvider, address(pdpServiceWithPayments), testExtraData
         );
-        // Registry state is unchanged
-        assertTrue(pdpServiceWithPayments.getProviderIdByAddress(sp1) != 0, "sp1 should remain approved");
+        // Verify the change succeeded
+        FilecoinWarmStorageService.DataSetInfo memory dataSet = pdpServiceWithPayments.getDataSet(testDataSetId);
+        assertEq(dataSet.payee, newProvider, "Payee should be updated to new service provider");
     }
 
     /**
      * @notice Test service provider change reverts if new service provider is zero address
      */
     function testServiceProviderChangedRevertsIfNewServiceProviderZeroAddress() public {
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(
-            "https://sp1.example.com/pdp", "https://sp1.example.com/retrieve"
-        );
-        pdpServiceWithPayments.approveServiceProvider(sp1);
         uint256 testDataSetId = createDataSetForServiceProviderTest(sp1, client, "Test Data Set");
         bytes memory testExtraData = new bytes(0);
         vm.prank(sp1);
@@ -1417,16 +731,6 @@ contract FilecoinWarmStorageServiceTest is Test {
      * @notice Test service provider change reverts if old service provider mismatch
      */
     function testServiceProviderChangedRevertsIfOldServiceProviderMismatch() public {
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(
-            "https://sp1.example.com/pdp", "https://sp1.example.com/retrieve"
-        );
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-        vm.prank(sp2);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(
-            "https://sp2.example.com/pdp", "https://sp2.example.com/retrieve"
-        );
-        pdpServiceWithPayments.approveServiceProvider(sp2);
         uint256 testDataSetId = createDataSetForServiceProviderTest(sp1, client, "Test Data Set");
         bytes memory testExtraData = new bytes(0);
         // Call directly as PDPVerifier with wrong old service provider
@@ -1439,16 +743,6 @@ contract FilecoinWarmStorageServiceTest is Test {
      * @notice Test service provider change reverts if called by unauthorized address
      */
     function testServiceProviderChangedRevertsIfUnauthorizedCaller() public {
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(
-            "https://sp1.example.com/pdp", "https://sp1.example.com/retrieve"
-        );
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-        vm.prank(sp2);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(
-            "https://sp2.example.com/pdp", "https://sp2.example.com/retrieve"
-        );
-        pdpServiceWithPayments.approveServiceProvider(sp2);
         uint256 testDataSetId = createDataSetForServiceProviderTest(sp1, client, "Test Data Set");
         bytes memory testExtraData = new bytes(0);
         // Call directly as sp2 (not PDPVerifier)
@@ -1461,17 +755,6 @@ contract FilecoinWarmStorageServiceTest is Test {
      * @notice Test multiple data sets per provider: only the targeted data set's payee is updated
      */
     function testMultipleDataSetsPerProviderServiceProviderChange() public {
-        // Register and approve two providers
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(
-            "https://sp1.example.com/pdp", "https://sp1.example.com/retrieve"
-        );
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-        vm.prank(sp2);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(
-            "https://sp2.example.com/pdp", "https://sp2.example.com/retrieve"
-        );
-        pdpServiceWithPayments.approveServiceProvider(sp2);
         // Create two data sets for sp1
         uint256 ps1 = createDataSetForServiceProviderTest(sp1, client, "Data Set 1");
         uint256 ps2 = createDataSetForServiceProviderTest(sp1, client, "Data Set 2");
@@ -1486,25 +769,12 @@ contract FilecoinWarmStorageServiceTest is Test {
         FilecoinWarmStorageService.DataSetInfo memory dataSet2 = pdpServiceWithPayments.getDataSet(ps2);
         assertEq(dataSet1.payee, sp2, "ps1 payee should be sp2");
         assertEq(dataSet2.payee, sp1, "ps2 payee should remain sp1");
-        // Registry state unchanged
-        assertTrue(pdpServiceWithPayments.getProviderIdByAddress(sp1) != 0, "sp1 remains approved");
-        assertTrue(pdpServiceWithPayments.getProviderIdByAddress(sp2) != 0, "sp2 remains approved");
     }
 
     /**
      * @notice Test service provider change works with arbitrary extra data
      */
     function testServiceProviderChangedWithArbitraryExtraData() public {
-        vm.prank(sp1);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(
-            "https://sp1.example.com/pdp", "https://sp1.example.com/retrieve"
-        );
-        pdpServiceWithPayments.approveServiceProvider(sp1);
-        vm.prank(sp2);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(
-            "https://sp2.example.com/pdp", "https://sp2.example.com/retrieve"
-        );
-        pdpServiceWithPayments.approveServiceProvider(sp2);
         uint256 testDataSetId = createDataSetForServiceProviderTest(sp1, client, "Test Data Set");
         // Use arbitrary extra data
         bytes memory testExtraData = abi.encode("arbitrary", 123, address(this));
@@ -1522,13 +792,7 @@ contract FilecoinWarmStorageServiceTest is Test {
         console.log("=== Test: Data Set Payment Termination Lifecycle ===");
 
         // 1. Setup: Create a dataset with CDN enabled.
-        console.log("1. Setting up: Registering and approving service provider");
-        // Register and approve service provider
-        vm.prank(serviceProvider);
-        pdpServiceWithPayments.registerServiceProvider{value: 1 ether}(
-            "https://sp.example.com/pdp", "https://sp.example.com/retrieve"
-        );
-        pdpServiceWithPayments.approveServiceProvider(serviceProvider);
+        console.log("1. Setting up: Creating dataset with service provider");
 
         // Prepare data set creation data
         FilecoinWarmStorageService.DataSetCreateData memory createData = FilecoinWarmStorageService.DataSetCreateData({
@@ -1652,24 +916,6 @@ contract FilecoinWarmStorageServiceTest is Test {
         console.log("[OK] nextProvingPeriod correctly reverted");
 
         console.log("\n=== Test completed successfully! ===");
-    }
-
-    function testRegisterServiceProviderRevertsIfNoValue() public {
-        vm.startPrank(sp1);
-        vm.expectRevert(abi.encodeWithSelector(Errors.IncorrectRegistrationFee.selector, 1 ether, 0));
-        pdpServiceWithPayments.registerServiceProvider(
-            "https://sp1.example.com/pdp", "https://sp1.example.com/retrieve"
-        );
-        vm.stopPrank();
-    }
-
-    function testRegisterServiceProviderRevertsIfWrongValue() public {
-        vm.startPrank(sp1);
-        vm.expectRevert(abi.encodeWithSelector(Errors.IncorrectRegistrationFee.selector, 1 ether, 0.5 ether));
-        pdpServiceWithPayments.registerServiceProvider{value: 0.5 ether}(
-            "https://sp1.example.com/pdp", "https://sp1.example.com/retrieve"
-        );
-        vm.stopPrank();
     }
 }
 


### PR DESCRIPTION
This PR does the first part of #119 i.e. removes all the code and tests for the service provider registry from this service contract. We will now build a new more extensible service registry contract  as specified in #119 and upgrade the warm storage service contract to use the registry. More PRs incoming for that.

But we can merge this standalone PR without waiting on them.