### PR TITLE
Move IPDPProvingSchedule To FilecoinWarmStorageService

### DIFF
--- a/service_contracts/src/FilecoinWarmStorageServiceStateView.sol
+++ b/service_contracts/src/FilecoinWarmStorageServiceStateView.sol
@@ -3,11 +3,10 @@ pragma solidity ^0.8.20;
 
 // Generated with tools/generate_view_contract.sh out/FilecoinWarmStorageServiceStateLibrary.sol/FilecoinWarmStorageServiceStateLibrary.json
 
-import {IPDPProvingSchedule} from "@pdp/IPDPProvingSchedule.sol";
 import "./FilecoinWarmStorageService.sol";
 import "./lib/FilecoinWarmStorageServiceStateInternalLibrary.sol";
 
-contract FilecoinWarmStorageServiceStateView is IPDPProvingSchedule {
+contract FilecoinWarmStorageServiceStateView {
     using FilecoinWarmStorageServiceStateInternalLibrary for FilecoinWarmStorageService;
 
     FilecoinWarmStorageService public immutable service;
@@ -16,20 +15,12 @@ contract FilecoinWarmStorageServiceStateView is IPDPProvingSchedule {
         service = _service;
     }
 
-    function challengeWindow() external view returns (uint256) {
-        return service.challengeWindow();
-    }
-
     function clientDataSetIDs(address payer) external view returns (uint256) {
         return service.clientDataSetIDs(payer);
     }
 
     function clientDataSets(address payer) external view returns (uint256[] memory dataSetIds) {
         return service.clientDataSets(payer);
-    }
-
-    function getChallengesPerProof() external pure returns (uint64) {
-        return FilecoinWarmStorageServiceStateInternalLibrary.getChallengesPerProof();
     }
 
     function getClientDataSets(address client)
@@ -48,20 +39,8 @@ contract FilecoinWarmStorageServiceStateView is IPDPProvingSchedule {
         return FilecoinWarmStorageServiceStateInternalLibrary.getDataSetSizeInBytes(leafCount);
     }
 
-    function getMaxProvingPeriod() external view returns (uint64) {
-        return service.getMaxProvingPeriod();
-    }
-
     function getPieceMetadata(uint256 dataSetId, uint256 pieceId) external view returns (string memory) {
         return service.getPieceMetadata(dataSetId, pieceId);
-    }
-
-    function initChallengeWindowStart() external view returns (uint256) {
-        return service.initChallengeWindowStart();
-    }
-
-    function nextChallengeWindowStart(uint256 setId) external view returns (uint256) {
-        return service.nextChallengeWindowStart(setId);
     }
 
     function provenPeriods(uint256 dataSetId, uint256 periodId) external view returns (bool) {
@@ -82,9 +61,5 @@ contract FilecoinWarmStorageServiceStateView is IPDPProvingSchedule {
 
     function railToDataSet(uint256 railId) external view returns (uint256) {
         return service.railToDataSet(railId);
-    }
-
-    function thisChallengeWindowStart(uint256 setId) external view returns (uint256) {
-        return service.thisChallengeWindowStart(setId);
     }
 }

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
@@ -67,10 +67,6 @@ library FilecoinWarmStorageServiceStateInternalLibrary {
         return leafCount * BYTES_PER_LEAF;
     }
 
-    function getChallengesPerProof() internal pure returns (uint64) {
-        return CHALLENGES_PER_PROOF;
-    }
-
     function clientDataSetIDs(FilecoinWarmStorageService service, address payer) internal view returns (uint256) {
         return uint256(service.extsload(keccak256(abi.encode(payer, CLIENT_DATA_SET_IDS_SLOT))));
     }
@@ -165,62 +161,6 @@ library FilecoinWarmStorageServiceStateInternalLibrary {
 
     function provingDeadlines(FilecoinWarmStorageService service, uint256 setId) internal view returns (uint256) {
         return uint256(service.extsload(keccak256(abi.encode(setId, PROVING_DEADLINES_SLOT))));
-    }
-
-    function getMaxProvingPeriod(FilecoinWarmStorageService service) internal view returns (uint64) {
-        return uint64(uint256(service.extsload(MAX_PROVING_PERIOD_SLOT)));
-    }
-
-    // Number of epochs at the end of a proving period during which a
-    // proof of possession can be submitted
-    function challengeWindow(FilecoinWarmStorageService service) internal view returns (uint256) {
-        return uint256(service.extsload(CHALLENGE_WINDOW_SIZE_SLOT));
-    }
-
-    // Initial value for challenge window start
-    // Can be used for first call to nextProvingPeriod
-    function initChallengeWindowStart(FilecoinWarmStorageService service) internal view returns (uint256) {
-        return block.number + getMaxProvingPeriod(service) - challengeWindow(service);
-    }
-
-    // The start of the challenge window for the current proving period
-    function thisChallengeWindowStart(FilecoinWarmStorageService service, uint256 setId)
-        internal
-        view
-        returns (uint256)
-    {
-        if (provingDeadlines(service, setId) == NO_PROVING_DEADLINE) {
-            revert Errors.ProvingPeriodNotInitialized(setId);
-        }
-
-        uint256 periodsSkipped;
-        // Proving period is open 0 skipped periods
-        if (block.number <= provingDeadlines(service, setId)) {
-            periodsSkipped = 0;
-        } else {
-            // Proving period has closed possibly some skipped periods
-            periodsSkipped = 1 + (block.number - (provingDeadlines(service, setId) + 1)) / getMaxProvingPeriod(service);
-        }
-        return
-            provingDeadlines(service, setId) + periodsSkipped * getMaxProvingPeriod(service) - challengeWindow(service);
-    }
-
-    // The start of the NEXT OPEN proving period's challenge window
-    // Useful for querying before nextProvingPeriod to determine challengeEpoch to submit for nextProvingPeriod
-    function nextChallengeWindowStart(FilecoinWarmStorageService service, uint256 setId)
-        internal
-        view
-        returns (uint256)
-    {
-        if (provingDeadlines(service, setId) == NO_PROVING_DEADLINE) {
-            revert Errors.ProvingPeriodNotInitialized(setId);
-        }
-        // If the current period is open this is the next period's challenge window
-        if (block.number <= provingDeadlines(service, setId)) {
-            return thisChallengeWindowStart(service, setId) + getMaxProvingPeriod(service);
-        }
-        // If the current period is not yet open this is the current period's challenge window
-        return thisChallengeWindowStart(service, setId);
     }
 
     function getClientDataSets(FilecoinWarmStorageService service, address client)

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceStateLibrary.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceStateLibrary.sol
@@ -65,10 +65,6 @@ library FilecoinWarmStorageServiceStateLibrary {
         return leafCount * BYTES_PER_LEAF;
     }
 
-    function getChallengesPerProof() public pure returns (uint64) {
-        return CHALLENGES_PER_PROOF;
-    }
-
     function clientDataSetIDs(FilecoinWarmStorageService service, address payer) public view returns (uint256) {
         return uint256(service.extsload(keccak256(abi.encode(payer, CLIENT_DATA_SET_IDS_SLOT))));
     }
@@ -163,62 +159,6 @@ library FilecoinWarmStorageServiceStateLibrary {
 
     function provingDeadlines(FilecoinWarmStorageService service, uint256 setId) public view returns (uint256) {
         return uint256(service.extsload(keccak256(abi.encode(setId, PROVING_DEADLINES_SLOT))));
-    }
-
-    function getMaxProvingPeriod(FilecoinWarmStorageService service) public view returns (uint64) {
-        return uint64(uint256(service.extsload(MAX_PROVING_PERIOD_SLOT)));
-    }
-
-    // Number of epochs at the end of a proving period during which a
-    // proof of possession can be submitted
-    function challengeWindow(FilecoinWarmStorageService service) public view returns (uint256) {
-        return uint256(service.extsload(CHALLENGE_WINDOW_SIZE_SLOT));
-    }
-
-    // Initial value for challenge window start
-    // Can be used for first call to nextProvingPeriod
-    function initChallengeWindowStart(FilecoinWarmStorageService service) public view returns (uint256) {
-        return block.number + getMaxProvingPeriod(service) - challengeWindow(service);
-    }
-
-    // The start of the challenge window for the current proving period
-    function thisChallengeWindowStart(FilecoinWarmStorageService service, uint256 setId)
-        public
-        view
-        returns (uint256)
-    {
-        if (provingDeadlines(service, setId) == NO_PROVING_DEADLINE) {
-            revert Errors.ProvingPeriodNotInitialized(setId);
-        }
-
-        uint256 periodsSkipped;
-        // Proving period is open 0 skipped periods
-        if (block.number <= provingDeadlines(service, setId)) {
-            periodsSkipped = 0;
-        } else {
-            // Proving period has closed possibly some skipped periods
-            periodsSkipped = 1 + (block.number - (provingDeadlines(service, setId) + 1)) / getMaxProvingPeriod(service);
-        }
-        return
-            provingDeadlines(service, setId) + periodsSkipped * getMaxProvingPeriod(service) - challengeWindow(service);
-    }
-
-    // The start of the NEXT OPEN proving period's challenge window
-    // Useful for querying before nextProvingPeriod to determine challengeEpoch to submit for nextProvingPeriod
-    function nextChallengeWindowStart(FilecoinWarmStorageService service, uint256 setId)
-        public
-        view
-        returns (uint256)
-    {
-        if (provingDeadlines(service, setId) == NO_PROVING_DEADLINE) {
-            revert Errors.ProvingPeriodNotInitialized(setId);
-        }
-        // If the current period is open this is the next period's challenge window
-        if (block.number <= provingDeadlines(service, setId)) {
-            return thisChallengeWindowStart(service, setId) + getMaxProvingPeriod(service);
-        }
-        // If the current period is not yet open this is the current period's challenge window
-        return thisChallengeWindowStart(service, setId);
     }
 
     function getClientDataSets(FilecoinWarmStorageService service, address client)

--- a/service_contracts/tools/generate_view_contract.sh
+++ b/service_contracts/tools/generate_view_contract.sh
@@ -6,11 +6,10 @@ echo
 echo // Generated with $0 $@
 echo
 
-echo 'import {IPDPProvingSchedule} from "@pdp/IPDPProvingSchedule.sol";'
 echo 'import "./FilecoinWarmStorageService.sol";'
 echo 'import "./lib/FilecoinWarmStorageServiceStateInternalLibrary.sol";'
 
-echo contract FilecoinWarmStorageServiceStateView is IPDPProvingSchedule {
+echo contract FilecoinWarmStorageServiceStateView {
 echo "    using FilecoinWarmStorageServiceStateInternalLibrary for FilecoinWarmStorageService;"
 echo "    FilecoinWarmStorageService public immutable service;"
 echo "    constructor(FilecoinWarmStorageService _service) {"


### PR DESCRIPTION

Reviewer @rvagg
helps with #163
Increasing codesize from `15876` to `16445` is acceptable if these are the only view methods needed to save a lot of effort refactoring up the pipeline.
#### Changes
* move IPDPProvingSchedule from FilecoinWarmStorageServiceStateView to FilecoinWarmStorageService