### PR TITLE
Handle ServiceTerminated and CDNServiceTerminated events

### DIFF
--- a/subgraph/abis/FilecoinWarmStorageService.json
+++ b/subgraph/abis/FilecoinWarmStorageService.json
@@ -2090,6 +2090,74 @@
     ],
     "anonymous": false
   },
+    {
+    "type": "event",
+    "name": "ServiceTerminated",
+    "inputs": [
+      {
+        "name": "caller",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "dataSetId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "pdpRailId",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "cacheMissRailId",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "cdnRailId",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "CDNServiceTerminated",
+    "inputs": [
+      {
+        "name": "caller",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "dataSetId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "cacheMissRailId",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "cdnRailId",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
   {
     "type": "error",
     "name": "AddressEmptyCode",

--- a/subgraph/src/filecoin-warm-storage-service.ts
+++ b/subgraph/src/filecoin-warm-storage-service.ts
@@ -7,6 +7,8 @@ import {
   ProviderRejected as ProviderRejectedEvent,
   ProviderRemoved as ProviderRemovedEvent,
   RailRateUpdated as RailRateUpdatedEvent,
+  ServiceTerminated as ServiceTerminatedEvent,
+  CDNServiceTerminated as CDNServiceTerminatedEvent,
 } from "../generated/FilecoinWarmStorageService/FilecoinWarmStorageService";
 import { PDPVerifier } from "../generated/PDPVerifier/PDPVerifier";
 import {
@@ -528,4 +530,39 @@ export function handleProviderRemoved(event: ProviderRemovedEvent): void {
   provider.blockNumber = event.block.number;
 
   provider.save();
+}
+
+
+/**
+ * Handler for ServiceTerminated event
+ * Sets `withCDN` and `isActive` to `false`
+ */
+export function handleServiceTerminated(event: ServiceTerminatedEvent): void {
+  const dataSetId = event.params.dataSetId;
+
+  let dataSet = DataSet.load(dataSetId);
+  if (!dataSet) return;
+
+  dataSet.isActive = false;
+  dataSet.withCDN = false;
+  dataSet.updatedAt = event.block.timestamp;
+
+  dataSet.save();
+}
+
+
+/**
+ * Handler for CDNServiceTerminated event
+ * Sets `withCDN` `false`
+ */
+export function handleCDNServiceTerminated(event: CDNServiceTerminatedEvent): void {
+  const dataSetId = event.params.dataSetId;
+
+  let dataSet = DataSet.load(dataSetId);
+  if (!dataSet) return;
+
+  dataSet.withCDN = false;
+  dataSet.updatedAt = event.block.timestamp;
+
+  dataSet.save();
 }

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -78,6 +78,8 @@ dataSources:
           handler: handleProviderApproved
         - event: "ProviderRejected(indexed address)"
           handler: handleProviderRejected
-        - event: "ProviderRemoved(indexed address,indexed uint256)"
-          handler: handleProviderRemoved
+        - event: "ServiceTerminated(indexed address,indexed uint256,uint256,uint256,uint256)"
+          handler: handleServiceTerminated
+        - event: "CDNServiceTerminated(indexed address,indexed uint256,uint256,uint256)"
+          handler: handleCDNServiceTerminated
       file: ./src/filecoin-warm-storage-service.ts


### PR DESCRIPTION
This is a follow-up PR to #161. It introduces handlers for `ServiceTerminated` and `CDNServiceTerminated` events.