### PR TITLE
Fix StateLibrary json Makefile recipe

### DIFF
--- a/service_contracts/Makefile
+++ b/service_contracts/Makefile
@@ -36,7 +36,7 @@ $(LAYOUT): tools/generate_storage_layout.sh src/FilecoinWarmStorageService.sol
 
 # JSON compilation for library (depends on the source library)
 $(LIBRARY_JSON): src/lib/FilecoinWarmStorageServiceStateLibrary.sol
-	forge build --via-ir src/lib/FilecoinWarmStorageServiceStateLibrary.sol
+	forge build --via-ir $^
 
 # View contract generation (depends on JSON)
 $(VIEW_CONTRACT): tools/generate_view_contract.sh $(LIBRARY_JSON)

--- a/service_contracts/Makefile
+++ b/service_contracts/Makefile
@@ -36,9 +36,7 @@ $(LAYOUT): tools/generate_storage_layout.sh src/FilecoinWarmStorageService.sol
 
 # JSON compilation for library (depends on the source library)
 $(LIBRARY_JSON): src/lib/FilecoinWarmStorageServiceStateLibrary.sol
-	@echo "Building library to generate ABI..."
-	@forge build --via-ir --force src/lib/FilecoinWarmStorageServiceStateLibrary.sol 2>/dev/null || \
-		(echo "Warning: Library compilation failed, view generation may be incomplete" && touch $@)
+	forge build --via-ir src/lib/FilecoinWarmStorageServiceStateLibrary.sol
 
 # View contract generation (depends on JSON)
 $(VIEW_CONTRACT): tools/generate_view_contract.sh $(LIBRARY_JSON)


### PR DESCRIPTION
Reviewer @rvagg
There are a few problems with the `FilecoinWarmStorageServiceStateLibrary.json` recipe.
It hides important information about why the build failed.
It behaves as if the recipe succeeded even when it failed.
#### Changes
* do not hide the build errors
* do not proceed as if successful when the build fails
* no need to --force the build