### PR TITLE
fix: move pdp proving schedule interface to view/library

### DIFF
--- a/service_contracts/abi/FilecoinWarmStorageService.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageService.abi.json
@@ -250,34 +250,6 @@
   },
   {
     "type": "function",
-    "name": "getPDPConfig",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      },
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
     "name": "getProvingPeriodForEpoch",
     "inputs": [
       {
@@ -389,25 +361,6 @@
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "nextPDPChallengeWindowStart",
-    "inputs": [
-      {
-        "name": "setId",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "view"
   },
   {
     "type": "function",
@@ -1681,17 +1634,6 @@
   {
     "type": "error",
     "name": "ProvingNotStarted",
-    "inputs": [
-      {
-        "name": "dataSetId",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "ProvingPeriodNotInitialized",
     "inputs": [
       {
         "name": "dataSetId",

--- a/service_contracts/abi/FilecoinWarmStorageServiceStateLibrary.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageServiceStateLibrary.abi.json
@@ -348,6 +348,40 @@
   },
   {
     "type": "function",
+    "name": "getPDPConfig",
+    "inputs": [
+      {
+        "name": "service",
+        "type": "FilecoinWarmStorageService",
+        "internalType": "contract FilecoinWarmStorageService"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "maxProvingPeriod",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "challengeWindowSize",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "challengesPerProof",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "initChallengeWindowStart",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "getPieceMetadata",
     "inputs": [
       {
@@ -381,6 +415,30 @@
         "name": "value",
         "type": "string",
         "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "nextPDPChallengeWindowStart",
+    "inputs": [
+      {
+        "name": "service",
+        "type": "FilecoinWarmStorageService",
+        "internalType": "contract FilecoinWarmStorageService"
+      },
+      {
+        "name": "setId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
       }
     ],
     "stateMutability": "view"
@@ -464,7 +522,7 @@
   },
   {
     "type": "function",
-    "name": "provingDeadlines",
+    "name": "provingDeadline",
     "inputs": [
       {
         "name": "service",
@@ -509,5 +567,16 @@
       }
     ],
     "stateMutability": "view"
+  },
+  {
+    "type": "error",
+    "name": "ProvingPeriodNotInitialized",
+    "inputs": [
+      {
+        "name": "dataSetId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
   }
 ]

--- a/service_contracts/abi/FilecoinWarmStorageServiceStateView.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageServiceStateView.abi.json
@@ -312,6 +312,34 @@
   },
   {
     "type": "function",
+    "name": "getPDPConfig",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "maxProvingPeriod",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "challengeWindowSize",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "challengesPerProof",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "initChallengeWindowStart",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "getPieceMetadata",
     "inputs": [
       {
@@ -340,6 +368,25 @@
         "name": "value",
         "type": "string",
         "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "nextPDPChallengeWindowStart",
+    "inputs": [
+      {
+        "name": "setId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
       }
     ],
     "stateMutability": "view"
@@ -408,7 +455,7 @@
   },
   {
     "type": "function",
-    "name": "provingDeadlines",
+    "name": "provingDeadline",
     "inputs": [
       {
         "name": "setId",
@@ -456,5 +503,16 @@
       }
     ],
     "stateMutability": "view"
+  },
+  {
+    "type": "error",
+    "name": "ProvingPeriodNotInitialized",
+    "inputs": [
+      {
+        "name": "dataSetId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
   }
 ]

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.20;
 
 import {PDPVerifier, PDPListener} from "@pdp/PDPVerifier.sol";
-import {IPDPProvingSchedule} from "@pdp/IPDPProvingSchedule.sol";
 import {IPDPTypes} from "@pdp/interfaces/IPDPTypes.sol";
 import {Cids} from "@pdp/Cids.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
@@ -29,7 +28,6 @@ uint256 constant COMMISSION_MAX_BPS = 10000; // 100% in basis points
 /// to reduce payments for faulted epochs.
 contract FilecoinWarmStorageService is
     PDPListener,
-    IPDPProvingSchedule,
     IValidator,
     Initializable,
     UUPSUpgradeable,
@@ -1340,50 +1338,5 @@ contract FilecoinWarmStorageService is
             info.paymentEndEpoch = endEpoch;
             emit PaymentTerminated(dataSetId, endEpoch, info.pdpRailId, info.cacheMissRailId, info.cdnRailId);
         }
-    }
-
-    /* IPDPProvingSchedule */
-
-    /**
-     * @notice Returns PDP configuration values
-     * @return maxProvingPeriod Maximum number of epochs between proofs
-     * @return challengeWindow Number of epochs for the challenge window
-     * @return challengesPerProof Number of challenges required per proof
-     * @return initChallengeWindowStart Initial challenge window start for new data sets
-     */
-    function getPDPConfig() external view returns (uint64, uint256, uint256, uint256) {
-        uint64 m = maxProvingPeriod;
-        uint256 c = challengeWindowSize;
-        return (m, c, CHALLENGES_PER_PROOF, block.number + m - c);
-    }
-
-    /**
-     * @notice Returns the start of the next challenge window for a data set
-     * @param setId The ID of the data set
-     * @return The block number when the next challenge window starts
-     */
-    function nextPDPChallengeWindowStart(uint256 setId) external view returns (uint256) {
-        if (provingDeadlines[setId] == NO_PROVING_DEADLINE) {
-            revert Errors.ProvingPeriodNotInitialized(setId);
-        }
-        // If the current period is open this is the next period's challenge window
-        if (block.number <= provingDeadlines[setId]) {
-            return _thisChallengeWindowStart(setId) + maxProvingPeriod;
-        }
-        // Otherwise return the current period's challenge window
-        return _thisChallengeWindowStart(setId);
-    }
-
-    // The start of the challenge window for the current proving period
-    function _thisChallengeWindowStart(uint256 setId) internal view returns (uint256) {
-        uint256 periodsSkipped;
-        // Proving period is open 0 skipped periods
-        if (block.number <= provingDeadlines[setId]) {
-            periodsSkipped = 0;
-        } else {
-            // Proving period has closed possibly some skipped periods
-            periodsSkipped = 1 + (block.number - (provingDeadlines[setId] + 1)) / maxProvingPeriod;
-        }
-        return provingDeadlines[setId] + periodsSkipped * maxProvingPeriod - challengeWindowSize;
     }
 }

--- a/service_contracts/src/FilecoinWarmStorageServiceStateView.sol
+++ b/service_contracts/src/FilecoinWarmStorageServiceStateView.sol
@@ -7,8 +7,9 @@ pragma solidity ^0.8.20;
 
 import "./FilecoinWarmStorageService.sol";
 import "./lib/FilecoinWarmStorageServiceStateInternalLibrary.sol";
+import "@pdp/IPDPProvingSchedule.sol";
 
-contract FilecoinWarmStorageServiceStateView {
+contract FilecoinWarmStorageServiceStateView is IPDPProvingSchedule {
     using FilecoinWarmStorageServiceStateInternalLibrary for FilecoinWarmStorageService;
 
     FilecoinWarmStorageService public immutable service;
@@ -77,12 +78,29 @@ contract FilecoinWarmStorageServiceStateView {
         return service.getMaxProvingPeriod();
     }
 
+    function getPDPConfig()
+        external
+        view
+        returns (
+            uint64 maxProvingPeriod,
+            uint256 challengeWindowSize,
+            uint256 challengesPerProof,
+            uint256 initChallengeWindowStart
+        )
+    {
+        return service.getPDPConfig();
+    }
+
     function getPieceMetadata(uint256 dataSetId, uint256 pieceId, string memory key)
         external
         view
         returns (bool exists, string memory value)
     {
         return service.getPieceMetadata(dataSetId, pieceId, key);
+    }
+
+    function nextPDPChallengeWindowStart(uint256 setId) external view returns (uint256) {
+        return service.nextPDPChallengeWindowStart(setId);
     }
 
     function provenPeriods(uint256 dataSetId, uint256 periodId) external view returns (bool) {
@@ -97,8 +115,8 @@ contract FilecoinWarmStorageServiceStateView {
         return service.provingActivationEpoch(dataSetId);
     }
 
-    function provingDeadlines(uint256 setId) external view returns (uint256) {
-        return service.provingDeadlines(setId);
+    function provingDeadline(uint256 setId) external view returns (uint256) {
+        return service.provingDeadline(setId);
     }
 
     function railToDataSet(uint256 railId) external view returns (uint256) {

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
@@ -137,7 +137,7 @@ library FilecoinWarmStorageServiceStateInternalLibrary {
         return uint256(service.extsload(keccak256(abi.encode(dataSetId, PROVING_ACTIVATION_EPOCH_SLOT))));
     }
 
-    function provingDeadlines(FilecoinWarmStorageService service, uint256 setId) internal view returns (uint256) {
+    function provingDeadline(FilecoinWarmStorageService service, uint256 setId) internal view returns (uint256) {
         return uint256(service.extsload(keccak256(abi.encode(setId, PROVING_DEADLINES_SLOT))));
     }
 
@@ -149,6 +149,84 @@ library FilecoinWarmStorageServiceStateInternalLibrary {
     // proof of possession can be submitted
     function challengeWindow(FilecoinWarmStorageService service) internal view returns (uint256) {
         return uint256(service.extsload(CHALLENGE_WINDOW_SIZE_SLOT));
+    }
+
+    /**
+     * @notice Returns PDP configuration values
+     * @param service The service contract
+     * @return maxProvingPeriod Maximum number of epochs between proofs
+     * @return challengeWindowSize Number of epochs for the challenge window
+     * @return challengesPerProof Number of challenges required per proof
+     * @return initChallengeWindowStart Initial challenge window start for new data sets assuming proving period starts now
+     */
+    function getPDPConfig(FilecoinWarmStorageService service)
+        internal
+        view
+        returns (
+            uint64 maxProvingPeriod,
+            uint256 challengeWindowSize,
+            uint256 challengesPerProof,
+            uint256 initChallengeWindowStart
+        )
+    {
+        maxProvingPeriod = getMaxProvingPeriod(service);
+        challengeWindowSize = challengeWindow(service);
+        challengesPerProof = CHALLENGES_PER_PROOF;
+        initChallengeWindowStart = block.number + maxProvingPeriod - challengeWindowSize;
+    }
+
+    /**
+     * @notice Returns the start of the next challenge window for a data set
+     * @param service The service contract
+     * @param setId The ID of the data set
+     * @return The block number when the next challenge window starts
+     */
+    function nextPDPChallengeWindowStart(FilecoinWarmStorageService service, uint256 setId)
+        internal
+        view
+        returns (uint256)
+    {
+        uint256 deadline = provingDeadline(service, setId);
+
+        if (deadline == NO_PROVING_DEADLINE) {
+            revert Errors.ProvingPeriodNotInitialized(setId);
+        }
+
+        uint64 maxProvingPeriod = getMaxProvingPeriod(service);
+
+        // If the current period is open this is the next period's challenge window
+        if (block.number <= deadline) {
+            return _thisChallengeWindowStart(service, setId) + maxProvingPeriod;
+        }
+
+        // Otherwise return the current period's challenge window
+        return _thisChallengeWindowStart(service, setId);
+    }
+
+    /**
+     * @notice Helper to get the start of the current challenge window
+     * @param service The service contract
+     * @param setId The ID of the data set
+     * @return The block number when the current challenge window starts
+     */
+    function _thisChallengeWindowStart(FilecoinWarmStorageService service, uint256 setId)
+        internal
+        view
+        returns (uint256)
+    {
+        uint256 deadline = provingDeadline(service, setId);
+        uint64 maxProvingPeriod = getMaxProvingPeriod(service);
+        uint256 challengeWindowSize = challengeWindow(service);
+
+        uint256 periodsSkipped;
+        // Proving period is open 0 skipped periods
+        if (block.number <= deadline) {
+            periodsSkipped = 0;
+        } else {
+            // Proving period has closed possibly some skipped periods
+            periodsSkipped = 1 + (block.number - (deadline + 1)) / maxProvingPeriod;
+        }
+        return deadline + periodsSkipped * maxProvingPeriod - challengeWindowSize;
     }
 
     function getClientDataSets(FilecoinWarmStorageService service, address client)

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -354,8 +354,7 @@ contract FilecoinWarmStorageServiceTest is Test {
             0, // 0%
             "Service commission should be set correctly"
         );
-        (uint64 maxProvingPeriod, uint256 challengeWindow, uint256 challengesPerProof,) =
-            pdpServiceWithPayments.getPDPConfig();
+        (uint64 maxProvingPeriod, uint256 challengeWindow, uint256 challengesPerProof,) = viewContract.getPDPConfig();
         assertEq(maxProvingPeriod, 2880, "Max proving period should be set correctly");
         assertEq(challengeWindow, 60, "Challenge window size should be set correctly");
         assertEq(challengesPerProof, 5, "Challenges per proof should be 5");
@@ -656,8 +655,7 @@ contract FilecoinWarmStorageServiceTest is Test {
 
     function testGlobalParameters() public view {
         // These parameters should be the same as in SimplePDPService
-        (uint64 maxProvingPeriod, uint256 challengeWindow, uint256 challengesPerProof,) =
-            pdpServiceWithPayments.getPDPConfig();
+        (uint64 maxProvingPeriod, uint256 challengeWindow, uint256 challengesPerProof,) = viewContract.getPDPConfig();
         assertEq(maxProvingPeriod, 2880, "Max proving period should be 2880 epochs");
         assertEq(challengeWindow, 60, "Challenge window should be 60 epochs");
         assertEq(challengesPerProof, 5, "Challenges per proof should be 5");
@@ -991,7 +989,7 @@ contract FilecoinWarmStorageServiceTest is Test {
         // 2. Submit a valid proof.
         console.log("\n2. Starting proving period and submitting proof");
         // Start proving period
-        (uint64 maxProvingPeriod, uint256 challengeWindow,,) = pdpServiceWithPayments.getPDPConfig();
+        (uint64 maxProvingPeriod, uint256 challengeWindow,,) = viewContract.getPDPConfig();
         uint256 challengeEpoch = block.number + maxProvingPeriod - (challengeWindow / 2);
 
         vm.prank(address(mockPDPVerifier));
@@ -1000,7 +998,7 @@ contract FilecoinWarmStorageServiceTest is Test {
         assertEq(viewContract.provingActivationEpoch(dataSetId), block.number);
 
         // Warp to challenge window
-        uint256 provingDeadline = viewContract.provingDeadlines(dataSetId);
+        uint256 provingDeadline = viewContract.provingDeadline(dataSetId);
         vm.roll(provingDeadline - (challengeWindow / 2));
 
         assertFalse(
@@ -2276,7 +2274,7 @@ contract FilecoinWarmStorageServiceUpgradeTest is Test {
         warmStorageService.setViewContract(address(viewContract));
 
         // Verify the values were set correctly through the view contract
-        (uint64 updatedMaxProvingPeriod, uint256 updatedChallengeWindow,,) = warmStorageService.getPDPConfig();
+        (uint64 updatedMaxProvingPeriod, uint256 updatedChallengeWindow,,) = viewContract.getPDPConfig();
         assertEq(updatedMaxProvingPeriod, newMaxProvingPeriod, "Max proving period should be updated");
         assertEq(updatedChallengeWindow, newChallengeWindowSize, "Challenge window size should be updated");
     }
@@ -2318,7 +2316,7 @@ contract FilecoinWarmStorageServiceUpgradeTest is Test {
         assertEq(warmStorageService.viewContractAddress(), address(viewContract), "View contract should be set");
 
         // Verify we can call PDP functions through view contract
-        (uint64 maxProvingPeriod, uint256 challengeWindow,,) = warmStorageService.getPDPConfig();
+        (uint64 maxProvingPeriod, uint256 challengeWindow,,) = viewContract.getPDPConfig();
         assertEq(maxProvingPeriod, 2880, "Max proving period should be accessible through view");
         assertEq(challengeWindow, 60, "Challenge window should be accessible through view");
     }
@@ -2330,7 +2328,7 @@ contract FilecoinWarmStorageServiceUpgradeTest is Test {
 
         // This should revert since no data set exists with proving period initialized
         vm.expectRevert(abi.encodeWithSelector(Errors.ProvingPeriodNotInitialized.selector, 999));
-        warmStorageService.nextPDPChallengeWindowStart(999);
+        viewContract.nextPDPChallengeWindowStart(999);
 
         // Note: We can't fully test nextPDPChallengeWindowStart without creating a data set
         // and initializing its proving period, which requires the full PDP system setup.

--- a/service_contracts/tools/generate_view_contract.sh
+++ b/service_contracts/tools/generate_view_contract.sh
@@ -10,8 +10,9 @@ echo
 
 echo 'import "./FilecoinWarmStorageService.sol";'
 echo 'import "./lib/FilecoinWarmStorageServiceStateInternalLibrary.sol";'
+echo 'import "@pdp/IPDPProvingSchedule.sol";'
 
-echo contract FilecoinWarmStorageServiceStateView {
+echo contract FilecoinWarmStorageServiceStateView is IPDPProvingSchedule {
 echo "    using FilecoinWarmStorageServiceStateInternalLibrary for FilecoinWarmStorageService;"
 echo "    FilecoinWarmStorageService public immutable service;"
 echo "    constructor(FilecoinWarmStorageService _service) {"


### PR DESCRIPTION
As per [Slack](https://filecoinproject.slack.com/archives/C07CGTXHHT4/p1756373274432239), I screwed up. Original plan was in https://github.com/FilOzone/filecoin-services/issues/163#issuecomment-3213815728, but at https://github.com/FilOzone/filecoin-services/pull/168#issuecomment-3223092280 I did a last minute switch for some reason. Maybe I'll blame a late night for this..