### PR TITLE
fix(ci): consistent comments for codegen

### DIFF
--- a/service_contracts/Makefile
+++ b/service_contracts/Makefile
@@ -44,7 +44,7 @@ $(VIEW_CONTRACT): tools/generate_view_contract.sh $(LIBRARY_JSON)
 
 # Internal library generation (simple sed transform)
 $(INTERNAL_LIB): src/lib/FilecoinWarmStorageServiceStateLibrary.sol
-	sed -e 's/public/internal/g' -e 's/StateLibrary/StateInternalLibrary/g' -e '3a\\n// Code generated - DO NOT EDIT.\n// This file is a generated binding and any changes will be lost.\n// Generated with '"'"'make $@'"'"'\n' $< | forge fmt -r - > $@
+	sed -e 's/public/internal/g' -e 's/StateLibrary/StateInternalLibrary/g' -e '3a\\n// Code generated - DO NOT EDIT.\n// This file is a generated binding and any changes will be lost.\n// Generated with make $(INTERNAL_LIB)\n' $< | forge fmt -r - > $@
 
 # Main code generation target with proper dependencies
 .PHONY: gen

--- a/service_contracts/src/FilecoinWarmStorageServiceStateView.sol
+++ b/service_contracts/src/FilecoinWarmStorageServiceStateView.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 // Code generated - DO NOT EDIT.
 // This file is a generated binding and any changes will be lost.
-// Generated with tools/generate_view_contract.sh out/FilecoinWarmStorageServiceStateLibrary.sol/FilecoinWarmStorageServiceStateLibrary.json
+// Generated with tools/generate_view_contract.sh
 
 import "./FilecoinWarmStorageService.sol";
 import "./lib/FilecoinWarmStorageServiceStateInternalLibrary.sol";

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceLayout.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceLayout.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 // Code generated - DO NOT EDIT.
 // This file is a generated binding and any changes will be lost.
-// Generated with tools/generate_storage_layout.sh src/FilecoinWarmStorageService.sol
+// Generated with tools/generate_storage_layout.sh
 
 bytes32 constant SERVICE_COMMISSION_BPS_SLOT = bytes32(uint256(0));
 bytes32 constant CLIENT_DATA_SET_IDS_SLOT = bytes32(uint256(1));

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 // Code generated - DO NOT EDIT.
 // This file is a generated binding and any changes will be lost.
-// Generated with 'make src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol'
+// Generated with make src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
 
 import {Errors} from "../Errors.sol";
 import "../FilecoinWarmStorageService.sol";

--- a/service_contracts/tools/generate_storage_layout.sh
+++ b/service_contracts/tools/generate_storage_layout.sh
@@ -5,7 +5,7 @@ echo pragma solidity ^0.8.20\;
 echo
 echo // Code generated - DO NOT EDIT.
 echo // This file is a generated binding and any changes will be lost.
-echo // Generated with $0 $@
+echo // Generated with tools/generate_storage_layout.sh
 echo
 
 forge inspect --json $1 storageLayout \

--- a/service_contracts/tools/generate_view_contract.sh
+++ b/service_contracts/tools/generate_view_contract.sh
@@ -5,7 +5,7 @@ echo pragma solidity ^0.8.20\;
 echo
 echo // Code generated - DO NOT EDIT.
 echo // This file is a generated binding and any changes will be lost.
-echo // Generated with $0 $@
+echo // Generated with tools/generate_view_contract.sh
 echo
 
 echo 'import "./FilecoinWarmStorageService.sol";'


### PR DESCRIPTION
different shells, different OS' causing inconsistency in the comment at the top of the generated files, so this is simplifying it and not using the input to determine the output