### PR TITLE
Restore type signatures accidentally deleted in #131, fix type hashes

### DIFF
--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -197,8 +197,7 @@ contract FilecoinWarmStorageService is
 
     bytes32 private constant ADD_PIECES_TYPEHASH = keccak256(
         "AddPieces(uint256 clientDataSetId,uint256 firstAdded,Cid[] pieceData,PieceMetadata[] pieceMetadata)"
-        "Cid(bytes data)"
-        "MetadataEntry(string key,string value)"
+        "Cid(bytes data)" "MetadataEntry(string key,string value)"
         "PieceMetadata(uint256 pieceIndex,MetadataEntry[] metadata)"
     );
 

--- a/service_contracts/test/SignatureFixtureTest.t.sol
+++ b/service_contracts/test/SignatureFixtureTest.t.sol
@@ -54,8 +54,7 @@ contract MetadataSignatureTestContract is EIP712 {
 
     bytes32 private constant ADD_PIECES_TYPEHASH = keccak256(
         "AddPieces(uint256 clientDataSetId,uint256 firstAdded,Cid[] pieceData,PieceMetadata[] pieceMetadata)"
-        "Cid(bytes data)"
-        "MetadataEntry(string key,string value)"
+        "Cid(bytes data)" "MetadataEntry(string key,string value)"
         "PieceMetadata(uint256 pieceIndex,MetadataEntry[] metadata)"
     );
 

--- a/service_contracts/test/external_signatures.json
+++ b/service_contracts/test/external_signatures.json
@@ -12,7 +12,7 @@
     ]
   },
   "addPieces": {
-    "signature": "0x6a44a94b3965ce8948b7e5975f1978dbaf5e975a4ccadd837ca7da9539ebe89c0b0cbfd2775d29a60e473197c84940280dac1b7e6a7e1e1bdbf4bd0f7d4a9a1a1b",
+    "signature": "0x215d2d6ea06c7daad46e3e636b305885c7d09aa34420e8dbace032af03cae06224cf678da808c7f1026b08ccf51f3d5d53351b935f5eee9750b80e78caffaaa91c",
     "clientDataSetId": 12345,
     "firstAdded": 1,
     "pieceCidBytes": [


### PR DESCRIPTION
Also fixes ordering of typehashes as defined in EIP-712. The member types should be listed in alphabetical order.