### PR TITLE
feat: semi-incremental abi generation

### DIFF
--- a/service_contracts/Makefile
+++ b/service_contracts/Makefile
@@ -103,6 +103,11 @@ clean:
 	forge clean
 	rm -rf out cache
 
+# Clean everything including generated files and ABIs
+.PHONY: clean-all
+clean-all: clean clean-gen clean-abi
+	@echo "All artifacts cleaned"
+
 # Format code
 .PHONY: fmt
 fmt:
@@ -132,18 +137,41 @@ contract-size-check:
 	@echo "Checking contract sizes..."
 	bash tools/check-contract-size.sh src/
 
-# Update checked-in ABIs
-.PHONY: update-abi
-update-abi: build
-	@echo "Updating checked-in ABIs..."
+# ABI Management
+
+# Core contracts we publish ABIs for
+ABI_CONTRACTS := \
+	FilecoinWarmStorageService \
+	FilecoinWarmStorageServiceStateLibrary \
+	FilecoinWarmStorageServiceStateView
+
+# Generate ABI file targets
+ABI_FILES := $(addprefix abi/,$(addsuffix .abi.json,$(ABI_CONTRACTS)))
+
+# Define a template for ABI extraction; we use a template approach instead of
+# defining a global pattern rule because patterns for files that don't exist
+# at parse-time will be rejected by make, so we'll be explicit instead.
+define ABI_RULE
+abi/$(1).abi.json: out/$(1).sol/$(1).json
 	@mkdir -p abi
-	@echo "  Extracting FilecoinWarmStorageService ABI..."
-	@forge inspect FilecoinWarmStorageService abi --json > abi/FilecoinWarmStorageService.abi.json
-	@echo "  Extracting FilecoinWarmStorageServiceStateView ABI..."
-	@forge inspect FilecoinWarmStorageServiceStateView abi --json > abi/FilecoinWarmStorageServiceStateView.abi.json
-	@echo "  Extracting FilecoinWarmStorageServiceStateLibrary ABI..."
-	@forge inspect src/lib/FilecoinWarmStorageServiceStateLibrary.sol:FilecoinWarmStorageServiceStateLibrary abi --json > abi/FilecoinWarmStorageServiceStateLibrary.abi.json
-	@echo "ABIs updated in abi/ directory"
+	@echo "Extracting ABI for $(1)..."
+	@jq '.abi' $$< > $$@
+endef
+
+# Generate rules for each contract using the template above
+$(foreach contract,$(ABI_CONTRACTS),$(eval $(call ABI_RULE,$(contract))))
+
+# JSON files depend on build
+out/%.sol/%.json: build
+
+# Update ABIs
+.PHONY: update-abi
+update-abi: $(ABI_FILES)
+
+# Clean just the ABIs
+.PHONY: clean-abi
+clean-abi:
+	@rm -rf abi
 
 # Help target
 .PHONY: help
@@ -166,4 +194,10 @@ help:
 	@echo ""
 	@echo "  help       - Show this help message"
 	@echo "  contract-size-check - Check contract sizes against EIP-170 and EIP-3860 limits"
-	@echo "  update-abi - Update checked-in ABIs in abi/ directory"
+	@echo ""
+	@echo "ABI management targets:"
+	@echo "  update-abi - Update checked-in ABIs in abi/ directory (incremental)"
+	@echo "  clean-abi  - Remove all ABI files"
+	@echo ""
+	@echo "Full cleanup:"
+	@echo "  clean-all  - Remove all artifacts (build, generated, ABIs)"


### PR DESCRIPTION
Building on discussion in https://github.com/FilOzone/filecoin-services/pull/180#discussion_r2308191369 about the current `update-abi` target.

There's a couple of compromises here over the pure pattern target approach, because:

1. If we rely on `forge inspect` we get a compile-all each time we call it, so it's just slow and tedious; we could go with that, but we have the build output anyway so we can just rely on that and get the same output plus pull in build to our dependency chain
2. I can't just do `abi/%.abi.json: out/%.sol/%.json` to rely on those because if they don't exist then they're not included in our pattern at parse time. This could work _if_ we wanted to dump all of the compiled contracts into abi/, but there's a _lot_ of contracts to dump in there. So we just have a whitelist and a macro to strictly specify that we have a rule per output file we want.

I also tried out a variant of this that put in some of our dependencies to capture their ABI at the current commit, but it was more complex so I'll leave that can of worms alone and we'll just focus on the contracts in here.