### PR TITLE
fix(deploy): handle setViewContract more gracefully; auto-detect chainId

### DIFF
--- a/service_contracts/tools/deploy-all-warm-storage-calibnet.sh
+++ b/service_contracts/tools/deploy-all-warm-storage-calibnet.sh
@@ -7,12 +7,27 @@
 #
 echo "Deploying all Warm Storage contracts to calibnet"
 
-CHAIN_ID=314159
-
 if [ -z "$RPC_URL" ]; then
   echo "Error: RPC_URL is not set"
   exit 1
 fi
+
+# Auto-detect chain ID from RPC
+CHAIN_ID=$(cast chain-id --rpc-url "$RPC_URL")
+if [ -z "$CHAIN_ID" ]; then
+  echo "Error: Failed to detect chain ID from RPC"
+  exit 1
+fi
+
+# Verify we're on calibnet
+if [ "$CHAIN_ID" != "314159" ]; then
+  echo "Error: This script is for Filecoin Calibration testnet only"
+  echo "  Expected chain ID: 314159 (calibnet)"
+  echo "  Detected chain ID: $CHAIN_ID"
+  exit 1
+fi
+
+echo "Detected Chain ID: $CHAIN_ID (calibnet)"
 
 if [ -z "$KEYSTORE" ]; then
   echo "Error: KEYSTORE is not set"
@@ -105,7 +120,7 @@ NONCE=$(expr $NONCE + "1")
 
 # Step 5: Deploy ServiceProviderRegistry implementation
 echo "Deploying ServiceProviderRegistry implementation..."
-REGISTRY_IMPLEMENTATION_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 src/ServiceProviderRegistry.sol:ServiceProviderRegistry | grep "Deployed to" | awk '{print $3}')
+REGISTRY_IMPLEMENTATION_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id $CHAIN_ID src/ServiceProviderRegistry.sol:ServiceProviderRegistry | grep "Deployed to" | awk '{print $3}')
 if [ -z "$REGISTRY_IMPLEMENTATION_ADDRESS" ]; then
     echo "Error: Failed to extract ServiceProviderRegistry implementation address"
     exit 1
@@ -116,7 +131,7 @@ NONCE=$(expr $NONCE + "1")
 # Step 6: Deploy ServiceProviderRegistry proxy
 echo "Deploying ServiceProviderRegistry proxy..."
 REGISTRY_INIT_DATA=$(cast calldata "initialize()")
-SERVICE_PROVIDER_REGISTRY_PROXY_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 lib/pdp/src/ERC1967Proxy.sol:MyERC1967Proxy --constructor-args $REGISTRY_IMPLEMENTATION_ADDRESS $REGISTRY_INIT_DATA | grep "Deployed to" | awk '{print $3}')
+SERVICE_PROVIDER_REGISTRY_PROXY_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id $CHAIN_ID lib/pdp/src/ERC1967Proxy.sol:MyERC1967Proxy --constructor-args $REGISTRY_IMPLEMENTATION_ADDRESS $REGISTRY_INIT_DATA | grep "Deployed to" | awk '{print $3}')
 if [ -z "$SERVICE_PROVIDER_REGISTRY_PROXY_ADDRESS" ]; then
     echo "Error: Failed to extract ServiceProviderRegistry proxy address"
     exit 1
@@ -152,15 +167,8 @@ NONCE=$(expr $NONCE + "1")
 source tools/deploy-warm-storage-view.sh
 
 # Step 8: Set the view contract address on the main contract
-echo "Setting view contract address on FilecoinWarmStorageService..."
 NONCE=$(expr $NONCE + "1")
-cast send --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --nonce $NONCE --chain-id $CHAIN_ID $WARM_STORAGE_SERVICE_ADDRESS "setViewContract(address)" $WARM_STORAGE_VIEW_ADDRESS
-if [ $? -eq 0 ]; then
-    echo "View contract address set successfully"
-else
-    echo "Error: Failed to set view contract address"
-    exit 1
-fi
+source tools/set-warm-storage-view.sh
 
 # Summary of deployed contracts
 echo

--- a/service_contracts/tools/deploy-session-key-registry.sh
+++ b/service_contracts/tools/deploy-session-key-registry.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 # env params:
-# CHAIN_ID
 # RPC_URL
 # KEYSTORE
 # PASSWORD
@@ -10,14 +9,18 @@
 # - called from service_contracts directory
 # - PATH has forge and cast
 
-if [ -z "$CHAIN_ID" ]; then
-  CHAIN_ID=314159
-  echo "CHAIN_ID not set, assuming Calibnet ($CHAIN_ID)"
-fi
-
 if [ -z "$RPC_URL" ]; then
   echo "Error: RPC_URL is not set"
   exit 1
+fi
+
+# Auto-detect chain ID from RPC if not already set
+if [ -z "$CHAIN_ID" ]; then
+  CHAIN_ID=$(cast chain-id --rpc-url "$RPC_URL")
+  if [ -z "$CHAIN_ID" ]; then
+    echo "Error: Failed to detect chain ID from RPC"
+    exit 1
+  fi
 fi
 
 if [ -z "$KEYSTORE" ]; then

--- a/service_contracts/tools/deploy-warm-storage-view.sh
+++ b/service_contracts/tools/deploy-warm-storage-view.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 # env params:
-# CHAIN_ID
 # RPC_URL
 # WARM_STORAGE_SERVICE_ADDRESS
 # KEYSTORE
@@ -11,14 +10,18 @@
 # - called from service_contracts directory
 # - PATH has forge and cast
 
-if [ -z "$CHAIN_ID" ]; then
-  CHAIN_ID=314159
-  echo "CHAIN_ID not set, assuming Calibnet ($CHAIN_ID)"
-fi
-
 if [ -z "$RPC_URL" ]; then
   echo "Error: RPC_URL is not set"
   exit 1
+fi
+
+# Auto-detect chain ID from RPC if not already set
+if [ -z "$CHAIN_ID" ]; then
+  CHAIN_ID=$(cast chain-id --rpc-url "$RPC_URL")
+  if [ -z "$CHAIN_ID" ]; then
+    echo "Error: Failed to detect chain ID from RPC"
+    exit 1
+  fi
 fi
 
 if [ -z "$WARM_STORAGE_SERVICE_ADDRESS" ]; then

--- a/service_contracts/tools/set-warm-storage-view.sh
+++ b/service_contracts/tools/set-warm-storage-view.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Helper script to set the view contract address on FilecoinWarmStorageService
+# with clean output (suppresses verbose transaction details)
+#
+# Environment variables required:
+# - RPC_URL: RPC endpoint URL
+# - WARM_STORAGE_SERVICE_ADDRESS: Address of the deployed FilecoinWarmStorageService proxy
+# - WARM_STORAGE_VIEW_ADDRESS: Address of the deployed FilecoinWarmStorageServiceStateView
+# - KEYSTORE: Path to keystore file
+# - PASSWORD: Keystore password
+# - NONCE: Transaction nonce (optional, will fetch if not provided)
+
+if [ -z "$RPC_URL" ]; then
+  echo "Error: RPC_URL is not set"
+  exit 1
+fi
+
+# Auto-detect chain ID from RPC if not already set
+if [ -z "$CHAIN_ID" ]; then
+  CHAIN_ID=$(cast chain-id --rpc-url "$RPC_URL")
+  if [ -z "$CHAIN_ID" ]; then
+    echo "Error: Failed to detect chain ID from RPC"
+    exit 1
+  fi
+fi
+
+if [ -z "$WARM_STORAGE_SERVICE_ADDRESS" ]; then
+  echo "Error: WARM_STORAGE_SERVICE_ADDRESS is not set"
+  exit 1
+fi
+
+if [ -z "$WARM_STORAGE_VIEW_ADDRESS" ]; then
+  echo "Error: WARM_STORAGE_VIEW_ADDRESS is not set"
+  exit 1
+fi
+
+if [ -z "$KEYSTORE" ]; then
+  echo "Error: KEYSTORE is not set"
+  exit 1
+fi
+
+# Get sender address
+ADDR=$(cast wallet address --keystore "$KEYSTORE" --password "$PASSWORD")
+
+# Get nonce if not provided
+if [ -z "$NONCE" ]; then
+  NONCE="$(cast nonce --rpc-url "$RPC_URL" "$ADDR")"
+fi
+
+echo "Setting view contract address on FilecoinWarmStorageService..."
+
+# Execute transaction and capture output, only show errors if it fails
+TX_OUTPUT=$(cast send --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --nonce $NONCE --chain-id $CHAIN_ID $WARM_STORAGE_SERVICE_ADDRESS "setViewContract(address)" $WARM_STORAGE_VIEW_ADDRESS 2>&1)
+
+if [ $? -eq 0 ]; then
+    echo "View contract address set successfully"
+else
+    echo "Error: Failed to set view contract address"
+    echo "$TX_OUTPUT"
+    exit 1
+fi


### PR DESCRIPTION
Couple of minor cleanups having run through this. The main annoyance was `setViewContract` coming out with very verbose output, now it's nice and compact and I extracted it to a separate script in the pattern that's developing in there.