### PR TITLE
feat: name and description in FWSS

### DIFF
--- a/service_contracts/abi/FilecoinWarmStorageService.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageService.abi.json
@@ -297,6 +297,32 @@
   },
   {
     "type": "function",
+    "name": "getServiceDescription",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getServiceName",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "getServicePrice",
     "inputs": [],
     "outputs": [
@@ -343,6 +369,16 @@
         "name": "_challengeWindowSize",
         "type": "uint256",
         "internalType": "uint256"
+      },
+      {
+        "name": "_name",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "_description",
+        "type": "string",
+        "internalType": "string"
       }
     ],
     "outputs": [],
@@ -950,6 +986,25 @@
         "type": "uint256",
         "indexed": false,
         "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "FilecoinServiceDeployed",
+    "inputs": [
+      {
+        "name": "name",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
       }
     ],
     "anonymous": false

--- a/service_contracts/test/ProviderValidation.t.sol
+++ b/service_contracts/test/ProviderValidation.t.sol
@@ -135,8 +135,13 @@ contract ProviderValidationTest is Test {
         FilecoinWarmStorageService warmStorageImpl = new FilecoinWarmStorageService(
             address(pdpVerifier), address(payments), address(usdfc), filCDN, serviceProviderRegistry, sessionKeyRegistry
         );
-        bytes memory warmStorageInitData =
-            abi.encodeWithSelector(FilecoinWarmStorageService.initialize.selector, uint64(2880), uint256(60));
+        bytes memory warmStorageInitData = abi.encodeWithSelector(
+            FilecoinWarmStorageService.initialize.selector,
+            uint64(2880),
+            uint256(60),
+            "Provider Validation Test Service",
+            "Test service for provider validation"
+        );
         MyERC1967Proxy warmStorageProxy = new MyERC1967Proxy(address(warmStorageImpl), warmStorageInitData);
         warmStorage = FilecoinWarmStorageService(address(warmStorageProxy));
 


### PR DESCRIPTION
We will raise a FRC down the road to standardize this so that Synapse tooling can pick up the name and description for newly deployed services. We only need to standardise the deployment event and the getters for these. 

Subsumes https://github.com/FilOzone/filecoin-services/pull/108.