### PR TITLE
gen: Fix bsd sed newline issue

### DIFF
--- a/service_contracts/Makefile
+++ b/service_contracts/Makefile
@@ -44,7 +44,7 @@ $(VIEW_CONTRACT): tools/generate_view_contract.sh $(LIBRARY_JSON)
 
 # Internal library generation (simple sed transform)
 %StateInternalLibrary.sol: %StateLibrary.sol
-	sed -e 's/public/internal/g' -e 's/StateLibrary/StateInternalLibrary/g' $< | awk 'NR == 4 { print "// Code generated - DO NOT EDIT.\n// This file is a generated binding and any changes will be lost.\n// Generated with make $@\n"} {print}' > $@
+	sed -e 's/public/internal/g' -e 's/StateLibrary/StateInternalLibrary/g' $< | awk 'NR == 4 { print "// Code generated - DO NOT EDIT.\n// This file is a generated binding and any changes will be lost.\n// Generated with make $@\n"} {print}' | forge fmt -r - > $@
 
 # Main code generation target with proper dependencies
 .PHONY: gen


### PR DESCRIPTION
Reviewer @bajtos
Fixes https://github.com/FilOzone/filecoin-services/issues/194
I spent too long trying to support both versions of sed and I don't think it's possible.
Make's newline encoding is [somehow](https://github.com/FilOzone/filecoin-services/issues/194#issuecomment-3246588792) different than bash's, even if you specify SHELL.
The easiest fix for the line insertion was to just use awk which seems to be more standardized.
#### Test plan
```sh
rm -f src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol; make src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
git diff src
```
#### Changes
* use awk
* use pattern (`%`) rule