### PR TITLE
update load session-key-registry via https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,4 +15,4 @@
 	url = https://github.com/FilOzone/pdp
 [submodule "service_contracts/lib/session-key-registry"]
 	path = service_contracts/lib/session-key-registry
-	url = git@github.com:FilOzone/SessionKeyRegistry.git
+	url = https://github.com/FilOzone/SessionKeyRegistry


### PR DESCRIPTION
Now everyone has git set up via SSH, but looking at the other submodules, everyone has it set up via HTTPS. I don't have it set up via SSH, therefore this failed to clone for me.