### PR TITLE
fix: remove serviceName and serviceDescription properties

### DIFF
--- a/service_contracts/abi/FilecoinWarmStorageService.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageService.abi.json
@@ -642,32 +642,6 @@
   },
   {
     "type": "function",
-    "name": "serviceDescription",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "string",
-        "internalType": "string"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "serviceName",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "string",
-        "internalType": "string"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
     "name": "serviceProviderRegistry",
     "inputs": [],
     "outputs": [

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -234,10 +234,6 @@ contract FilecoinWarmStorageService is
     // The address allowed to terminate CDN services
     address private filCDNControllerAddress;
 
-    // Service information
-    string public serviceName;
-    string public serviceDescription;
-
     // Modifier to ensure only the PDP verifier contract can call certain functions
 
     modifier onlyPDPVerifier() {
@@ -331,10 +327,6 @@ contract FilecoinWarmStorageService is
         require(bytes(_name).length <= 256, "Service name exceeds 256 characters");
         require(bytes(_description).length > 0, "Service description cannot be empty");
         require(bytes(_description).length <= 256, "Service description exceeds 256 characters");
-
-        // Store service information
-        serviceName = _name;
-        serviceDescription = _description;
 
         // Emit the FilecoinServiceDeployed event
         emit FilecoinServiceDeployed(_name, _description);

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceLayout.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceLayout.sol
@@ -24,5 +24,3 @@ bytes32 constant VIEW_CONTRACT_ADDRESS_SLOT = bytes32(uint256(15));
 bytes32 constant APPROVED_PROVIDERS_SLOT = bytes32(uint256(16));
 bytes32 constant APPROVED_PROVIDER_IDS_SLOT = bytes32(uint256(17));
 bytes32 constant FIL_CDN_CONTROLLER_ADDRESS_SLOT = bytes32(uint256(18));
-bytes32 constant SERVICE_NAME_SLOT = bytes32(uint256(19));
-bytes32 constant SERVICE_DESCRIPTION_SLOT = bytes32(uint256(20));


### PR DESCRIPTION
Same as https://github.com/FilOzone/filecoin-services/pull/196, which was accidentally re-applied due to miscommunication.