### PR TITLE
rm safe-gen

### DIFF
--- a/service_contracts/CONTRIBUTING.md
+++ b/service_contracts/CONTRIBUTING.md
@@ -64,7 +64,6 @@ make src/FilecoinWarmStorageServiceStateView.sol                # View contract
 - `FilecoinWarmStorageServiceLayout` is auto-generated from the storage layout of `FilecoinWarmStorageService`
 - Always run `make gen` after modifying storage variables or the state library
 - Use `make force-gen` if the generated files become corrupted
-- Use `make safe-gen` for a safe regeneration with automatic rollback on failure
 
 ### Deploy a new `FilecoinWarmStorageServiceStateView`
 ```sh

--- a/service_contracts/Makefile
+++ b/service_contracts/Makefile
@@ -64,22 +64,6 @@ clean-gen:
 	@rm -rf out/FilecoinWarmStorageServiceStateLibrary.sol
 	@echo "Generated files removed"
 
-# Safe regeneration - saves current state, attempts gen, restores on failure
-.PHONY: safe-gen
-safe-gen: check-tools
-	@echo "Backing up current generated files..."
-	@mkdir -p .backup-gen
-	@cp -f $(LAYOUT) $(INTERNAL_LIB) $(VIEW_CONTRACT) .backup-gen/ 2>/dev/null || true
-	@if $(MAKE) force-gen; then \
-		echo "Generation successful"; \
-		rm -rf .backup-gen; \
-	else \
-		echo "Generation failed, restoring backup..."; \
-		cp -f .backup-gen/* . 2>/dev/null || true; \
-		rm -rf .backup-gen; \
-		exit 1; \
-	fi
-
 # Check required tools
 .PHONY: check-tools
 check-tools:
@@ -195,7 +179,6 @@ help:
 	@echo "Code generation targets:"
 	@echo "  gen        - Generate code (layout, internal lib, view contract)"
 	@echo "  force-gen  - Clean and regenerate all files (use when broken)"
-	@echo "  safe-gen   - Attempt generation with automatic rollback on failure"
 	@echo "  clean-gen  - Remove all generated files"
 	@echo ""
 	@echo "  help       - Show this help message"

--- a/service_contracts/README.md
+++ b/service_contracts/README.md
@@ -100,9 +100,6 @@ make force-gen
 
 # Clean all generated files
 make clean-gen
-
-# Safe regeneration with automatic rollback on failure
-make safe-gen
 ```
 
 ### ABI Management


### PR DESCRIPTION

Reviewer @rvagg
The on-failure restoration was putting the files into the wrong directory.
I agree that we should just remove safe-gen.
We can use version control or other approaches to backup if necessary.
#### Changes
* rm `safe-gen`