### PR TITLE
Fix: Clear `withCDN` flag when terminating service

### DIFF
--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -968,6 +968,12 @@ contract FilecoinWarmStorageService is
         if (hasMetadataKey(dataSetMetadataKeys[dataSetId], METADATA_KEY_WITH_CDN)) {
             payments.terminateRail(info.cacheMissRailId);
             payments.terminateRail(info.cdnRailId);
+
+            // Delete withCDN flag from metadata to prevent further CDN operations
+            dataSetMetadataKeys[dataSetId] = deleteMetadataKey(dataSetMetadataKeys[dataSetId], METADATA_KEY_WITH_CDN);
+            delete dataSetMetadata[dataSetId][METADATA_KEY_WITH_CDN];
+
+            emit CDNServiceTerminated(msg.sender, dataSetId, info.cacheMissRailId, info.cdnRailId);
         }
 
         emit ServiceTerminated(msg.sender, dataSetId, info.pdpRailId, info.cacheMissRailId, info.cdnRailId);

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -1264,7 +1264,14 @@ contract FilecoinWarmStorageServiceTest is Test {
         // Check pdpEndEpoch is set
         FilecoinWarmStorageService.DataSetInfo memory info = viewContract.getDataSet(dataSetId);
         assertTrue(info.pdpEndEpoch > 0, "pdpEndEpoch should be set after termination");
-        console.log("Payment termination successful. Payment end epoch:", info.pdpEndEpoch);
+        console.log("PDP termination successful. PDP end epoch:", info.pdpEndEpoch);
+        // Check cdnEndEpoch is set
+        assertTrue(info.cdnEndEpoch > 0, "cdnEndEpoch should be set after termination");
+        console.log("CDN termination successful. CDN end epoch:", info.cdnEndEpoch);
+        // Check withCDN metadata is cleared
+        (bool exists, string memory withCDN) = viewContract.getDataSetMetadata(dataSetId, "withCDN");
+        assertFalse(exists, "withCDN metadata should not exist after termination");
+        assertEq(withCDN, "", "withCDN value should be cleared for dataset");
 
         // Ensure piecesAdded reverts
         console.log("\n4. Testing operations after termination");


### PR DESCRIPTION
This pull request fixes the termination process for data sets that use CDN service. The changes ensure that the CDN metadata is properly cleared when the CDN service is terminated.

**Changes:**

* When terminating the service, the `withCDN` metadata key is now cleared if data set had it previously set
* An event `CDNServiceTerminated` is emitted for data sets that had CDN service enabled

Follow-up to #161 