### PR TITLE
feat: service registry: add providerId to ServiceInfo

### DIFF
--- a/service_contracts/abi/ServiceProviderRegistry.abi.json
+++ b/service_contracts/abi/ServiceProviderRegistry.abi.json
@@ -391,6 +391,11 @@
                 "internalType": "struct ServiceProviderRegistryStorage.ServiceProviderInfo",
                 "components": [
                   {
+                    "name": "providerId",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
                     "name": "serviceProvider",
                     "type": "address",
                     "internalType": "address"
@@ -693,6 +698,11 @@
         "internalType": "struct ServiceProviderRegistryStorage.ServiceProviderInfo",
         "components": [
           {
+            "name": "providerId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
             "name": "serviceProvider",
             "type": "address",
             "internalType": "address"
@@ -738,6 +748,11 @@
         "type": "tuple",
         "internalType": "struct ServiceProviderRegistryStorage.ServiceProviderInfo",
         "components": [
+          {
+            "name": "providerId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
           {
             "name": "serviceProvider",
             "type": "address",
@@ -841,6 +856,11 @@
                 "type": "tuple",
                 "internalType": "struct ServiceProviderRegistryStorage.ServiceProviderInfo",
                 "components": [
+                  {
+                    "name": "providerId",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
                   {
                     "name": "serviceProvider",
                     "type": "address",
@@ -1095,6 +1115,11 @@
       }
     ],
     "outputs": [
+      {
+        "name": "providerId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
       {
         "name": "serviceProvider",
         "type": "address",

--- a/service_contracts/src/ServiceProviderRegistry.sol
+++ b/service_contracts/src/ServiceProviderRegistry.sol
@@ -158,6 +158,7 @@ contract ServiceProviderRegistry is
 
         // Store provider info
         providers[providerId] = ServiceProviderInfo({
+            providerId: providerId,
             serviceProvider: msg.sender,
             payee: payee,
             name: name,

--- a/service_contracts/src/ServiceProviderRegistryStorage.sol
+++ b/service_contracts/src/ServiceProviderRegistryStorage.sol
@@ -18,6 +18,7 @@ contract ServiceProviderRegistryStorage {
 
     /// @notice Main provider information
     struct ServiceProviderInfo {
+        uint256 providerId; // Unique identifier for the provider
         address serviceProvider; // Address that controls the provider registration
         address payee; // Address that receives payments (cannot be changed after registration)
         string name; // Optional provider name (max 128 chars)

--- a/service_contracts/test/ServiceProviderRegistry.t.sol
+++ b/service_contracts/test/ServiceProviderRegistry.t.sol
@@ -204,6 +204,7 @@ contract ServiceProviderRegistryTest is Test {
 
         // Verify provider info
         ServiceProviderRegistryStorage.ServiceProviderInfo memory info = registry.getProvider(providerId);
+        assertEq(info.providerId, providerId, "Provider ID should match");
         assertEq(info.serviceProvider, user1, "Service provider should be user1");
         assertEq(info.payee, user2, "Payee should be user2");
         assertTrue(info.isActive, "Provider should be active");
@@ -279,6 +280,7 @@ contract ServiceProviderRegistryTest is Test {
 
         // Now get provider should work
         ServiceProviderRegistryStorage.ServiceProviderInfo memory info = registry.getProvider(1);
+        assertEq(info.providerId, 1, "Provider ID should be 1");
         assertEq(info.serviceProvider, user1, "Service provider should be user1");
         assertEq(info.payee, user1, "Payee should be user1");
     }

--- a/service_contracts/test/ServiceProviderRegistryFull.t.sol
+++ b/service_contracts/test/ServiceProviderRegistryFull.t.sol
@@ -164,6 +164,7 @@ contract ServiceProviderRegistryFullTest is Test {
         assertEq(providerId, 1, "Provider ID should be 1");
         ServiceProviderRegistryStorage.ServiceProviderInfo memory providerInfo =
             registry.getProviderByAddress(provider1);
+        assertEq(providerInfo.providerId, 1, "Provider ID should be 1");
         assertEq(providerInfo.serviceProvider, provider1, "Provider address should match");
         assertTrue(providerInfo.isActive, "Provider should be active");
         assertTrue(registry.isRegisteredProvider(provider1), "Provider should be registered");
@@ -171,6 +172,7 @@ contract ServiceProviderRegistryFullTest is Test {
 
         // Verify provider info
         ServiceProviderRegistryStorage.ServiceProviderInfo memory info = registry.getProvider(1);
+        assertEq(info.providerId, 1, "Provider ID should be 1");
         assertEq(info.serviceProvider, provider1, "Service provider should be provider1");
         assertEq(info.payee, provider1, "Payee should be provider1");
         assertEq(info.name, "", "Name should be empty");
@@ -683,6 +685,7 @@ contract ServiceProviderRegistryFullTest is Test {
 
         // Verify provider info still exists (soft delete)
         ServiceProviderRegistryStorage.ServiceProviderInfo memory info = registry.getProvider(1);
+        assertEq(info.providerId, 1, "Provider ID should still be 1");
         assertFalse(info.isActive, "Provider should be marked inactive");
         assertEq(info.serviceProvider, provider1, "Service provider should still be recorded");
         assertEq(info.payee, provider1, "Payee should still be recorded");
@@ -1162,6 +1165,7 @@ contract ServiceProviderRegistryFullTest is Test {
 
         // Verify initial description
         ServiceProviderRegistryStorage.ServiceProviderInfo memory info = registry.getProvider(1);
+        assertEq(info.providerId, 1, "Provider ID should be 1");
         assertEq(info.description, "Initial description", "Initial description should match");
 
         // Update description
@@ -1172,6 +1176,7 @@ contract ServiceProviderRegistryFullTest is Test {
 
         // Verify updated description
         info = registry.getProvider(1);
+        assertEq(info.providerId, 1, "Provider ID should still be 1");
         assertEq(info.description, "Updated description", "Description should be updated");
     }
 


### PR DESCRIPTION
Add providerId to ServiceInfo for easy provider lookup.