### PR TITLE
feat: update getClientDataSets to return dataSetId

### DIFF
--- a/service_contracts/.gitignore
+++ b/service_contracts/.gitignore
@@ -10,3 +10,6 @@ node_modules/
 
 # Lock files
 package-lock.json
+
+# Ignore IDEs
+.idea

--- a/service_contracts/abi/FilecoinWarmStorageServiceStateLibrary.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageServiceStateLibrary.abi.json
@@ -199,7 +199,7 @@
       {
         "name": "infos",
         "type": "tuple[]",
-        "internalType": "struct FilecoinWarmStorageService.DataSetInfo[]",
+        "internalType": "struct FilecoinWarmStorageService.DataSetInfoView[]",
         "components": [
           {
             "name": "pdpRailId",
@@ -253,6 +253,11 @@
           },
           {
             "name": "cdnEndEpoch",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "dataSetId",
             "type": "uint256",
             "internalType": "uint256"
           }
@@ -280,7 +285,7 @@
       {
         "name": "info",
         "type": "tuple",
-        "internalType": "struct FilecoinWarmStorageService.DataSetInfo",
+        "internalType": "struct FilecoinWarmStorageService.DataSetInfoView",
         "components": [
           {
             "name": "pdpRailId",
@@ -334,6 +339,11 @@
           },
           {
             "name": "cdnEndEpoch",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "dataSetId",
             "type": "uint256",
             "internalType": "uint256"
           }

--- a/service_contracts/abi/FilecoinWarmStorageServiceStateView.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageServiceStateView.abi.json
@@ -167,7 +167,7 @@
       {
         "name": "infos",
         "type": "tuple[]",
-        "internalType": "struct FilecoinWarmStorageService.DataSetInfo[]",
+        "internalType": "struct FilecoinWarmStorageService.DataSetInfoView[]",
         "components": [
           {
             "name": "pdpRailId",
@@ -221,6 +221,11 @@
           },
           {
             "name": "cdnEndEpoch",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "dataSetId",
             "type": "uint256",
             "internalType": "uint256"
           }
@@ -243,7 +248,7 @@
       {
         "name": "info",
         "type": "tuple",
-        "internalType": "struct FilecoinWarmStorageService.DataSetInfo",
+        "internalType": "struct FilecoinWarmStorageService.DataSetInfoView",
         "components": [
           {
             "name": "pdpRailId",
@@ -297,6 +302,11 @@
           },
           {
             "name": "cdnEndEpoch",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "dataSetId",
             "type": "uint256",
             "internalType": "uint256"
           }

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -111,6 +111,22 @@ contract FilecoinWarmStorageService is
         uint256 cdnEndEpoch; // 0 if CDN rails are not terminated
     }
 
+    // Storage for data set payment information with dataSetId
+    struct DataSetInfoView {
+        uint256 pdpRailId; // ID of the PDP payment rail
+        uint256 cacheMissRailId; // For CDN add-on: ID of the cache miss payment rail, which rewards the SP for serving data to the CDN when it doesn't already have it cached
+        uint256 cdnRailId; // For CDN add-on: ID of the CDN payment rail, which rewards the CDN for serving data to clients
+        address payer; // Address paying for storage
+        address payee; // SP's beneficiary address
+        address serviceProvider; // Current service provider of the dataset
+        uint256 commissionBps; // Commission rate for this data set (dynamic based on whether the client purchases CDN add-on)
+        uint256 clientDataSetId; // ClientDataSetID
+        uint256 pdpEndEpoch; // 0 if PDP rail are not terminated
+        uint256 providerId; // Provider ID from the ServiceProviderRegistry
+        uint256 cdnEndEpoch; // 0 if CDN rails are not terminated
+        uint256 dataSetId; // DataSet ID
+    }
+
     // Decode structure for data set creation extra data
     struct DataSetCreateData {
         address payer;

--- a/service_contracts/src/FilecoinWarmStorageServiceStateView.sol
+++ b/service_contracts/src/FilecoinWarmStorageServiceStateView.sol
@@ -61,12 +61,16 @@ contract FilecoinWarmStorageServiceStateView is IPDPProvingSchedule {
     function getClientDataSets(address client)
         external
         view
-        returns (FilecoinWarmStorageService.DataSetInfo[] memory infos)
+        returns (FilecoinWarmStorageService.DataSetInfoView[] memory infos)
     {
         return service.getClientDataSets(client);
     }
 
-    function getDataSet(uint256 dataSetId) external view returns (FilecoinWarmStorageService.DataSetInfo memory info) {
+    function getDataSet(uint256 dataSetId)
+        external
+        view
+        returns (FilecoinWarmStorageService.DataSetInfoView memory info)
+    {
         return service.getDataSet(dataSetId);
     }
 

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
@@ -94,7 +94,7 @@ library FilecoinWarmStorageServiceStateInternalLibrary {
     function getDataSet(FilecoinWarmStorageService service, uint256 dataSetId)
         internal
         view
-        returns (FilecoinWarmStorageService.DataSetInfo memory info)
+        returns (FilecoinWarmStorageService.DataSetInfoView memory info)
     {
         bytes32 slot = keccak256(abi.encode(dataSetId, StorageLayout.DATA_SET_INFO_SLOT));
         bytes32[] memory info11 = service.extsloadStruct(slot, 11);
@@ -109,6 +109,7 @@ library FilecoinWarmStorageServiceStateInternalLibrary {
         info.pdpEndEpoch = uint256(info11[8]);
         info.providerId = uint256(info11[9]);
         info.cdnEndEpoch = uint256(info11[10]);
+        info.dataSetId = dataSetId;
     }
 
     function clientDataSets(FilecoinWarmStorageService service, address payer)
@@ -247,11 +248,11 @@ library FilecoinWarmStorageServiceStateInternalLibrary {
     function getClientDataSets(FilecoinWarmStorageService service, address client)
         internal
         view
-        returns (FilecoinWarmStorageService.DataSetInfo[] memory infos)
+        returns (FilecoinWarmStorageService.DataSetInfoView[] memory infos)
     {
         uint256[] memory dataSetIds = clientDataSets(service, client);
 
-        infos = new FilecoinWarmStorageService.DataSetInfo[](dataSetIds.length);
+        infos = new FilecoinWarmStorageService.DataSetInfoView[](dataSetIds.length);
         for (uint256 i = 0; i < dataSetIds.length; i++) {
             infos[i] = getDataSet(service, dataSetIds[i]);
         }

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceStateLibrary.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceStateLibrary.sol
@@ -90,7 +90,7 @@ library FilecoinWarmStorageServiceStateLibrary {
     function getDataSet(FilecoinWarmStorageService service, uint256 dataSetId)
         public
         view
-        returns (FilecoinWarmStorageService.DataSetInfo memory info)
+        returns (FilecoinWarmStorageService.DataSetInfoView memory info)
     {
         bytes32 slot = keccak256(abi.encode(dataSetId, StorageLayout.DATA_SET_INFO_SLOT));
         bytes32[] memory info11 = service.extsloadStruct(slot, 11);
@@ -105,6 +105,7 @@ library FilecoinWarmStorageServiceStateLibrary {
         info.pdpEndEpoch = uint256(info11[8]);
         info.providerId = uint256(info11[9]);
         info.cdnEndEpoch = uint256(info11[10]);
+        info.dataSetId = dataSetId;
     }
 
     function clientDataSets(FilecoinWarmStorageService service, address payer)
@@ -243,11 +244,11 @@ library FilecoinWarmStorageServiceStateLibrary {
     function getClientDataSets(FilecoinWarmStorageService service, address client)
         public
         view
-        returns (FilecoinWarmStorageService.DataSetInfo[] memory infos)
+        returns (FilecoinWarmStorageService.DataSetInfoView[] memory infos)
     {
         uint256[] memory dataSetIds = clientDataSets(service, client);
 
-        infos = new FilecoinWarmStorageService.DataSetInfo[](dataSetIds.length);
+        infos = new FilecoinWarmStorageService.DataSetInfoView[](dataSetIds.length);
         for (uint256 i = 0; i < dataSetIds.length; i++) {
             infos[i] = getDataSet(service, dataSetIds[i]);
         }

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -513,7 +513,7 @@ contract FilecoinWarmStorageServiceTest is Test {
         vm.stopPrank();
 
         // Get data set info
-        FilecoinWarmStorageService.DataSetInfo memory dataSet = viewContract.getDataSet(newDataSetId);
+        FilecoinWarmStorageService.DataSetInfoView memory dataSet = viewContract.getDataSet(newDataSetId);
         uint256 pdpRailId = dataSet.pdpRailId;
         uint256 cacheMissRailId = dataSet.cacheMissRailId;
         uint256 cdnRailId = dataSet.cdnRailId;
@@ -541,7 +541,7 @@ contract FilecoinWarmStorageServiceTest is Test {
         assertEq(viewContract.railToDataSet(cdnRailId), newDataSetId);
 
         // Verify data set info
-        FilecoinWarmStorageService.DataSetInfo memory dataSetInfo = viewContract.getDataSet(newDataSetId);
+        FilecoinWarmStorageService.DataSetInfoView memory dataSetInfo = viewContract.getDataSet(newDataSetId);
         assertEq(dataSetInfo.pdpRailId, pdpRailId, "PDP rail ID should match");
         assertNotEq(dataSetInfo.cacheMissRailId, 0, "Cache miss rail ID should be set");
         assertNotEq(dataSetInfo.cdnRailId, 0, "CDN rail ID should be set");
@@ -640,7 +640,7 @@ contract FilecoinWarmStorageServiceTest is Test {
         vm.stopPrank();
 
         // Get data set info
-        FilecoinWarmStorageService.DataSetInfo memory dataSet = viewContract.getDataSet(newDataSetId);
+        FilecoinWarmStorageService.DataSetInfoView memory dataSet = viewContract.getDataSet(newDataSetId);
         assertEq(dataSet.payer, client);
         assertEq(dataSet.payee, serviceProvider);
         // Verify the commission rate was set correctly for basic service (no CDN)
@@ -660,7 +660,7 @@ contract FilecoinWarmStorageServiceTest is Test {
         vm.prank(serviceProvider);
         uint256 newDataSetId2 = mockPDPVerifier.createDataSet(pdpServiceWithPayments, extraData);
 
-        FilecoinWarmStorageService.DataSetInfo memory dataSet2 = viewContract.getDataSet(newDataSetId2);
+        FilecoinWarmStorageService.DataSetInfoView memory dataSet2 = viewContract.getDataSet(newDataSetId2);
         assertEq(dataSet2.payer, client);
         assertEq(dataSet2.payee, serviceProvider);
 
@@ -904,7 +904,7 @@ contract FilecoinWarmStorageServiceTest is Test {
 
     function testGetClientDataSets_EmptyClient() public view {
         // Test with a client that has no data sets
-        FilecoinWarmStorageService.DataSetInfo[] memory dataSets = viewContract.getClientDataSets(client);
+        FilecoinWarmStorageService.DataSetInfoView[] memory dataSets = viewContract.getClientDataSets(client);
 
         assertEq(dataSets.length, 0, "Should return empty array for client with no data sets");
     }
@@ -916,7 +916,7 @@ contract FilecoinWarmStorageServiceTest is Test {
         createDataSetForClient(sp1, client, metadataKeys, metadataValues);
 
         // Get data sets
-        FilecoinWarmStorageService.DataSetInfo[] memory dataSets = viewContract.getClientDataSets(client);
+        FilecoinWarmStorageService.DataSetInfoView[] memory dataSets = viewContract.getClientDataSets(client);
 
         // Verify results
         assertEq(dataSets.length, 1, "Should return one data set");
@@ -935,7 +935,7 @@ contract FilecoinWarmStorageServiceTest is Test {
         createDataSetForClient(sp2, client, metadataKeys2, metadataValues2);
 
         // Get data sets
-        FilecoinWarmStorageService.DataSetInfo[] memory dataSets = viewContract.getClientDataSets(client);
+        FilecoinWarmStorageService.DataSetInfoView[] memory dataSets = viewContract.getClientDataSets(client);
 
         // Verify results
         assertEq(dataSets.length, 2, "Should return two data sets");
@@ -962,7 +962,7 @@ contract FilecoinWarmStorageServiceTest is Test {
         createDataSetForClient(sp1, client, metadataKeys3, metadataValues3);
 
         // Verify we have 3 datasets initially
-        FilecoinWarmStorageService.DataSetInfo[] memory dataSets = viewContract.getClientDataSets(client);
+        FilecoinWarmStorageService.DataSetInfoView[] memory dataSets = viewContract.getClientDataSets(client);
         assertEq(dataSets.length, 3, "Should return three data sets initially");
 
         // Terminate the second dataset (dataSet2) - client terminates
@@ -970,7 +970,7 @@ contract FilecoinWarmStorageServiceTest is Test {
         pdpServiceWithPayments.terminateService(dataSet2);
 
         // Verify the dataset is now terminated (paymentEndEpoch > 0)
-        FilecoinWarmStorageService.DataSetInfo memory terminatedInfo = viewContract.getDataSet(dataSet2);
+        FilecoinWarmStorageService.DataSetInfoView memory terminatedInfo = viewContract.getDataSet(dataSet2);
         assertTrue(terminatedInfo.pdpEndEpoch > 0, "Dataset 2 should have paymentEndEpoch set after termination");
 
         // Verify getClientDataSets still returns all 3 datasets (termination doesn't exclude from list)
@@ -992,7 +992,7 @@ contract FilecoinWarmStorageServiceTest is Test {
         createDataSetForClient(sp1, client, metadataKeys3, metadataValues3);
 
         // Verify we have 3 datasets initially
-        FilecoinWarmStorageService.DataSetInfo[] memory dataSets = viewContract.getClientDataSets(client);
+        FilecoinWarmStorageService.DataSetInfoView[] memory dataSets = viewContract.getClientDataSets(client);
         assertEq(dataSets.length, 3, "Should return three data sets initially");
 
         // Terminate the second dataset (dataSet2)
@@ -1000,7 +1000,7 @@ contract FilecoinWarmStorageServiceTest is Test {
         pdpServiceWithPayments.terminateService(dataSet2);
 
         // Verify termination status
-        FilecoinWarmStorageService.DataSetInfo memory terminatedInfo = viewContract.getDataSet(dataSet2);
+        FilecoinWarmStorageService.DataSetInfoView memory terminatedInfo = viewContract.getDataSet(dataSet2);
         assertTrue(terminatedInfo.pdpEndEpoch > 0, "Dataset 2 should be terminated");
 
         // Advance block number to be greater than the end epoch to allow deletion
@@ -1074,7 +1074,7 @@ contract FilecoinWarmStorageServiceTest is Test {
         mockPDPVerifier.changeDataSetServiceProvider(testDataSetId, sp2, address(pdpServiceWithPayments), testExtraData);
 
         // Only the data set's service provider is updated
-        FilecoinWarmStorageService.DataSetInfo memory dataSet = viewContract.getDataSet(testDataSetId);
+        FilecoinWarmStorageService.DataSetInfoView memory dataSet = viewContract.getDataSet(testDataSetId);
         assertEq(dataSet.serviceProvider, sp2, "Service provider should be updated to new service provider");
         // Payee should remain unchanged (still sp1's beneficiary)
         assertEq(dataSet.payee, sp1, "Payee should remain unchanged");
@@ -1148,8 +1148,8 @@ contract FilecoinWarmStorageServiceTest is Test {
         vm.prank(sp2);
         mockPDPVerifier.changeDataSetServiceProvider(ps1, sp2, address(pdpServiceWithPayments), testExtraData);
         // ps1 service provider updated, ps2 service provider unchanged
-        FilecoinWarmStorageService.DataSetInfo memory dataSet1 = viewContract.getDataSet(ps1);
-        FilecoinWarmStorageService.DataSetInfo memory dataSet2 = viewContract.getDataSet(ps2);
+        FilecoinWarmStorageService.DataSetInfoView memory dataSet1 = viewContract.getDataSet(ps1);
+        FilecoinWarmStorageService.DataSetInfoView memory dataSet2 = viewContract.getDataSet(ps2);
         assertEq(dataSet1.serviceProvider, sp2, "ps1 service provider should be sp2");
         assertEq(dataSet1.payee, sp1, "ps1 payee should remain sp1");
         assertEq(dataSet2.serviceProvider, sp1, "ps2 service provider should remain sp1");
@@ -1167,7 +1167,7 @@ contract FilecoinWarmStorageServiceTest is Test {
         emit DataSetServiceProviderChanged(testDataSetId, sp1, sp2);
         vm.prank(sp2);
         mockPDPVerifier.changeDataSetServiceProvider(testDataSetId, sp2, address(pdpServiceWithPayments), testExtraData);
-        FilecoinWarmStorageService.DataSetInfo memory dataSet = viewContract.getDataSet(testDataSetId);
+        FilecoinWarmStorageService.DataSetInfoView memory dataSet = viewContract.getDataSet(testDataSetId);
         assertEq(dataSet.serviceProvider, sp2, "Service provider should be updated to new service provider");
         assertEq(dataSet.payee, sp1, "Payee should remain unchanged");
     }
@@ -1253,7 +1253,7 @@ contract FilecoinWarmStorageServiceTest is Test {
 
         // 4. Assertions
         // Check pdpEndEpoch is set
-        FilecoinWarmStorageService.DataSetInfo memory info = viewContract.getDataSet(dataSetId);
+        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
         assertTrue(info.pdpEndEpoch > 0, "pdpEndEpoch should be set after termination");
         console.log("PDP termination successful. PDP end epoch:", info.pdpEndEpoch);
         // Check cdnEndEpoch is set
@@ -1412,7 +1412,7 @@ contract FilecoinWarmStorageServiceTest is Test {
         // 4. Try to terminate payment from FilCDN address
         console.log("\n4. Terminating CDN payment rails from FilCDN address -- should pass");
         console.log("Current block:", block.number);
-        FilecoinWarmStorageService.DataSetInfo memory info = viewContract.getDataSet(dataSetId);
+        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
         vm.prank(viewContract.filCDNControllerAddress()); // FilCDN terminates
         vm.expectEmit(true, true, true, true);
         emit FilecoinWarmStorageService.CDNServiceTerminated(
@@ -1518,7 +1518,7 @@ contract FilecoinWarmStorageServiceTest is Test {
         );
         console.log("Proof submitted successfully");
 
-        FilecoinWarmStorageService.DataSetInfo memory info = viewContract.getDataSet(dataSetId);
+        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
         Payments.RailView memory pdpRailPreTermination = payments.getRail(info.pdpRailId);
 
         // 3. Try to terminate payment from FilCDN address
@@ -2606,7 +2606,7 @@ contract FilecoinWarmStorageServiceTest is Test {
         string[] memory metadataKeys = new string[](0);
         string[] memory metadataValues = new string[](0);
         uint256 dataSetId = createDataSetForClient(sp1, client, metadataKeys, metadataValues);
-        FilecoinWarmStorageService.DataSetInfo memory info = viewContract.getDataSet(dataSetId);
+        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
 
         vm.expectRevert(abi.encodeWithSelector(Errors.CallerNotPayments.selector, address(payments), address(sp1)));
         vm.prank(sp1);
@@ -2617,7 +2617,7 @@ contract FilecoinWarmStorageServiceTest is Test {
         string[] memory metadataKeys = new string[](0);
         string[] memory metadataValues = new string[](0);
         uint256 dataSetId = createDataSetForClient(sp1, client, metadataKeys, metadataValues);
-        FilecoinWarmStorageService.DataSetInfo memory info = viewContract.getDataSet(dataSetId);
+        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
 
         vm.expectRevert(abi.encodeWithSelector(Errors.ServiceContractMustTerminateRail.selector));
         vm.prank(address(payments));
@@ -2633,7 +2633,7 @@ contract FilecoinWarmStorageServiceTest is Test {
     function testRailTerminated_SetsPdpEndEpochAndEmitsEvent() public {
         (string[] memory metadataKeys, string[] memory metadataValues) = _getSingleMetadataKV("withCDN", "true");
         uint256 dataSetId = createDataSetForClient(sp1, client, metadataKeys, metadataValues);
-        FilecoinWarmStorageService.DataSetInfo memory info = viewContract.getDataSet(dataSetId);
+        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
 
         vm.expectEmit(true, true, true, true);
         emit FilecoinWarmStorageService.PDPPaymentTerminated(dataSetId, 123, info.pdpRailId);
@@ -2648,7 +2648,7 @@ contract FilecoinWarmStorageServiceTest is Test {
     function testRailTerminated_SetsCdnEndEpochAndEmitsEvent_CdnRail() public {
         (string[] memory metadataKeys, string[] memory metadataValues) = _getSingleMetadataKV("withCDN", "true");
         uint256 dataSetId = createDataSetForClient(sp1, client, metadataKeys, metadataValues);
-        FilecoinWarmStorageService.DataSetInfo memory info = viewContract.getDataSet(dataSetId);
+        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
 
         vm.expectEmit(true, true, true, true);
         emit FilecoinWarmStorageService.CDNPaymentTerminated(dataSetId, 123, info.cacheMissRailId, info.cdnRailId);
@@ -2663,7 +2663,7 @@ contract FilecoinWarmStorageServiceTest is Test {
     function testRailTerminated_SetsCdnEndEpochAndEmitsEvent_CacheMissRail() public {
         (string[] memory metadataKeys, string[] memory metadataValues) = _getSingleMetadataKV("withCDN", "true");
         uint256 dataSetId = createDataSetForClient(sp1, client, metadataKeys, metadataValues);
-        FilecoinWarmStorageService.DataSetInfo memory info = viewContract.getDataSet(dataSetId);
+        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
 
         vm.expectEmit(true, true, true, true);
         emit FilecoinWarmStorageService.CDNPaymentTerminated(dataSetId, 123, info.cacheMissRailId, info.cdnRailId);
@@ -2678,7 +2678,7 @@ contract FilecoinWarmStorageServiceTest is Test {
     function testRailTerminated_DoesNotOverwritePdpEndEpoch() public {
         (string[] memory metadataKeys, string[] memory metadataValues) = _getSingleMetadataKV("withCDN", "true");
         uint256 dataSetId = createDataSetForClient(sp1, client, metadataKeys, metadataValues);
-        FilecoinWarmStorageService.DataSetInfo memory info = viewContract.getDataSet(dataSetId);
+        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
 
         vm.expectEmit(true, true, true, true);
         emit FilecoinWarmStorageService.PDPPaymentTerminated(dataSetId, 123, info.pdpRailId);
@@ -2702,7 +2702,7 @@ contract FilecoinWarmStorageServiceTest is Test {
     function testRailTerminated_DoesNotOverwriteCdnEndEpoch() public {
         (string[] memory metadataKeys, string[] memory metadataValues) = _getSingleMetadataKV("withCDN", "true");
         uint256 dataSetId = createDataSetForClient(sp1, client, metadataKeys, metadataValues);
-        FilecoinWarmStorageService.DataSetInfo memory info = viewContract.getDataSet(dataSetId);
+        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
 
         vm.expectEmit(true, true, true, true);
         emit FilecoinWarmStorageService.CDNPaymentTerminated(dataSetId, 321, info.cacheMissRailId, info.cdnRailId);

--- a/service_contracts/test/FilecoinWarmStorageServiceOwner.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageServiceOwner.t.sol
@@ -195,7 +195,7 @@ contract FilecoinWarmStorageServiceOwnerTest is Test {
         uint256 dataSetId = createDataSet(provider1, client);
 
         // Check that owner is set to the creator (provider1)
-        FilecoinWarmStorageService.DataSetInfo memory info = viewContract.getDataSet(dataSetId);
+        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
 
         assertEq(info.serviceProvider, provider1, "Service provider should be set to creator");
         assertEq(info.payer, client, "Payer should be set correctly");
@@ -210,7 +210,7 @@ contract FilecoinWarmStorageServiceOwnerTest is Test {
         uint256 dataSetId = createDataSet(provider1, client);
 
         // Get initial state
-        FilecoinWarmStorageService.DataSetInfo memory infoBefore = viewContract.getDataSet(dataSetId);
+        FilecoinWarmStorageService.DataSetInfoView memory infoBefore = viewContract.getDataSet(dataSetId);
         assertEq(infoBefore.serviceProvider, provider1, "Initial owner should be provider1");
 
         // Change storage provider
@@ -221,7 +221,7 @@ contract FilecoinWarmStorageServiceOwnerTest is Test {
         pdpVerifier.changeDataSetServiceProvider(dataSetId, provider2, address(serviceContract), new bytes(0));
 
         // Check updated state
-        FilecoinWarmStorageService.DataSetInfo memory infoAfter = viewContract.getDataSet(dataSetId);
+        FilecoinWarmStorageService.DataSetInfoView memory infoAfter = viewContract.getDataSet(dataSetId);
 
         assertEq(infoAfter.serviceProvider, provider2, "Service provider should be updated to provider2");
         assertEq(infoAfter.payee, provider1, "Payee should remain unchanged");
@@ -326,14 +326,14 @@ contract FilecoinWarmStorageServiceOwnerTest is Test {
         vm.prank(provider2);
         pdpVerifier.changeDataSetServiceProvider(dataSetId, provider2, address(serviceContract), new bytes(0));
 
-        FilecoinWarmStorageService.DataSetInfo memory info1 = viewContract.getDataSet(dataSetId);
+        FilecoinWarmStorageService.DataSetInfoView memory info1 = viewContract.getDataSet(dataSetId);
         assertEq(info1.serviceProvider, provider2, "Service provider should be provider2 after first change");
 
         // Second change: provider2 -> provider3
         vm.prank(provider3);
         pdpVerifier.changeDataSetServiceProvider(dataSetId, provider3, address(serviceContract), new bytes(0));
 
-        FilecoinWarmStorageService.DataSetInfo memory info2 = viewContract.getDataSet(dataSetId);
+        FilecoinWarmStorageService.DataSetInfoView memory info2 = viewContract.getDataSet(dataSetId);
         assertEq(info2.serviceProvider, provider3, "Service provider should be provider3 after second change");
         assertEq(info2.payee, provider1, "Payee should still be original provider1");
 


### PR DESCRIPTION
Fixes https://github.com/FilOzone/filecoin-services/issues/235

This PR adds a new struct DataSetInfoView and returns the same for getClientDataSets. The new struct is a copy of DataSetInfo with additional parameter `uint256 dataSetId`.