### PR TITLE
feat: remove dataset creation fee

### DIFF
--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -171,7 +171,6 @@ contract FilecoinWarmStorageService is
     address payable private constant BURN_ADDRESS = payable(0xff00000000000000000000000000000000000063);
 
     // Dynamic fee values based on token decimals
-    uint256 private immutable DATA_SET_CREATION_FEE; // 0.1 USDFC with correct decimals
 
     // Token decimals
     uint8 private immutable TOKEN_DECIMALS;
@@ -315,7 +314,6 @@ contract FilecoinWarmStorageService is
 
         // Initialize the fee constants based on the actual token decimals
         STORAGE_PRICE_PER_TIB_PER_MONTH = (5 * 10 ** TOKEN_DECIMALS) / 2; // 2.5 USDFC
-        DATA_SET_CREATION_FEE = (1 * 10 ** TOKEN_DECIMALS) / 10; // 0.1 USDFC
         CACHE_MISS_PRICE_PER_TIB_PER_MONTH = (1 * 10 ** TOKEN_DECIMALS) / 2; // 0.5 USDFC
         CDN_PRICE_PER_TIB_PER_MONTH = (1 * 10 ** TOKEN_DECIMALS) / 2; // 0.5 USDFC
     }
@@ -570,20 +568,14 @@ contract FilecoinWarmStorageService is
         // Store reverse mapping from rail ID to data set ID for validation
         railToDataSet[pdpRailId] = dataSetId;
 
-        // First, set a lockupFixed value that's at least equal to the one-time payment
-        // This is necessary because modifyRailPayment requires that lockupFixed >= oneTimePayment
-        payments.modifyRailLockup(
-            pdpRailId,
-            DEFAULT_LOCKUP_PERIOD,
-            DATA_SET_CREATION_FEE // lockupFixed equal to the one-time payment amount
-        );
+        // Set lockup period for the rail
+        payments.modifyRailLockup(pdpRailId, DEFAULT_LOCKUP_PERIOD, 0);
 
-        // Charge the one-time data set creation fee
-        // This is a payment from payer to data set service provider of a fixed amount
+        // Initialize rail with zero rate - will be updated when roots are added
         payments.modifyRailPayment(
             pdpRailId,
             0, // Initial rate is 0, will be updated when roots are added
-            DATA_SET_CREATION_FEE // One-time payment amount
+            0
         );
 
         uint256 cacheMissRailId = 0;

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -462,7 +462,7 @@ contract FilecoinWarmStorageServiceTest is Test {
         return (keys, values);
     }
 
-    function testCreateDataSetCreatesRailAndChargesFee() public {
+    function testCreateDataSetCreatesRail() public {
         // Prepare ExtraData - withCDN key presence means CDN is enabled
         (string[] memory metadataKeys, string[] memory metadataValues) = _getSingleMetadataKV("withCDN", "true");
 
@@ -490,15 +490,11 @@ contract FilecoinWarmStorageServiceTest is Test {
             365 days // max lockup period
         );
 
-        // Client deposits funds to the Payments contract for the one-time fee
-        uint256 depositAmount = 1e6; // 10x the required fee
+        // Client deposits funds to the Payments contract for future payments
+        uint256 depositAmount = 1e5; // Sufficient funds for future operations
         mockUSDFC.approve(address(payments), depositAmount);
         payments.deposit(mockUSDFC, client, depositAmount);
         vm.stopPrank();
-
-        // Get account balances before creating data set
-        (uint256 clientFundsBefore,) = getAccountInfo(mockUSDFC, client);
-        (uint256 spFundsBefore,) = getAccountInfo(mockUSDFC, serviceProvider);
 
         // Expect DataSetCreated event when creating the data set
         vm.expectEmit(true, true, true, true);
@@ -578,19 +574,6 @@ contract FilecoinWarmStorageServiceTest is Test {
         assertEq(cdnRail.commissionRateBps, 0, "No commission");
         assertEq(cdnRail.lockupFixed, 0, "Lockup fixed should be 0 after one-time payment");
         assertEq(cdnRail.paymentRate, 0, "Initial payment rate should be 0");
-
-        // Get account balances after creating data set
-        (uint256 clientFundsAfter,) = getAccountInfo(mockUSDFC, client);
-        (uint256 spFundsAfter,) = getAccountInfo(mockUSDFC, serviceProvider);
-
-        // Calculate expected client balance
-        uint256 expectedClientFundsAfter = clientFundsBefore - 1e5;
-
-        // Verify balances changed correctly (one-time fee transferred)
-        assertEq(
-            clientFundsAfter, expectedClientFundsAfter, "Client funds should decrease by the data set creation fee"
-        );
-        assertTrue(spFundsAfter > spFundsBefore, "Service provider funds should increase");
     }
 
     function testCreateDataSetNoCDN() public {
@@ -621,8 +604,8 @@ contract FilecoinWarmStorageServiceTest is Test {
             365 days // max lockup period
         );
 
-        // Client deposits funds to the Payments contract for the one-time fee
-        uint256 depositAmount = 1e6; // 10x the required fee
+        // Client deposits funds to the Payments contract for future payments
+        uint256 depositAmount = 1e5; // Sufficient funds for future operations
         mockUSDFC.approve(address(payments), depositAmount);
         payments.deposit(mockUSDFC, client, depositAmount);
         vm.stopPrank();
@@ -700,7 +683,7 @@ contract FilecoinWarmStorageServiceTest is Test {
             1000e6, // lockup allowance (1000 USDFC)
             365 days // max lockup period
         );
-        uint256 depositAmount = 1e6; // 10x the required fee
+        uint256 depositAmount = 1e5;
         mockUSDFC.approve(address(payments), depositAmount);
         payments.deposit(mockUSDFC, client, depositAmount);
         vm.stopPrank();


### PR DESCRIPTION
# Remove Dataset Creation Fee

## Summary
Removes the 0.1 USDFC dataset creation fee.

## Changes
- **Removed** `DATA_SET_CREATION_FEE` constant and initialization
- **Updated** `createDataSet()` function to set zero lockup and payment amounts
- **Fixed** tests to expect no fee charges during dataset creation
- **Updated** comments and test names to reflect fee removal

## Rationale
The dataset creation fee was originally introduced to prevent storage providers from creating unused datasets. However, since dataset creation now coincides with adding the first data piece, this concern is addressed without the fee.

## Files Changed
- `src/FilecoinWarmStorageService.sol` - Removed fee logic
- `test/FilecoinWarmStorageService.t.sol` - Updated test expectations

## Testing
- All existing tests pass with updated expectations
- Dataset creation now requires no upfront payment

Issue #241 