### PR TITLE
feat: remove provierId from ServiceProviderInfo struct

### DIFF
--- a/service_contracts/abi/ServiceProviderRegistry.abi.json
+++ b/service_contracts/abi/ServiceProviderRegistry.abi.json
@@ -388,13 +388,8 @@
               {
                 "name": "providerInfo",
                 "type": "tuple",
-                "internalType": "struct ServiceProviderRegistryStorage.ServiceProviderInfoView",
+                "internalType": "struct ServiceProviderRegistryStorage.ServiceProviderInfo",
                 "components": [
-                  {
-                    "name": "providerId",
-                    "type": "uint256",
-                    "internalType": "uint256"
-                  },
                   {
                     "name": "serviceProvider",
                     "type": "address",
@@ -695,7 +690,7 @@
       {
         "name": "info",
         "type": "tuple",
-        "internalType": "struct ServiceProviderRegistryStorage.ServiceProviderInfoView",
+        "internalType": "struct ServiceProviderRegistry.ServiceProviderInfoView",
         "components": [
           {
             "name": "providerId",
@@ -703,29 +698,36 @@
             "internalType": "uint256"
           },
           {
-            "name": "serviceProvider",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "payee",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "name",
-            "type": "string",
-            "internalType": "string"
-          },
-          {
-            "name": "description",
-            "type": "string",
-            "internalType": "string"
-          },
-          {
-            "name": "isActive",
-            "type": "bool",
-            "internalType": "bool"
+            "name": "info",
+            "type": "tuple",
+            "internalType": "struct ServiceProviderRegistryStorage.ServiceProviderInfo",
+            "components": [
+              {
+                "name": "serviceProvider",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "payee",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "description",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "isActive",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
           }
         ]
       }
@@ -746,7 +748,7 @@
       {
         "name": "info",
         "type": "tuple",
-        "internalType": "struct ServiceProviderRegistryStorage.ServiceProviderInfoView",
+        "internalType": "struct ServiceProviderRegistry.ServiceProviderInfoView",
         "components": [
           {
             "name": "providerId",
@@ -754,29 +756,36 @@
             "internalType": "uint256"
           },
           {
-            "name": "serviceProvider",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "payee",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "name",
-            "type": "string",
-            "internalType": "string"
-          },
-          {
-            "name": "description",
-            "type": "string",
-            "internalType": "string"
-          },
-          {
-            "name": "isActive",
-            "type": "bool",
-            "internalType": "bool"
+            "name": "info",
+            "type": "tuple",
+            "internalType": "struct ServiceProviderRegistryStorage.ServiceProviderInfo",
+            "components": [
+              {
+                "name": "serviceProvider",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "payee",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "description",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "isActive",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
           }
         ]
       }
@@ -854,13 +863,8 @@
               {
                 "name": "providerInfo",
                 "type": "tuple",
-                "internalType": "struct ServiceProviderRegistryStorage.ServiceProviderInfoView",
+                "internalType": "struct ServiceProviderRegistryStorage.ServiceProviderInfo",
                 "components": [
-                  {
-                    "name": "providerId",
-                    "type": "uint256",
-                    "internalType": "uint256"
-                  },
                   {
                     "name": "serviceProvider",
                     "type": "address",

--- a/service_contracts/abi/ServiceProviderRegistry.abi.json
+++ b/service_contracts/abi/ServiceProviderRegistry.abi.json
@@ -388,8 +388,13 @@
               {
                 "name": "providerInfo",
                 "type": "tuple",
-                "internalType": "struct ServiceProviderRegistryStorage.ServiceProviderInfo",
+                "internalType": "struct ServiceProviderRegistryStorage.ServiceProviderInfoView",
                 "components": [
+                  {
+                    "name": "providerId",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
                   {
                     "name": "serviceProvider",
                     "type": "address",
@@ -414,11 +419,6 @@
                     "name": "isActive",
                     "type": "bool",
                     "internalType": "bool"
-                  },
-                  {
-                    "name": "providerId",
-                    "type": "uint256",
-                    "internalType": "uint256"
                   }
                 ]
               },
@@ -695,8 +695,13 @@
       {
         "name": "info",
         "type": "tuple",
-        "internalType": "struct ServiceProviderRegistryStorage.ServiceProviderInfo",
+        "internalType": "struct ServiceProviderRegistryStorage.ServiceProviderInfoView",
         "components": [
+          {
+            "name": "providerId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
           {
             "name": "serviceProvider",
             "type": "address",
@@ -721,11 +726,6 @@
             "name": "isActive",
             "type": "bool",
             "internalType": "bool"
-          },
-          {
-            "name": "providerId",
-            "type": "uint256",
-            "internalType": "uint256"
           }
         ]
       }
@@ -746,8 +746,13 @@
       {
         "name": "info",
         "type": "tuple",
-        "internalType": "struct ServiceProviderRegistryStorage.ServiceProviderInfo",
+        "internalType": "struct ServiceProviderRegistryStorage.ServiceProviderInfoView",
         "components": [
+          {
+            "name": "providerId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
           {
             "name": "serviceProvider",
             "type": "address",
@@ -772,11 +777,6 @@
             "name": "isActive",
             "type": "bool",
             "internalType": "bool"
-          },
-          {
-            "name": "providerId",
-            "type": "uint256",
-            "internalType": "uint256"
           }
         ]
       }
@@ -854,8 +854,13 @@
               {
                 "name": "providerInfo",
                 "type": "tuple",
-                "internalType": "struct ServiceProviderRegistryStorage.ServiceProviderInfo",
+                "internalType": "struct ServiceProviderRegistryStorage.ServiceProviderInfoView",
                 "components": [
+                  {
+                    "name": "providerId",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
                   {
                     "name": "serviceProvider",
                     "type": "address",
@@ -880,11 +885,6 @@
                     "name": "isActive",
                     "type": "bool",
                     "internalType": "bool"
-                  },
-                  {
-                    "name": "providerId",
-                    "type": "uint256",
-                    "internalType": "uint256"
                   }
                 ]
               },
@@ -1139,11 +1139,6 @@
         "name": "isActive",
         "type": "bool",
         "internalType": "bool"
-      },
-      {
-        "name": "providerId",
-        "type": "uint256",
-        "internalType": "uint256"
       }
     ],
     "stateMutability": "view"

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -494,7 +494,7 @@ contract FilecoinWarmStorageService is
         // Check if provider is approved
         require(approvedProviders[providerId], Errors.ProviderNotApproved(serviceProvider, providerId));
 
-        ServiceProviderRegistryStorage.ServiceProviderInfo memory providerInfo =
+        ServiceProviderRegistryStorage.ServiceProviderInfoView memory providerInfo =
             serviceProviderRegistry.getProvider(providerId);
         address payee = providerInfo.payee;
 

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -15,7 +15,6 @@ import {Payments, IValidator} from "@fws-payments/Payments.sol";
 import {Errors} from "./Errors.sol";
 
 import {ServiceProviderRegistry} from "./ServiceProviderRegistry.sol";
-import {ServiceProviderRegistryStorage} from "./ServiceProviderRegistryStorage.sol";
 
 import {Extsload} from "./Extsload.sol";
 
@@ -494,9 +493,9 @@ contract FilecoinWarmStorageService is
         // Check if provider is approved
         require(approvedProviders[providerId], Errors.ProviderNotApproved(serviceProvider, providerId));
 
-        ServiceProviderRegistryStorage.ServiceProviderInfoView memory providerInfo =
+        ServiceProviderRegistry.ServiceProviderInfoView memory providerInfo =
             serviceProviderRegistry.getProvider(providerId);
-        address payee = providerInfo.payee;
+        address payee = providerInfo.info.payee;
 
         uint256 clientDataSetId = clientDataSetIds[createData.payer]++;
         clientDataSets[createData.payer].push(dataSetId);

--- a/service_contracts/src/ServiceProviderRegistry.sol
+++ b/service_contracts/src/ServiceProviderRegistry.sol
@@ -17,6 +17,12 @@ contract ServiceProviderRegistry is
     EIP712Upgradeable,
     ServiceProviderRegistryStorage
 {
+    /// @notice Provider information for API returns
+    struct ServiceProviderInfoView {
+        uint256 providerId; // Provider ID
+        ServiceProviderInfo info; // Nested provider information
+    }
+
     /// @notice Version of the contract implementation
     string public constant VERSION = "0.0.1";
 
@@ -475,14 +481,7 @@ contract ServiceProviderRegistry is
         returns (ServiceProviderInfoView memory info)
     {
         ServiceProviderInfo storage provider = providers[providerId];
-        return ServiceProviderInfoView({
-            providerId: providerId,
-            serviceProvider: provider.serviceProvider,
-            payee: provider.payee,
-            name: provider.name,
-            description: provider.description,
-            isActive: provider.isActive
-        });
+        return ServiceProviderInfoView({providerId: providerId, info: provider});
     }
 
     /// @notice Get product data for a specific product type
@@ -558,14 +557,7 @@ contract ServiceProviderRegistry is
                     ServiceProviderInfo storage provider = providers[i];
                     result.providers[resultIndex] = ProviderWithProduct({
                         providerId: i,
-                        providerInfo: ServiceProviderInfoView({
-                            providerId: i,
-                            serviceProvider: provider.serviceProvider,
-                            payee: provider.payee,
-                            name: provider.name,
-                            description: provider.description,
-                            isActive: provider.isActive
-                        }),
+                        providerInfo: provider,
                         product: providerProducts[i][productType]
                     });
                     resultIndex++;
@@ -615,14 +607,7 @@ contract ServiceProviderRegistry is
                     ServiceProviderInfo storage provider = providers[i];
                     result.providers[resultIndex] = ProviderWithProduct({
                         providerId: i,
-                        providerInfo: ServiceProviderInfoView({
-                            providerId: i,
-                            serviceProvider: provider.serviceProvider,
-                            payee: provider.payee,
-                            name: provider.name,
-                            description: provider.description,
-                            isActive: provider.isActive
-                        }),
+                        providerInfo: provider,
                         product: providerProducts[i][productType]
                     });
                     resultIndex++;
@@ -657,23 +642,18 @@ contract ServiceProviderRegistry is
         if (providerId == 0) {
             return ServiceProviderInfoView({
                 providerId: 0,
-                serviceProvider: address(0),
-                payee: address(0),
-                name: "",
-                description: "",
-                isActive: false
+                info: ServiceProviderInfo({
+                    serviceProvider: address(0),
+                    payee: address(0),
+                    name: "",
+                    description: "",
+                    isActive: false
+                })
             });
         }
 
         ServiceProviderInfo storage provider = providers[providerId];
-        return ServiceProviderInfoView({
-            providerId: providerId,
-            serviceProvider: provider.serviceProvider,
-            payee: provider.payee,
-            name: provider.name,
-            description: provider.description,
-            isActive: provider.isActive
-        });
+        return ServiceProviderInfoView({providerId: providerId, info: provider});
     }
 
     /// @notice Get provider ID by address

--- a/service_contracts/src/ServiceProviderRegistry.sol
+++ b/service_contracts/src/ServiceProviderRegistry.sol
@@ -161,8 +161,7 @@ contract ServiceProviderRegistry is
             payee: payee,
             name: name,
             description: description,
-            isActive: true,
-            providerId: providerId
+            isActive: true
         });
 
         // Update address mapping
@@ -473,9 +472,17 @@ contract ServiceProviderRegistry is
         external
         view
         providerExists(providerId)
-        returns (ServiceProviderInfo memory info)
+        returns (ServiceProviderInfoView memory info)
     {
-        return providers[providerId];
+        ServiceProviderInfo storage provider = providers[providerId];
+        return ServiceProviderInfoView({
+            providerId: providerId,
+            serviceProvider: provider.serviceProvider,
+            payee: provider.payee,
+            name: provider.name,
+            description: provider.description,
+            isActive: provider.isActive
+        });
     }
 
     /// @notice Get product data for a specific product type
@@ -548,9 +555,17 @@ contract ServiceProviderRegistry is
         for (uint256 i = 1; i <= numProviders && resultIndex < limit; i++) {
             if (providerProducts[i][productType].productData.length > 0) {
                 if (currentIndex >= offset && currentIndex < offset + limit) {
+                    ServiceProviderInfo storage provider = providers[i];
                     result.providers[resultIndex] = ProviderWithProduct({
                         providerId: i,
-                        providerInfo: providers[i],
+                        providerInfo: ServiceProviderInfoView({
+                            providerId: i,
+                            serviceProvider: provider.serviceProvider,
+                            payee: provider.payee,
+                            name: provider.name,
+                            description: provider.description,
+                            isActive: provider.isActive
+                        }),
                         product: providerProducts[i][productType]
                     });
                     resultIndex++;
@@ -597,9 +612,17 @@ contract ServiceProviderRegistry is
                     && providerProducts[i][productType].productData.length > 0
             ) {
                 if (currentIndex >= offset && currentIndex < offset + limit) {
+                    ServiceProviderInfo storage provider = providers[i];
                     result.providers[resultIndex] = ProviderWithProduct({
                         providerId: i,
-                        providerInfo: providers[i],
+                        providerInfo: ServiceProviderInfoView({
+                            providerId: i,
+                            serviceProvider: provider.serviceProvider,
+                            payee: provider.payee,
+                            name: provider.name,
+                            description: provider.description,
+                            isActive: provider.isActive
+                        }),
                         product: providerProducts[i][productType]
                     });
                     resultIndex++;
@@ -625,9 +648,32 @@ contract ServiceProviderRegistry is
     /// @notice Get provider info by address
     /// @param providerAddress The address of the service provider
     /// @return info The provider information (empty struct if not registered)
-    function getProviderByAddress(address providerAddress) external view returns (ServiceProviderInfo memory info) {
+    function getProviderByAddress(address providerAddress)
+        external
+        view
+        returns (ServiceProviderInfoView memory info)
+    {
         uint256 providerId = addressToProviderId[providerAddress];
-        return providers[providerId];
+        if (providerId == 0) {
+            return ServiceProviderInfoView({
+                providerId: 0,
+                serviceProvider: address(0),
+                payee: address(0),
+                name: "",
+                description: "",
+                isActive: false
+            });
+        }
+
+        ServiceProviderInfo storage provider = providers[providerId];
+        return ServiceProviderInfoView({
+            providerId: providerId,
+            serviceProvider: provider.serviceProvider,
+            payee: provider.payee,
+            name: provider.name,
+            description: provider.description,
+            isActive: provider.isActive
+        });
     }
 
     /// @notice Get provider ID by address

--- a/service_contracts/src/ServiceProviderRegistryStorage.sol
+++ b/service_contracts/src/ServiceProviderRegistryStorage.sol
@@ -25,16 +25,6 @@ contract ServiceProviderRegistryStorage {
         bool isActive;
     }
 
-    /// @notice Provider information for API returns
-    struct ServiceProviderInfoView {
-        uint256 providerId; // Provider ID
-        address serviceProvider; // Address that controls the provider registration
-        address payee; // Address that receives payments (cannot be changed after registration)
-        string name; // Optional provider name (max 128 chars)
-        string description; //Service description, ToC, contract info, website..
-        bool isActive;
-    }
-
     /// @notice Product offering of the Service Provider
     struct ServiceProduct {
         ProductType productType;
@@ -59,7 +49,7 @@ contract ServiceProviderRegistryStorage {
     /// @notice Combined provider and product information for detailed queries
     struct ProviderWithProduct {
         uint256 providerId;
-        ServiceProviderInfoView providerInfo;
+        ServiceProviderInfo providerInfo;
         ServiceProduct product;
     }
 

--- a/service_contracts/src/ServiceProviderRegistryStorage.sol
+++ b/service_contracts/src/ServiceProviderRegistryStorage.sol
@@ -23,7 +23,16 @@ contract ServiceProviderRegistryStorage {
         string name; // Optional provider name (max 128 chars)
         string description; //Service description, ToC, contract info, website..
         bool isActive;
-        uint256 providerId; // Unique identifier for the provider
+    }
+
+    /// @notice Provider information for API returns
+    struct ServiceProviderInfoView {
+        uint256 providerId; // Provider ID
+        address serviceProvider; // Address that controls the provider registration
+        address payee; // Address that receives payments (cannot be changed after registration)
+        string name; // Optional provider name (max 128 chars)
+        string description; //Service description, ToC, contract info, website..
+        bool isActive;
     }
 
     /// @notice Product offering of the Service Provider
@@ -50,7 +59,7 @@ contract ServiceProviderRegistryStorage {
     /// @notice Combined provider and product information for detailed queries
     struct ProviderWithProduct {
         uint256 providerId;
-        ServiceProviderInfo providerInfo;
+        ServiceProviderInfoView providerInfo;
         ServiceProduct product;
     }
 

--- a/service_contracts/test/ServiceProviderRegistry.t.sol
+++ b/service_contracts/test/ServiceProviderRegistry.t.sol
@@ -204,11 +204,11 @@ contract ServiceProviderRegistryTest is Test {
         );
 
         // Verify provider info
-        ServiceProviderRegistryStorage.ServiceProviderInfoView memory info = registry.getProvider(providerId);
+        ServiceProviderRegistry.ServiceProviderInfoView memory info = registry.getProvider(providerId);
         assertEq(info.providerId, providerId, "Provider ID should match");
-        assertEq(info.serviceProvider, user1, "Service provider should be user1");
-        assertEq(info.payee, user2, "Payee should be user2");
-        assertTrue(info.isActive, "Provider should be active");
+        assertEq(info.info.serviceProvider, user1, "Service provider should be user1");
+        assertEq(info.info.payee, user2, "Payee should be user2");
+        assertTrue(info.info.isActive, "Provider should be active");
     }
 
     function testCannotRegisterWithZeroBeneficiary() public {
@@ -280,10 +280,10 @@ contract ServiceProviderRegistryTest is Test {
         );
 
         // Now get provider should work
-        ServiceProviderRegistryStorage.ServiceProviderInfoView memory info = registry.getProvider(1);
+        ServiceProviderRegistry.ServiceProviderInfoView memory info = registry.getProvider(1);
         assertEq(info.providerId, 1, "Provider ID should be 1");
-        assertEq(info.serviceProvider, user1, "Service provider should be user1");
-        assertEq(info.payee, user1, "Payee should be user1");
+        assertEq(info.info.serviceProvider, user1, "Service provider should be user1");
+        assertEq(info.info.payee, user1, "Payee should be user1");
     }
 
     // Note: We can't test non-PDP product types since Solidity doesn't allow

--- a/service_contracts/test/ServiceProviderRegistry.t.sol
+++ b/service_contracts/test/ServiceProviderRegistry.t.sol
@@ -204,7 +204,7 @@ contract ServiceProviderRegistryTest is Test {
         );
 
         // Verify provider info
-        ServiceProviderRegistryStorage.ServiceProviderInfo memory info = registry.getProvider(providerId);
+        ServiceProviderRegistryStorage.ServiceProviderInfoView memory info = registry.getProvider(providerId);
         assertEq(info.providerId, providerId, "Provider ID should match");
         assertEq(info.serviceProvider, user1, "Service provider should be user1");
         assertEq(info.payee, user2, "Payee should be user2");
@@ -280,7 +280,7 @@ contract ServiceProviderRegistryTest is Test {
         );
 
         // Now get provider should work
-        ServiceProviderRegistryStorage.ServiceProviderInfo memory info = registry.getProvider(1);
+        ServiceProviderRegistryStorage.ServiceProviderInfoView memory info = registry.getProvider(1);
         assertEq(info.providerId, 1, "Provider ID should be 1");
         assertEq(info.serviceProvider, user1, "Service provider should be user1");
         assertEq(info.payee, user1, "Payee should be user1");

--- a/service_contracts/test/ServiceProviderRegistryFull.t.sol
+++ b/service_contracts/test/ServiceProviderRegistryFull.t.sol
@@ -162,7 +162,7 @@ contract ServiceProviderRegistryFullTest is Test {
 
         // Verify registration
         assertEq(providerId, 1, "Provider ID should be 1");
-        ServiceProviderRegistryStorage.ServiceProviderInfo memory providerInfo =
+        ServiceProviderRegistryStorage.ServiceProviderInfoView memory providerInfo =
             registry.getProviderByAddress(provider1);
         assertEq(providerInfo.providerId, 1, "Provider ID should be 1");
         assertEq(providerInfo.serviceProvider, provider1, "Provider address should match");
@@ -171,7 +171,7 @@ contract ServiceProviderRegistryFullTest is Test {
         assertTrue(registry.isProviderActive(1), "Provider should be active");
 
         // Verify provider info
-        ServiceProviderRegistryStorage.ServiceProviderInfo memory info = registry.getProvider(1);
+        ServiceProviderRegistryStorage.ServiceProviderInfoView memory info = registry.getProvider(1);
         assertEq(info.providerId, 1, "Provider ID should be 1");
         assertEq(info.serviceProvider, provider1, "Service provider should be provider1");
         assertEq(info.payee, provider1, "Payee should be provider1");
@@ -409,7 +409,7 @@ contract ServiceProviderRegistryFullTest is Test {
         );
 
         // Verify provider was not registered
-        ServiceProviderRegistryStorage.ServiceProviderInfo memory notRegisteredInfo =
+        ServiceProviderRegistryStorage.ServiceProviderInfoView memory notRegisteredInfo =
             registry.getProviderByAddress(provider1);
         assertEq(notRegisteredInfo.serviceProvider, address(0), "Provider should not be registered");
     }
@@ -680,11 +680,12 @@ contract ServiceProviderRegistryFullTest is Test {
         // Verify removal
         assertFalse(registry.isProviderActive(1), "Provider should be inactive");
         assertFalse(registry.isRegisteredProvider(provider1), "Provider should not be registered");
-        ServiceProviderRegistryStorage.ServiceProviderInfo memory removedInfo = registry.getProviderByAddress(provider1);
+        ServiceProviderRegistryStorage.ServiceProviderInfoView memory removedInfo =
+            registry.getProviderByAddress(provider1);
         assertEq(removedInfo.serviceProvider, address(0), "Address lookup should return empty");
 
         // Verify provider info still exists (soft delete)
-        ServiceProviderRegistryStorage.ServiceProviderInfo memory info = registry.getProvider(1);
+        ServiceProviderRegistryStorage.ServiceProviderInfoView memory info = registry.getProvider(1);
         assertEq(info.providerId, 1, "Provider ID should still be 1");
         assertFalse(info.isActive, "Provider should be marked inactive");
         assertEq(info.serviceProvider, provider1, "Service provider should still be recorded");
@@ -1164,7 +1165,7 @@ contract ServiceProviderRegistryFullTest is Test {
         );
 
         // Verify initial description
-        ServiceProviderRegistryStorage.ServiceProviderInfo memory info = registry.getProvider(1);
+        ServiceProviderRegistryStorage.ServiceProviderInfoView memory info = registry.getProvider(1);
         assertEq(info.providerId, 1, "Provider ID should be 1");
         assertEq(info.description, "Initial description", "Initial description should match");
 

--- a/service_contracts/test/ServiceProviderRegistryFull.t.sol
+++ b/service_contracts/test/ServiceProviderRegistryFull.t.sol
@@ -162,22 +162,21 @@ contract ServiceProviderRegistryFullTest is Test {
 
         // Verify registration
         assertEq(providerId, 1, "Provider ID should be 1");
-        ServiceProviderRegistryStorage.ServiceProviderInfoView memory providerInfo =
-            registry.getProviderByAddress(provider1);
+        ServiceProviderRegistry.ServiceProviderInfoView memory providerInfo = registry.getProviderByAddress(provider1);
         assertEq(providerInfo.providerId, 1, "Provider ID should be 1");
-        assertEq(providerInfo.serviceProvider, provider1, "Provider address should match");
-        assertTrue(providerInfo.isActive, "Provider should be active");
+        assertEq(providerInfo.info.serviceProvider, provider1, "Provider address should match");
+        assertTrue(providerInfo.info.isActive, "Provider should be active");
         assertTrue(registry.isRegisteredProvider(provider1), "Provider should be registered");
         assertTrue(registry.isProviderActive(1), "Provider should be active");
 
         // Verify provider info
-        ServiceProviderRegistryStorage.ServiceProviderInfoView memory info = registry.getProvider(1);
+        ServiceProviderRegistry.ServiceProviderInfoView memory info = registry.getProvider(1);
         assertEq(info.providerId, 1, "Provider ID should be 1");
-        assertEq(info.serviceProvider, provider1, "Service provider should be provider1");
-        assertEq(info.payee, provider1, "Payee should be provider1");
-        assertEq(info.name, "", "Name should be empty");
-        assertEq(info.description, "Test provider description", "Description should match");
-        assertTrue(info.isActive, "Provider should be active");
+        assertEq(info.info.serviceProvider, provider1, "Service provider should be provider1");
+        assertEq(info.info.payee, provider1, "Payee should be provider1");
+        assertEq(info.info.name, "", "Name should be empty");
+        assertEq(info.info.description, "Test provider description", "Description should match");
+        assertTrue(info.info.isActive, "Provider should be active");
 
         // Verify PDP service using getPDPService (including capabilities)
         (ServiceProviderRegistryStorage.PDPOffering memory pdpData, string[] memory keys, bool isActive) =
@@ -409,9 +408,9 @@ contract ServiceProviderRegistryFullTest is Test {
         );
 
         // Verify provider was not registered
-        ServiceProviderRegistryStorage.ServiceProviderInfoView memory notRegisteredInfo =
+        ServiceProviderRegistry.ServiceProviderInfoView memory notRegisteredInfo =
             registry.getProviderByAddress(provider1);
-        assertEq(notRegisteredInfo.serviceProvider, address(0), "Provider should not be registered");
+        assertEq(notRegisteredInfo.info.serviceProvider, address(0), "Provider should not be registered");
     }
 
     function testRegisterWithInvalidData() public {
@@ -680,16 +679,15 @@ contract ServiceProviderRegistryFullTest is Test {
         // Verify removal
         assertFalse(registry.isProviderActive(1), "Provider should be inactive");
         assertFalse(registry.isRegisteredProvider(provider1), "Provider should not be registered");
-        ServiceProviderRegistryStorage.ServiceProviderInfoView memory removedInfo =
-            registry.getProviderByAddress(provider1);
-        assertEq(removedInfo.serviceProvider, address(0), "Address lookup should return empty");
+        ServiceProviderRegistry.ServiceProviderInfoView memory removedInfo = registry.getProviderByAddress(provider1);
+        assertEq(removedInfo.info.serviceProvider, address(0), "Address lookup should return empty");
 
         // Verify provider info still exists (soft delete)
-        ServiceProviderRegistryStorage.ServiceProviderInfoView memory info = registry.getProvider(1);
+        ServiceProviderRegistry.ServiceProviderInfoView memory info = registry.getProvider(1);
         assertEq(info.providerId, 1, "Provider ID should still be 1");
-        assertFalse(info.isActive, "Provider should be marked inactive");
-        assertEq(info.serviceProvider, provider1, "Service provider should still be recorded");
-        assertEq(info.payee, provider1, "Payee should still be recorded");
+        assertFalse(info.info.isActive, "Provider should be marked inactive");
+        assertEq(info.info.serviceProvider, provider1, "Service provider should still be recorded");
+        assertEq(info.info.payee, provider1, "Payee should still be recorded");
 
         // Verify PDP service is inactive
         (,, bool isActive) = registry.getPDPService(1);
@@ -1165,9 +1163,9 @@ contract ServiceProviderRegistryFullTest is Test {
         );
 
         // Verify initial description
-        ServiceProviderRegistryStorage.ServiceProviderInfoView memory info = registry.getProvider(1);
+        ServiceProviderRegistry.ServiceProviderInfoView memory info = registry.getProvider(1);
         assertEq(info.providerId, 1, "Provider ID should be 1");
-        assertEq(info.description, "Initial description", "Initial description should match");
+        assertEq(info.info.description, "Initial description", "Initial description should match");
 
         // Update description
         vm.prank(provider1);
@@ -1178,7 +1176,7 @@ contract ServiceProviderRegistryFullTest is Test {
         // Verify updated description
         info = registry.getProvider(1);
         assertEq(info.providerId, 1, "Provider ID should still be 1");
-        assertEq(info.description, "Updated description", "Description should be updated");
+        assertEq(info.info.description, "Updated description", "Description should be updated");
     }
 
     function testCannotUpdateProviderDescriptionIfNotOwner() public {


### PR DESCRIPTION
# Remove providerId from ServiceProviderInfo struct

## Summary
Remove `providerId` from `ServiceProviderInfo` struct and introduce `ServiceProviderInfoView` as a view struct to return provider ID with provider info.

## Related Issue
Fixes #234

## Changes
- **Removed** `providerId` field from `ServiceProviderInfo` struct
- **Added** `ServiceProviderInfoView` struct with `providerId` field for external consumption
- **Updated** all getter functions to return `ServiceProviderInfoView`
- **Updated** tests and ABI definitions

## Files Modified
- `ServiceProviderRegistry.sol`
- `ServiceProviderRegistryStorage.sol` 
- `FilecoinWarmStorageService.sol`
- Test files and ABI
