### PR TITLE
perf(ServiceProviderRegistry): getProviderPayee helper for dataSetCreated

### DIFF
--- a/service_contracts/abi/ServiceProviderRegistry.abi.json
+++ b/service_contracts/abi/ServiceProviderRegistry.abi.json
@@ -826,6 +826,25 @@
   },
   {
     "type": "function",
+    "name": "getProviderPayee",
+    "inputs": [
+      {
+        "name": "providerId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "payee",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "getProvidersByProductType",
     "inputs": [
       {

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -489,9 +489,7 @@ contract FilecoinWarmStorageService is
         // Check if provider is approved
         require(approvedProviders[providerId], Errors.ProviderNotApproved(serviceProvider, providerId));
 
-        ServiceProviderRegistry.ServiceProviderInfoView memory providerInfo =
-            serviceProviderRegistry.getProvider(providerId);
-        address payee = providerInfo.info.payee;
+        address payee = serviceProviderRegistry.getProviderPayee(providerId);
 
         uint256 clientDataSetId = clientDataSetIds[createData.payer]++;
         clientDataSets[createData.payer].push(dataSetId);

--- a/service_contracts/src/ServiceProviderRegistry.sol
+++ b/service_contracts/src/ServiceProviderRegistry.sol
@@ -484,6 +484,13 @@ contract ServiceProviderRegistry is
         return ServiceProviderInfoView({providerId: providerId, info: provider});
     }
 
+    /// @notice Get only the payee address for a provider
+    /// @param providerId The ID of the provider
+    /// @return payee The payee address
+    function getProviderPayee(uint256 providerId) external view providerExists(providerId) returns (address payee) {
+        return providers[providerId].payee;
+    }
+
     /// @notice Get product data for a specific product type
     /// @param providerId The ID of the provider
     /// @param productType The type of product to retrieve


### PR DESCRIPTION
## Description

Implements a helper function to fetch only the payee address for service providers, reducing the access footprint of `CreateDataSet`.

## Problem

Currently, `FilecoinWarmStorageService.dataSetCreated()` calls `getProvider(providerId)` which reads the entire `ServiceProviderInfo` struct from storage, including expensive string fields (`name` and `description`), when only the `payee` address is needed.

## Solution

- **Added `getProviderPayee(uint256 providerId)`** in `ServiceProviderRegistry.sol`
  - Returns only the payee address directly from storage
  - Uses `providerExists` modifier for safety

- **Updated `FilecoinWarmStorageService.sol`**
  - Replaced `getProvider()` call with `getProviderPayee()` in `dataSetCreated()`
  - Eliminates intermediate struct creation and string reads

- **Added unit tests**
  - `testGetProviderPayeeReturnsCorrectAddress()` - verifies correct payee returned
  - `testGetProviderPayeeRevertsForInvalidProviderId()` - verifies revert behavior

Fixes #248