### PR TITLE
feat(ServiceProviderRegistry): add getProvidersByIds batch lookup function

### DIFF
--- a/service_contracts/abi/ServiceProviderRegistry.abi.json
+++ b/service_contracts/abi/ServiceProviderRegistry.abi.json
@@ -845,6 +845,69 @@
   },
   {
     "type": "function",
+    "name": "getProvidersByIds",
+    "inputs": [
+      {
+        "name": "providerIds",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "providerInfos",
+        "type": "tuple[]",
+        "internalType": "struct ServiceProviderRegistry.ServiceProviderInfoView[]",
+        "components": [
+          {
+            "name": "providerId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "info",
+            "type": "tuple",
+            "internalType": "struct ServiceProviderRegistryStorage.ServiceProviderInfo",
+            "components": [
+              {
+                "name": "serviceProvider",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "payee",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "description",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "isActive",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "validIds",
+        "type": "bool[]",
+        "internalType": "bool[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "getProvidersByProductType",
     "inputs": [
       {


### PR DESCRIPTION
## Summary
Implements `getProvidersByIds` function to enable batch retrieval of provider information by an array of IDs, addressing the need to efficiently query multiple providers after getting approved provider IDs from WASM storage.

## Changes
- **New function**: `getProvidersByIds(uint256[] calldata providerIds)` 
- **Returns**: Array of `ServiceProviderInfoView` structs and corresponding validity flags
- **Handles invalid IDs**: Returns empty structs with `validIds[i] = false` for non-existent/inactive providers
- **Gas optimized**: Caches storage reads and uses efficient storage references
- **Helper function**: `_getEmptyProviderInfoView()` for consistent empty struct creation

## Use Case
Enables the workflow described in [issue #232](https://github.com/FilOzone/filecoin-services/issues/232):
1. Call WASM storage `getApprovedProviders` to get list of provider IDs
2. Use same list to batch query service registry for provider info
3. Process results with validity flags to handle any invalid IDs

## Testing
- ✅ Comprehensive test coverage for success cases, invalid IDs, and edge cases
- ✅ All existing tests pass

```solidity
function getProvidersByIds(uint256[] calldata providerIds)
    external
    view
    returns (ServiceProviderInfoView[] memory providerInfos, bool[] memory validIds)
```

Closes #232