### PR TITLE
perf(provenPeriods): bitmap

### DIFF
--- a/service_contracts/foundry.toml
+++ b/service_contracts/foundry.toml
@@ -27,6 +27,7 @@ fs_permissions = [{ access = "read", path = "./test" }]
 [lint]
 exclude_lints = [
     "asm-keccak256",
+    "incorrect-shift",
     "mixed-case-function",
     "mixed-case-variable",
     "pascal-case-struct",

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -227,8 +227,8 @@ contract FilecoinWarmStorageService is
     // Commission rate
     uint256 public serviceCommissionBps;
 
-    // Track which proving periods have valid proofs
-    mapping(uint256 dataSetId => mapping(uint256 periodId => bool)) private provenPeriods;
+    // Track which proving periods have valid proofs with bitmap
+    mapping(uint256 dataSetId => mapping(uint256 periodId => uint256)) private provenPeriods;
     // Track when proving was first activated for each data set
     mapping(uint256 dataSetId => uint256) private provingActivationEpoch;
 
@@ -814,7 +814,7 @@ contract FilecoinWarmStorageService is
         }
         provenThisPeriod[dataSetId] = true;
         uint256 currentPeriod = getProvingPeriodForEpoch(dataSetId, block.number);
-        provenPeriods[dataSetId][currentPeriod] = true;
+        provenPeriods[dataSetId][currentPeriod >> 8] |= uint256(1) << (currentPeriod & 255);
     }
 
     // nextProvingPeriod checks for unsubmitted proof in which case it emits a fault event
@@ -889,12 +889,12 @@ contract FilecoinWarmStorageService is
         }
 
         // Record the status of the current/previous proving period that's ending
-        if (provingDeadlines[dataSetId] != NO_PROVING_DEADLINE) {
+        if (provingDeadlines[dataSetId] != NO_PROVING_DEADLINE && provenThisPeriod[dataSetId]) {
             // Determine the period ID that just completed
             uint256 completedPeriodId = getProvingPeriodForEpoch(dataSetId, provingDeadlines[dataSetId] - 1);
 
             // Record whether this period was proven
-            provenPeriods[dataSetId][completedPeriodId] = provenThisPeriod[dataSetId];
+            provenPeriods[dataSetId][completedPeriodId >> 8] |= uint256(1) << (completedPeriodId & 255);
         }
 
         provingDeadlines[dataSetId] = nextDeadline;
@@ -1114,8 +1114,8 @@ contract FilecoinWarmStorageService is
             return provenThisPeriod[dataSetId];
         }
 
-        // For past periods, check the provenPeriods mapping
-        return provenPeriods[dataSetId][periodId];
+        // For past periods, check the provenPeriods bitmapping
+        return 0 != provenPeriods[dataSetId][periodId >> 8] & (uint256(1) << (periodId & 255));
     }
 
     function max(uint256 a, uint256 b) internal pure returns (uint256) {

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -814,7 +814,7 @@ contract FilecoinWarmStorageService is
         }
         provenThisPeriod[dataSetId] = true;
         uint256 currentPeriod = getProvingPeriodForEpoch(dataSetId, block.number);
-        provenPeriods[dataSetId][currentPeriod >> 8] |= uint256(1) << (currentPeriod & 255);
+        provenPeriods[dataSetId][currentPeriod >> 8] |= 1 << (currentPeriod & 255);
     }
 
     // nextProvingPeriod checks for unsubmitted proof in which case it emits a fault event
@@ -894,7 +894,7 @@ contract FilecoinWarmStorageService is
             uint256 completedPeriodId = getProvingPeriodForEpoch(dataSetId, provingDeadlines[dataSetId] - 1);
 
             // Record whether this period was proven
-            provenPeriods[dataSetId][completedPeriodId >> 8] |= uint256(1) << (completedPeriodId & 255);
+            provenPeriods[dataSetId][completedPeriodId >> 8] |= 1 << (completedPeriodId & 255);
         }
 
         provingDeadlines[dataSetId] = nextDeadline;
@@ -1115,7 +1115,7 @@ contract FilecoinWarmStorageService is
         }
 
         // For past periods, check the provenPeriods bitmapping
-        return 0 != provenPeriods[dataSetId][periodId >> 8] & (uint256(1) << (periodId & 255));
+        return 0 != provenPeriods[dataSetId][periodId >> 8] & (1 << (periodId & 255));
     }
 
     function max(uint256 a, uint256 b) internal pure returns (uint256) {

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceLayout.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceLayout.sol
@@ -4,3 +4,23 @@ pragma solidity ^0.8.20;
 // Code generated - DO NOT EDIT.
 // This file is a generated binding and any changes will be lost.
 // Generated with tools/generate_storage_layout.sh
+
+bytes32 constant MAX_PROVING_PERIOD_SLOT = bytes32(uint256(0));
+bytes32 constant CHALLENGE_WINDOW_SIZE_SLOT = bytes32(uint256(1));
+bytes32 constant SERVICE_COMMISSION_BPS_SLOT = bytes32(uint256(2));
+bytes32 constant PROVEN_PERIODS_SLOT = bytes32(uint256(3));
+bytes32 constant PROVING_ACTIVATION_EPOCH_SLOT = bytes32(uint256(4));
+bytes32 constant PROVING_DEADLINES_SLOT = bytes32(uint256(5));
+bytes32 constant PROVEN_THIS_PERIOD_SLOT = bytes32(uint256(6));
+bytes32 constant DATA_SET_INFO_SLOT = bytes32(uint256(7));
+bytes32 constant CLIENT_DATA_SET_IDS_SLOT = bytes32(uint256(8));
+bytes32 constant CLIENT_DATA_SETS_SLOT = bytes32(uint256(9));
+bytes32 constant RAIL_TO_DATA_SET_SLOT = bytes32(uint256(10));
+bytes32 constant DATA_SET_METADATA_SLOT = bytes32(uint256(11));
+bytes32 constant DATA_SET_METADATA_KEYS_SLOT = bytes32(uint256(12));
+bytes32 constant DATA_SET_PIECE_METADATA_SLOT = bytes32(uint256(13));
+bytes32 constant DATA_SET_PIECE_METADATA_KEYS_SLOT = bytes32(uint256(14));
+bytes32 constant APPROVED_PROVIDERS_SLOT = bytes32(uint256(15));
+bytes32 constant APPROVED_PROVIDER_IDS_SLOT = bytes32(uint256(16));
+bytes32 constant VIEW_CONTRACT_ADDRESS_SLOT = bytes32(uint256(17));
+bytes32 constant FIL_BEAM_CONTROLLER_ADDRESS_SLOT = bytes32(uint256(18));

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceLayout.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceLayout.sol
@@ -4,23 +4,3 @@ pragma solidity ^0.8.20;
 // Code generated - DO NOT EDIT.
 // This file is a generated binding and any changes will be lost.
 // Generated with tools/generate_storage_layout.sh
-
-bytes32 constant MAX_PROVING_PERIOD_SLOT = bytes32(uint256(0));
-bytes32 constant CHALLENGE_WINDOW_SIZE_SLOT = bytes32(uint256(1));
-bytes32 constant SERVICE_COMMISSION_BPS_SLOT = bytes32(uint256(2));
-bytes32 constant PROVEN_PERIODS_SLOT = bytes32(uint256(3));
-bytes32 constant PROVING_ACTIVATION_EPOCH_SLOT = bytes32(uint256(4));
-bytes32 constant PROVING_DEADLINES_SLOT = bytes32(uint256(5));
-bytes32 constant PROVEN_THIS_PERIOD_SLOT = bytes32(uint256(6));
-bytes32 constant DATA_SET_INFO_SLOT = bytes32(uint256(7));
-bytes32 constant CLIENT_DATA_SET_IDS_SLOT = bytes32(uint256(8));
-bytes32 constant CLIENT_DATA_SETS_SLOT = bytes32(uint256(9));
-bytes32 constant RAIL_TO_DATA_SET_SLOT = bytes32(uint256(10));
-bytes32 constant DATA_SET_METADATA_SLOT = bytes32(uint256(11));
-bytes32 constant DATA_SET_METADATA_KEYS_SLOT = bytes32(uint256(12));
-bytes32 constant DATA_SET_PIECE_METADATA_SLOT = bytes32(uint256(13));
-bytes32 constant DATA_SET_PIECE_METADATA_KEYS_SLOT = bytes32(uint256(14));
-bytes32 constant APPROVED_PROVIDERS_SLOT = bytes32(uint256(15));
-bytes32 constant APPROVED_PROVIDER_IDS_SLOT = bytes32(uint256(16));
-bytes32 constant VIEW_CONTRACT_ADDRESS_SLOT = bytes32(uint256(17));
-bytes32 constant FIL_BEAM_CONTROLLER_ADDRESS_SLOT = bytes32(uint256(18));

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
@@ -149,9 +149,13 @@ library FilecoinWarmStorageServiceStateInternalLibrary {
         view
         returns (bool)
     {
-        return service.extsload(
-            keccak256(abi.encode(periodId, keccak256(abi.encode(dataSetId, StorageLayout.PROVEN_PERIODS_SLOT))))
-        ) != bytes32(0);
+        return uint256(
+            service.extsload(
+                keccak256(
+                    abi.encode(periodId >> 8, keccak256(abi.encode(dataSetId, StorageLayout.PROVEN_PERIODS_SLOT)))
+                )
+            )
+        ) & (uint256(1) << (periodId & 255)) != 0;
     }
 
     function provingActivationEpoch(FilecoinWarmStorageService service, uint256 dataSetId)

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
@@ -155,7 +155,7 @@ library FilecoinWarmStorageServiceStateInternalLibrary {
                     abi.encode(periodId >> 8, keccak256(abi.encode(dataSetId, StorageLayout.PROVEN_PERIODS_SLOT)))
                 )
             )
-        ) & (uint256(1) << (periodId & 255)) != 0;
+        ) & (1 << (periodId & 255)) != 0;
     }
 
     function provingActivationEpoch(FilecoinWarmStorageService service, uint256 dataSetId)

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceStateLibrary.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceStateLibrary.sol
@@ -151,7 +151,7 @@ library FilecoinWarmStorageServiceStateLibrary {
                     abi.encode(periodId >> 8, keccak256(abi.encode(dataSetId, StorageLayout.PROVEN_PERIODS_SLOT)))
                 )
             )
-        ) & (uint256(1) << (periodId & 255)) != 0;
+        ) & (1 << (periodId & 255)) != 0;
     }
 
     function provingActivationEpoch(FilecoinWarmStorageService service, uint256 dataSetId)

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceStateLibrary.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceStateLibrary.sol
@@ -145,9 +145,13 @@ library FilecoinWarmStorageServiceStateLibrary {
         view
         returns (bool)
     {
-        return service.extsload(
-            keccak256(abi.encode(periodId, keccak256(abi.encode(dataSetId, StorageLayout.PROVEN_PERIODS_SLOT))))
-        ) != bytes32(0);
+        return uint256(
+            service.extsload(
+                keccak256(
+                    abi.encode(periodId >> 8, keccak256(abi.encode(dataSetId, StorageLayout.PROVEN_PERIODS_SLOT)))
+                )
+            )
+        ) & (uint256(1) << (periodId & 255)) != 0;
     }
 
     function provingActivationEpoch(FilecoinWarmStorageService service, uint256 dataSetId)

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -9,7 +9,7 @@ import {Cids} from "@pdp/Cids.sol";
 import {MyERC1967Proxy} from "@pdp/ERC1967Proxy.sol";
 import {SessionKeyRegistry} from "@session-key-registry/SessionKeyRegistry.sol";
 
-import {FilecoinWarmStorageService} from "../src/FilecoinWarmStorageService.sol";
+import {CHALLENGES_PER_PROOF, FilecoinWarmStorageService} from "../src/FilecoinWarmStorageService.sol";
 import {FilecoinWarmStorageServiceStateView} from "../src/FilecoinWarmStorageServiceStateView.sol";
 import {Payments} from "@fws-payments/Payments.sol";
 import {MockERC20, MockPDPVerifier} from "./mocks/SharedMocks.sol";
@@ -1150,6 +1150,36 @@ contract FilecoinWarmStorageServiceTest is Test {
         FilecoinWarmStorageService.DataSetInfoView memory dataSet = viewContract.getDataSet(testDataSetId);
         assertEq(dataSet.serviceProvider, sp2, "Service provider should be updated to new service provider");
         assertEq(dataSet.payee, sp1, "Payee should remain unchanged");
+    }
+
+    function testProvenPeriods() public {
+        uint256 testDataSetId = createDataSetForServiceProviderTest(sp1, client, "Test Data Set");
+        for (uint256 i = 0; i < 2049; i++) {
+            assertFalse(viewContract.provenPeriods(testDataSetId, i));
+        }
+        (
+            uint64 maxProvingPeriod,
+            uint256 challengeWindowSize,
+            uint256 challengesPerProof,
+            uint256 initChallengeWindowStart
+        ) = viewContract.getPDPConfig();
+        vm.startPrank(address(mockPDPVerifier));
+        pdpServiceWithPayments.nextProvingPeriod(testDataSetId, vm.getBlockNumber() + maxProvingPeriod, 100, "");
+        vm.roll(vm.getBlockNumber() + maxProvingPeriod - challengeWindowSize);
+        for (uint256 i = 0; i < 2049; i++) {
+            assertFalse(viewContract.provenPeriods(testDataSetId, i));
+            pdpServiceWithPayments.possessionProven(testDataSetId, 100, 12345, CHALLENGES_PER_PROOF);
+            assertTrue(viewContract.provenPeriods(testDataSetId, i));
+
+            vm.roll(vm.getBlockNumber() + challengeWindowSize);
+            pdpServiceWithPayments.nextProvingPeriod(testDataSetId, vm.getBlockNumber() + maxProvingPeriod, 100, "");
+            vm.roll(vm.getBlockNumber() + maxProvingPeriod - challengeWindowSize);
+        }
+        vm.stopPrank();
+
+        for (uint256 i = 0; i < 2049; i++) {
+            assertTrue(viewContract.provenPeriods(testDataSetId, i));
+        }
     }
 
     // Data Set Payment Termination Tests


### PR DESCRIPTION
Reviewer @rvagg @kubuxu
Closes https://github.com/FilOzone/filecoin-services/issues/257
This should reduce the proof storage growth by a factor of 256.
If the proving period is 1 day, and the deal lasts 1 year, this mapping will use 2 slots instead of 356.
#### Changes
* Change provenPeriods to bitmap