### PR TITLE
announcePlannedUpgrade

### DIFF
--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -151,6 +151,12 @@ contract FilecoinWarmStorageService is
         uint256 epochsPerMonth; // Number of epochs in a month
     }
 
+    // Used for announcing upgrades, packed into one slot
+    struct PlannedUpgrade {
+        address nextImplementation;
+        uint96 afterEpoch;
+    }
+
     // =========================================================================
     // Constants
 
@@ -262,6 +268,10 @@ contract FilecoinWarmStorageService is
     // The address allowed to terminate CDN services
     address private filBeamControllerAddress;
 
+    PlannedUpgrade private nextUpgrade;
+
+    event UpgradeAnnounced(PlannedUpgrade plannedUpgrade);
+
     // =========================================================================
 
     // Modifier to ensure only the PDP verifier contract can call certain functions
@@ -366,7 +376,19 @@ contract FilecoinWarmStorageService is
         serviceCommissionBps = 0; // 0%
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
+    function announcePlannedUpgrade(PlannedUpgrade calldata plannedUpgrade) external onlyOwner {
+        require(plannedUpgrade.nextImplementation.code.length > 3000);
+        require(plannedUpgrade.afterEpoch > block.number);
+        nextUpgrade = plannedUpgrade;
+        emit UpgradeAnnounced(plannedUpgrade);
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {
+        // zero address already checked by ERC1967Utils._setImplementation
+        require(newImplementation == nextUpgrade.nextImplementation);
+        require(block.number >= nextUpgrade.afterEpoch);
+        delete nextUpgrade;
+    }
 
     /**
      * @notice Sets new proving period parameters
@@ -390,9 +412,7 @@ contract FilecoinWarmStorageService is
      * Only callable during proxy upgrade process
      * @param _viewContract Address of the view contract (optional, can be address(0))
      */
-    function migrate(address _viewContract) public onlyProxy reinitializer(4) {
-        require(msg.sender == address(this), Errors.OnlySelf(address(this), msg.sender));
-
+    function migrate(address _viewContract) public onlyProxy onlyOwner reinitializer(4) {
         // Set view contract if provided
         if (_viewContract != address(0)) {
             viewContractAddress = _viewContract;

--- a/service_contracts/src/FilecoinWarmStorageServiceStateView.sol
+++ b/service_contracts/src/FilecoinWarmStorageServiceStateView.sol
@@ -131,6 +131,10 @@ contract FilecoinWarmStorageServiceStateView is IPDPProvingSchedule {
         return service.nextPDPChallengeWindowStart(setId);
     }
 
+    function nextUpgrade() external view returns (address nextImplementation, uint96 afterEpoch) {
+        return service.nextUpgrade();
+    }
+
     function provenPeriods(uint256 dataSetId, uint256 periodId) external view returns (bool) {
         return service.provenPeriods(dataSetId, periodId);
     }

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceLayout.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceLayout.sol
@@ -24,3 +24,4 @@ bytes32 constant APPROVED_PROVIDERS_SLOT = bytes32(uint256(15));
 bytes32 constant APPROVED_PROVIDER_IDS_SLOT = bytes32(uint256(16));
 bytes32 constant VIEW_CONTRACT_ADDRESS_SLOT = bytes32(uint256(17));
 bytes32 constant FIL_BEAM_CONTROLLER_ADDRESS_SLOT = bytes32(uint256(18));
+bytes32 constant NEXT_UPGRADE_SLOT = bytes32(uint256(19));

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
@@ -487,4 +487,20 @@ library FilecoinWarmStorageServiceStateInternalLibrary {
     function filBeamControllerAddress(FilecoinWarmStorageService service) internal view returns (address) {
         return address(uint160(uint256(service.extsload(StorageLayout.FIL_BEAM_CONTROLLER_ADDRESS_SLOT))));
     }
+
+    /**
+     * @notice Get information about the next contract upgrade
+     * @param service The service contract
+     * @return nextImplementation The next code for the contract
+     * @return afterEpoch The earliest the upgrade may complete
+     */
+    function nextUpgrade(FilecoinWarmStorageService service)
+        internal
+        view
+        returns (address nextImplementation, uint96 afterEpoch)
+    {
+        bytes32 upgradeInfo = service.extsload(StorageLayout.NEXT_UPGRADE_SLOT);
+        nextImplementation = address(uint160(uint256(upgradeInfo)));
+        afterEpoch = uint96(uint256(upgradeInfo) >> 160);
+    }
 }

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceStateLibrary.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceStateLibrary.sol
@@ -483,4 +483,20 @@ library FilecoinWarmStorageServiceStateLibrary {
     function filBeamControllerAddress(FilecoinWarmStorageService service) public view returns (address) {
         return address(uint160(uint256(service.extsload(StorageLayout.FIL_BEAM_CONTROLLER_ADDRESS_SLOT))));
     }
+
+    /**
+     * @notice Get information about the next contract upgrade
+     * @param service The service contract
+     * @return nextImplementation The next code for the contract
+     * @return afterEpoch The earliest the upgrade may complete
+     */
+    function nextUpgrade(FilecoinWarmStorageService service)
+        public
+        view
+        returns (address nextImplementation, uint96 afterEpoch)
+    {
+        bytes32 upgradeInfo = service.extsload(StorageLayout.NEXT_UPGRADE_SLOT);
+        nextImplementation = address(uint160(uint256(upgradeInfo)));
+        afterEpoch = uint96(uint256(upgradeInfo) >> 160);
+    }
 }

--- a/service_contracts/tools/announce-planned-upgrade.sh
+++ b/service_contracts/tools/announce-planned-upgrade.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# announce-planned-upgrade.sh: Completes a pending upgrade
+# Required args: RPC_URL, WARM_STORAGE_PROXY_ADDRESS, KEYSTORE, PASSWORD, NEW_WARM_STORAGE_IMPLEMENTATION_ADDRESS, AFTER_EPOCH
+
+if [ -z "$RPC_URL" ]; then
+  echo "Error: RPC_URL is not set"
+  exit 1
+fi
+
+if [ -z "$KEYSTORE" ]; then
+  echo "Error: KEYSTORE is not set"
+  exit 1
+fi
+
+if [ -z "$PASSWORD" ]; then
+  echo "Error: PASSWORD is not set"
+  exit 1
+fi
+
+if [ -z "$CHAIN_ID" ]; then
+  CHAIN_ID=$(cast chain-id --rpc-url "$RPC_URL")
+  if [ -z "$CHAIN_ID" ]; then
+    echo "Error: Failed to detect chain ID from RPC"
+    exit 1
+  fi
+fi
+
+if [ -z "$NEW_WARM_STORAGE_IMPLEMENTATION_ADDRESS" ]; then
+  echo "NEW_WARM_STORAGE_IMPLEMENTATION_ADDRESS is not set"
+  exit 1
+fi
+
+if [ -z "$AFTER_EPOCH" ]; then
+  echo "AFTER_EPOCH is not set"
+  exit 1
+fi
+
+CURRENT_EPOCH=$(cast block-number --rpc-url $RPC_URL 2>/dev/null)
+
+if [ "$CURRENT_EPOCH" -gt "$AFTER_EPOCH" ]; then
+  echo "Already past AFTER_EPOCH ($CURRENT_EPOCH > $AFTER_EPOCH)"
+  exit 1
+else
+  echo "Announcing planned upgrade after $(($AFTER_EPOCH - $CURRENT_EPOCH)) epochs"
+fi
+
+
+ADDR=$(cast wallet address --keystore "$KEYSTORE" --password "$PASSWORD")
+echo "Sending announcement from owner address: $ADDR"
+
+# Get current nonce
+NONCE=$(cast nonce --rpc-url "$RPC_URL" "$ADDR")
+
+if [ -z "$WARM_STORAGE_PROXY_ADDRESS" ]; then
+  echo "Error: WARM_STORAGE_PROXY_ADDRESS is not set"
+  exit 1
+fi
+
+PROXY_OWNER=$(cast call "$WARM_STORAGE_PROXY_ADDRESS" "owner()(address)" --rpc-url "$RPC_URL" 2>/dev/null)
+if [ "$PROXY_OWNER" != "$ADDR" ]; then
+  echo "Supplied KEYSTORE ($ADDR) is not the proxy owner ($PROXY_OWNER)."
+  exit 1
+fi
+
+TX_HASH=$(cast send "$WARM_STORAGE_PROXY_ADDRESS" "announcePlannedUpgrade((address,uint96))" "($NEW_WARM_STORAGE_IMPLEMENTATION_ADDRESS,$AFTER_EPOCH)" \
+  --rpc-url "$RPC_URL" \
+  --keystore "$KEYSTORE" \
+  --password "$PASSWORD" \
+  --nonce "$NONCE" \
+  --chain-id "$CHAIN_ID" \
+  --json | jq -r '.transactionHash')
+
+if [ -z "$TX_HASH" ]; then
+  echo "Error: Failed to send announcePlannedUpgrade transaction"
+fi
+
+echo "announcePlannedUpgrade transaction sent: $TX_HASH"

--- a/service_contracts/tools/deploy-warm-storage-implementation-only.sh
+++ b/service_contracts/tools/deploy-warm-storage-implementation-only.sh
@@ -2,9 +2,6 @@
 # deploy-warm-storage-implementation-only.sh - Deploy only FilecoinWarmStorageService implementation (no proxy)
 # This allows updating an existing proxy to point to the new implementation
 # Assumption: KEYSTORE, PASSWORD, RPC_URL env vars are set
-# Optional: WARM_STORAGE_PROXY_ADDRESS to automatically upgrade the proxy
-# Optional: DEPLOY_VIEW_CONTRACT=true to deploy a new view contract during upgrade
-# Optional: VIEW_CONTRACT_ADDRESS=0x... to use an existing view contract during upgrade
 # Assumption: forge, cast are in the PATH
 # Assumption: called from service_contracts directory so forge paths work out
 
@@ -18,6 +15,15 @@ fi
 if [ -z "$KEYSTORE" ]; then
   echo "Error: KEYSTORE is not set"
   exit 1
+fi
+
+# Auto-detect chain ID from RPC if not already set
+if [ -z "$CHAIN_ID" ]; then
+  CHAIN_ID=$(cast chain-id --rpc-url "$RPC_URL")
+  if [ -z "$CHAIN_ID" ]; then
+    echo "Error: Failed to detect chain ID from RPC"
+    exit 1
+  fi
 fi
 
 # Get deployer address
@@ -71,7 +77,7 @@ echo "  FilBeam Beneficiary Address: $FILBEAM_BENEFICIARY_ADDRESS"
 echo "  ServiceProviderRegistry: $SERVICE_PROVIDER_REGISTRY_PROXY_ADDRESS"
 echo "  SessionKeyRegistry: $SESSION_KEY_REGISTRY_ADDRESS"
 
-WARM_STORAGE_IMPLEMENTATION_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id 314159 src/FilecoinWarmStorageService.sol:FilecoinWarmStorageService --constructor-args $PDP_VERIFIER_ADDRESS $PAYMENTS_CONTRACT_ADDRESS $USDFC_TOKEN_ADDRESS $FILBEAM_BENEFICIARY_ADDRESS $SERVICE_PROVIDER_REGISTRY_PROXY_ADDRESS $SESSION_KEY_REGISTRY_ADDRESS | grep "Deployed to" | awk '{print $3}')
+WARM_STORAGE_IMPLEMENTATION_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --broadcast --nonce $NONCE --chain-id $CHAIN_ID src/FilecoinWarmStorageService.sol:FilecoinWarmStorageService --constructor-args $PDP_VERIFIER_ADDRESS $PAYMENTS_CONTRACT_ADDRESS $USDFC_TOKEN_ADDRESS $FILBEAM_BENEFICIARY_ADDRESS $SERVICE_PROVIDER_REGISTRY_PROXY_ADDRESS $SESSION_KEY_REGISTRY_ADDRESS | grep "Deployed to" | awk '{print $3}')
 
 if [ -z "$WARM_STORAGE_IMPLEMENTATION_ADDRESS" ]; then
     echo "Error: Failed to deploy FilecoinWarmStorageService implementation"
@@ -82,106 +88,3 @@ echo ""
 echo "# DEPLOYMENT COMPLETE"
 echo "FilecoinWarmStorageService Implementation deployed at: $WARM_STORAGE_IMPLEMENTATION_ADDRESS"
 echo ""
-
-# If proxy address is provided, perform the upgrade
-if [ -n "$WARM_STORAGE_PROXY_ADDRESS" ]; then
-    echo "Proxy address provided: $WARM_STORAGE_PROXY_ADDRESS"
-
-    # First check if we're the owner
-    echo "Checking proxy ownership..."
-    PROXY_OWNER=$(cast call "$WARM_STORAGE_PROXY_ADDRESS" "owner()(address)" --rpc-url "$RPC_URL" 2>/dev/null || echo "")
-
-    if [ -z "$PROXY_OWNER" ]; then
-        echo "Warning: Could not determine proxy owner. Attempting upgrade anyway..."
-    else
-        echo "Proxy owner: $PROXY_OWNER"
-        echo "Your address: $ADDR"
-
-        if [ "$PROXY_OWNER" != "$ADDR" ]; then
-            echo
-            echo "⚠️  WARNING: You are not the owner of this proxy!"
-            echo "Only the owner ($PROXY_OWNER) can upgrade this proxy."
-            echo
-            echo "If you need to upgrade, you have these options:"
-            echo "1. Have the owner run this script"
-            echo "2. Have the owner transfer ownership to you first"
-            echo "3. If the owner is a multisig, create a proposal"
-            echo
-            echo "To manually upgrade (as owner):"
-            echo "cast send $WARM_STORAGE_PROXY_ADDRESS \"upgradeTo(address)\" $WARM_STORAGE_IMPLEMENTATION_ADDRESS --rpc-url \$RPC_URL"
-            exit 1
-        fi
-    fi
-
-    echo "Performing proxy upgrade..."
-
-    # Check if we should deploy and set a new view contract
-    if [ -n "$DEPLOY_VIEW_CONTRACT" ] && [ "$DEPLOY_VIEW_CONTRACT" = "true" ]; then
-        echo "Deploying new view contract for upgraded proxy..."
-        NONCE=$(expr $NONCE + "1")
-        export WARM_STORAGE_SERVICE_ADDRESS=$WARM_STORAGE_PROXY_ADDRESS
-        source tools/deploy-warm-storage-view.sh
-        echo "New view contract deployed at: $WARM_STORAGE_VIEW_ADDRESS"
-
-        # Prepare migrate call with view contract address
-        MIGRATE_DATA=$(cast calldata "migrate(address)" "$WARM_STORAGE_VIEW_ADDRESS")
-    else
-        # Check if a view contract address was provided
-        if [ -n "$VIEW_CONTRACT_ADDRESS" ]; then
-            echo "Using provided view contract address: $VIEW_CONTRACT_ADDRESS"
-            MIGRATE_DATA=$(cast calldata "migrate(address)" "$VIEW_CONTRACT_ADDRESS")
-        else
-            echo "No view contract address provided, using address(0) in migrate"
-            MIGRATE_DATA=$(cast calldata "migrate(address)" "0x0000000000000000000000000000000000000000")
-        fi
-    fi
-
-    # Increment nonce for next transaction
-    NONCE=$(expr $NONCE + "1")
-
-    # Call upgradeToAndCall on the proxy with migrate function
-    echo "Upgrading proxy and calling migrate..."
-    TX_HASH=$(cast send "$WARM_STORAGE_PROXY_ADDRESS" "upgradeToAndCall(address,bytes)" "$WARM_STORAGE_IMPLEMENTATION_ADDRESS" "$MIGRATE_DATA" \
-        --rpc-url "$RPC_URL" \
-        --keystore "$KEYSTORE" \
-        --password "$PASSWORD" \
-        --nonce "$NONCE" \
-        --chain-id 314159 \
-        --json | jq -r '.transactionHash')
-
-    if [ -z "$TX_HASH" ]; then
-        echo "Error: Failed to send upgrade transaction"
-        echo "The transaction may have failed due to:"
-        echo "- Insufficient permissions (not owner)"
-        echo "- Proxy is paused or locked"
-        echo "- Implementation address is invalid"
-        exit 1
-    fi
-
-    echo "Upgrade transaction sent: $TX_HASH"
-    echo "Waiting for confirmation..."
-
-    # Wait for transaction receipt
-    cast receipt --rpc-url "$RPC_URL" "$TX_HASH" --confirmations 1 > /dev/null
-
-    # Verify the upgrade by checking the implementation address
-    echo "Verifying upgrade (waiting for Filecoin 30s block time)..."
-    sleep 35
-    NEW_IMPL=$(cast rpc eth_getStorageAt "$WARM_STORAGE_PROXY_ADDRESS" 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc latest --rpc-url "$RPC_URL" | sed 's/"//g' | sed 's/0x000000000000000000000000/0x/')
-
-    if [ "$NEW_IMPL" = "$WARM_STORAGE_IMPLEMENTATION_ADDRESS" ]; then
-        echo "✅ Upgrade successful! Proxy now points to: $WARM_STORAGE_IMPLEMENTATION_ADDRESS"
-    else
-        echo "⚠️  Warning: Could not verify upgrade. Please check manually."
-        echo "Expected: $WARM_STORAGE_IMPLEMENTATION_ADDRESS"
-        echo "Got: $NEW_IMPL"
-    fi
-else
-    echo "No WARM_STORAGE_PROXY_ADDRESS provided. Skipping automatic upgrade."
-    echo ""
-    echo "To upgrade an existing proxy manually:"
-    echo "1. Export the proxy address: export WARM_STORAGE_PROXY_ADDRESS=<your_proxy_address>"
-    echo "2. Run this script again, or"
-    echo "3. Run manually:"
-    echo "   cast send <PROXY_ADDRESS> \"upgradeTo(address)\" $WARM_STORAGE_IMPLEMENTATION_ADDRESS --rpc-url \$RPC_URL --keystore \$KEYSTORE --password \$PASSWORD"
-fi

--- a/service_contracts/tools/upgrade.sh
+++ b/service_contracts/tools/upgrade.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+# upgrade.sh: Completes a pending upgrade
+# Required args: RPC_URL, WARM_STORAGE_PROXY_ADDRESS, KEYSTORE, PASSWORD, NEW_WARM_STORAGE_IMPLEMENTATION_ADDRESS
+# Optional args: NEW_WARM_STORAGE_VIEW_ADDRESS
+# Calculated if unset: CHAIN_ID, WARM_STORAGE_VIEW_ADDRESS
+
+if [ -z "$NEW_WARM_STORAGE_VIEW_ADDRESS" ]; then
+  echo "Warning: NEW_WARM_STORAGE_VIEW_ADDRESS is not set. Keeping previous view contract." 
+fi
+
+if [ -z "$RPC_URL" ]; then
+  echo "Error: RPC_URL is not set"
+  exit 1
+fi
+
+if [ -z "$KEYSTORE" ]; then
+  echo "Error: KEYSTORE is not set"
+  exit 1
+fi
+
+if [ -z "$PASSWORD" ]; then
+  echo "Error: PASSWORD is not set"
+  exit 1
+fi
+
+if [ -z "$CHAIN_ID" ]; then
+  CHAIN_ID=$(cast chain-id --rpc-url "$RPC_URL")
+  if [ -z "$CHAIN_ID" ]; then
+    echo "Error: Failed to detect chain ID from RPC"
+    exit 1
+  fi
+fi
+
+ADDR=$(cast wallet address --keystore "$KEYSTORE" --password "$PASSWORD")
+echo "Using owner address: $ADDR"
+
+# Get current nonce
+NONCE=$(cast nonce --rpc-url "$RPC_URL" "$ADDR")
+
+if [ -z "$WARM_STORAGE_PROXY_ADDRESS" ]; then
+  echo "Error: WARM_STORAGE_PROXY_ADDRESS is not set"
+  exit 1
+fi
+
+PROXY_OWNER=$(cast call "$WARM_STORAGE_PROXY_ADDRESS" "owner()(address)" --rpc-url "$RPC_URL" 2>/dev/null)
+if [ "$PROXY_OWNER" != "$ADDR" ]; then
+  echo "Supplied KEYSTORE ($ADDR) is not the proxy owner ($PROXY_OWNER)."
+  exit 1
+fi
+
+if [ -z "$WARM_STORAGE_VIEW_ADDRESS" ]; then
+  WARM_STORAGE_VIEW_ADDRESS=$(cast call "$WARM_STORAGE_PROXY_ADDRESS" "viewContractAddress()(address)" --rpc-url "$RPC_URL" 2>/dev/null)
+fi
+
+# Get the upgrade plan
+UPGRADE_PLAN=($(cast call "$WARM_STORAGE_VIEW_ADDRESS" "nextUpgrade()(address,uint96)" --rpc-url "$RPC_URL" 2>/dev/null))
+
+PLANNED_WARM_STORAGE_IMPLEMENTATION_ADDRESS=${UPGRADE_PLAN[0]}
+AFTER_EPOCH=${UPGRADE_PLAN[1]}
+
+if [ "$PLANNED_WARM_STORAGE_IMPLEMENTATION_ADDRESS" != "$NEW_WARM_STORAGE_IMPLEMENTATION_ADDRESS" ]; then
+  echo "NEW_WARM_STORAGE_IMPLEMENTATION_ADDRESS ($NEW_WARM_STORAGE_IMPLEMENTATION_ADDRESS) != planned ($PLANNED_WARM_STORAGE_IMPLEMENTATION_ADDRESS)"
+  exit 1
+else
+  echo "Upgrade plan matches ($NEW_WARM_STORAGE_IMPLEMENTATION_ADDRESS)"
+fi
+
+CURRENT_EPOCH=$(cast block-number --rpc-url $RPC_URL 2>/dev/null)
+
+if [ "$CURRENT_EPOCH" -lt "$AFTER_EPOCH" ]; then
+  echo "Not time yet ($CURRENT_EPOCH < $AFTER_EPOCH)"
+  exit 1
+else
+  echo "Upgrade ready ($CURRENT_EPOCH > $AFTER_EPOCH)"
+fi
+
+if [ -n "$NEW_WARM_STORAGE_VIEW_ADDRESS" ]; then
+  echo "Using provided view contract address: $NEW_WARM_STORAGE_VIEW_ADDRESS"
+  MIGRATE_DATA=$(cast calldata "migrate(address)" "$NEW_WARM_STORAGE_VIEW_ADDRESS")
+else
+  echo "Keeping previous view contract address ($WARM_STORAGE_VIEW_ADDRESS)"
+  MIGRATE_DATA=$(cast calldata "migrate(address)" "0x0000000000000000000000000000000000000000")
+fi
+
+# Call upgradeToAndCall on the proxy with migrate function
+echo "Upgrading proxy and calling migrate..."
+TX_HASH=$(cast send "$WARM_STORAGE_PROXY_ADDRESS" "upgradeToAndCall(address,bytes)" "$NEW_WARM_STORAGE_IMPLEMENTATION_ADDRESS" "$MIGRATE_DATA" \
+  --rpc-url "$RPC_URL" \
+  --keystore "$KEYSTORE" \
+  --password "$PASSWORD" \
+  --nonce "$NONCE" \
+  --chain-id $CHAIN_ID \
+  --json | jq -r '.transactionHash')
+
+if [ -z "$TX_HASH" ]; then
+  echo "Error: Failed to send upgrade transaction"
+  echo "The transaction may have failed due to:"
+  echo "- Insufficient permissions (not owner)"
+  echo "- Proxy is paused or locked"
+  echo "- Implementation address is invalid"
+  exit 1
+fi
+
+echo "Upgrade transaction sent: $TX_HASH"
+echo "Waiting for confirmation..."
+
+# Wait for transaction receipt
+cast receipt --rpc-url "$RPC_URL" "$TX_HASH" --confirmations 1 > /dev/null
+
+# Verify the upgrade by checking the implementation address
+echo "Verifying upgrade..."
+NEW_IMPL=$(cast rpc eth_getStorageAt "$WARM_STORAGE_PROXY_ADDRESS" 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc latest --rpc-url "$RPC_URL" | sed 's/"//g' | sed 's/0x000000000000000000000000/0x/')
+
+# Compare to lowercase
+export EXPECTED_IMPL=$(echo $NEW_WARM_STORAGE_IMPLEMENTATION_ADDRESS | tr '[:upper:]' '[:lower:]')
+
+if [ "$NEW_IMPL" = "$EXPECTED_IMPL" ]; then
+    echo "✅ Upgrade successful! Proxy now points to: $NEW_WARM_STORAGE_IMPLEMENTATION_ADDRESS"
+else
+    echo "⚠️  Warning: Could not verify upgrade. Please check manually."
+    echo "Expected: $NEW_WARM_STORAGE_IMPLEMENTATION_ADDRESS"
+    echo "Got: $NEW_IMPL"
+fi


### PR DESCRIPTION

Reviewer @rvagg
Per a discussion with @jennijuju, we want to make the upgrade process more transparent.
This changes upgrades to a two step process.
First, we announce the planned upgrade.
Then, after the designated time, we can complete the upgrade.
The delay gives us time to check the pending implementation address.
I also fix https://github.com/FilOzone/filecoin-services/issues/259 in this change, because I was already adding tests for `upgradeToAndCall`.
#### Test Plan
I tested the new deployment scripts by running them on calibnet.
* [announcePlannedUpgrade](https://calibration.filfox.info/en/message/bafy2bzaceb6vpcsy563vhpwig5g6jy7gb6fr2ssxhjgwiagj7k3vbjrg3dg56?t=3)
* [upgradeToAndCall](https://calibration.filfox.info/en/message/bafy2bzaceadjmlemjyrv7nmwh5lzavdbntjmywvblrzmtuh3wsyldqlvxbcyo?t=3)
#### Changes
* announcePlannedUpgrade
* update _authorizeUpgrade
* new view method for pending upgrade
* make gen
* add and fix tests covering upgradeToAndCall with migrate
* separate announce and upgrade scripts
* update implementation-only script