### PR TITLE
perf: rm railToDataSet mapping for cdn rails

### DIFF
--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -626,7 +626,6 @@ contract FilecoinWarmStorageService is
                 address(this) // controller
             );
             info.cacheMissRailId = cacheMissRailId;
-            railToDataSet[cacheMissRailId] = dataSetId;
             payments.modifyRailLockup(cacheMissRailId, DEFAULT_LOCKUP_PERIOD, DEFAULT_CACHE_MISS_LOCKUP_AMOUNT);
 
             cdnRailId = payments.createRail(
@@ -638,7 +637,6 @@ contract FilecoinWarmStorageService is
                 address(this) // controller
             );
             info.cdnRailId = cdnRailId;
-            railToDataSet[cdnRailId] = dataSetId;
             payments.modifyRailLockup(cdnRailId, DEFAULT_LOCKUP_PERIOD, DEFAULT_CDN_LOCKUP_AMOUNT);
 
             emit CDNPaymentRailsToppedUp(dataSetId, DEFAULT_CDN_LOCKUP_AMOUNT, DEFAULT_CACHE_MISS_LOCKUP_AMOUNT);
@@ -704,10 +702,6 @@ contract FilecoinWarmStorageService is
 
         // Clean up rail mappings
         delete railToDataSet[info.pdpRailId];
-        if (dataSetHasCDNMetadataKey(dataSetId)) {
-            delete railToDataSet[info.cacheMissRailId];
-            delete railToDataSet[info.cdnRailId];
-        }
 
         // Clean up metadata mappings
         string[] storage metadataKeys = dataSetMetadataKeys[dataSetId];

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -605,7 +605,6 @@ contract FilecoinWarmStorageServiceTest is Test {
         assertEq(clientDataSetIds[0], newDataSetId);
 
         assertEq(viewContract.railToDataSet(pdpRailId), newDataSetId);
-        assertEq(viewContract.railToDataSet(cdnRailId), newDataSetId);
 
         // Verify data set info
         FilecoinWarmStorageService.DataSetInfoView memory dataSetInfo = viewContract.getDataSet(newDataSetId);


### PR DESCRIPTION
Reviewer @rvagg
CC @Chaitu-Tatipamula
Closes #277
Resolves https://github.com/FilOzone/filecoin-services/pull/269#pullrequestreview-3320867878
We are able to remove this mapping because it is only used by IValidator functions, and, since https://github.com/FilOzone/filecoin-services/pull/237, FWSS is not the IValidator for these rails.

This reduces codesize 23,991 -> 23,898 (-93)
#### Changes
* remove railToDataSet mapping for both cdn rails