### PR TITLE
chore(tools): remaining ETH_KEYSTORE, ETH_RPC_URL, and CHAIN changes

### DIFF
--- a/service_contracts/tools/README.md
+++ b/service_contracts/tools/README.md
@@ -91,9 +91,9 @@ export CHALLENGE_WINDOW_SIZE="30"      # 30 epochs for calibnet, 60 for mainnet
 ### Deploy FilecoinWarmStorageService Only
 
 ```bash
-export KEYSTORE="/path/to/keystore.json"
+export ETH_KEYSTORE="/path/to/keystore.json"
 export PASSWORD="your-password"
-export RPC_URL="https://api.calibration.node.glif.io/rpc/v1"
+export ETH_RPC_URL="https://api.calibration.node.glif.io/rpc/v1"
 export PDP_VERIFIER_ADDRESS="0x123..."
 export PAYMENTS_CONTRACT_ADDRESS="0x456..."
 
@@ -103,9 +103,9 @@ export PAYMENTS_CONTRACT_ADDRESS="0x456..."
 ### Upgrade Existing Contract
 
 ```bash
-export KEYSTORE="/path/to/keystore.json"
+export ETH_KEYSTORE="/path/to/keystore.json"
 export PASSWORD="your-password"
-export RPC_URL="https://api.calibration.node.glif.io/rpc/v1"
+export ETH_RPC_URL="https://api.calibration.node.glif.io/rpc/v1"
 export WARM_STORAGE_SERVICE_PROXY_ADDRESS="0x789..."
 
 # Optional: Custom proving periods

--- a/service_contracts/tools/create_data_set_with_payments.sh
+++ b/service_contracts/tools/create_data_set_with_payments.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # Check if required environment variables are set
-if [ -z "$RPC_URL" ]; then
-  echo "Error: RPC_URL is not set. Please set it to a valid Calibration testnet endpoint."
-  echo "Example: export RPC_URL=https://api.calibration.node.glif.io/rpc/v1"
+if [ -z "$ETH_RPC_URL" ]; then
+  echo "Error: ETH_RPC_URL is not set. Please set it to a valid Calibration testnet endpoint."
+  echo "Example: export ETH_RPC_URL=https://api.calibration.node.glif.io/rpc/v1"
   exit 1
 fi
 
@@ -13,7 +13,7 @@ if [ -z "$ETH_KEYSTORE" ]; then
 fi
 
 # Print the RPC URL being used
-echo "Using RPC URL: $RPC_URL"
+echo "Using RPC URL: $ETH_RPC_URL"
 
 # Set the contract addresses
 PDP_VERIFIER_PROXY="0xC1Ded64818C89d12D624aF40E8E56dfe70F3fd3c"
@@ -26,7 +26,7 @@ MY_ADDRESS=$(cast wallet address --password "$PASSWORD")
 echo "Using wallet address: $MY_ADDRESS"
 
 # Get current nonce
-CURRENT_NONCE=$(cast nonce --rpc-url "$RPC_URL" "$MY_ADDRESS")
+CURRENT_NONCE=$(cast nonce "$MY_ADDRESS")
 echo "Current nonce: $CURRENT_NONCE"
 
 # Prepare the extraData for data set creation (metadata and payer address)
@@ -36,17 +36,17 @@ EXTRA_DATA=$(cast abi-encode "f((string,address))" "($METADATA,$MY_ADDRESS)")
 
 # Check USDFC balance before
 echo "Checking USDFC balance before approval and data set creation..."
-BALANCE_BEFORE=$(cast call --rpc-url "$RPC_URL" $USDFC_TOKEN "balanceOf(address)" "$MY_ADDRESS")
+BALANCE_BEFORE=$(cast call $USDFC_TOKEN "balanceOf(address)" "$MY_ADDRESS")
 echo "USDFC Balance before: $BALANCE_BEFORE"
 
 # Check Payments contract internal balance before
 echo "Checking Payments contract internal balance before..."
-ACCOUNT_INFO_BEFORE=$(cast call --rpc-url "$RPC_URL" $PAYMENTS_PROXY "accounts(address,address)" $USDFC_TOKEN "$MY_ADDRESS")
+ACCOUNT_INFO_BEFORE=$(cast call $PAYMENTS_PROXY "accounts(address,address)" $USDFC_TOKEN "$MY_ADDRESS")
 echo "Internal account balance before: $ACCOUNT_INFO_BEFORE"
 
 # First, deposit USDFC into the Payments contract (this step is crucial!)
 echo "Approving USDFC to be spent by Payments contract..."
-APPROVE_TX=$(cast send --rpc-url "$RPC_URL" --password "$PASSWORD" \
+APPROVE_TX=$(cast send --password "$PASSWORD" \
     $USDFC_TOKEN "approve(address,uint256)" $PAYMENTS_PROXY "1000000000000000000" \
     --gas-limit 3000000000 --nonce "$CURRENT_NONCE")
 echo "Approval TX: $APPROVE_TX"
@@ -61,7 +61,7 @@ echo "Next nonce: $CURRENT_NONCE"
 
 # Actually deposit funds into the Payments contract
 echo "Depositing USDFC into the Payments contract..."
-DEPOSIT_TX=$(cast send --rpc-url "$RPC_URL" --password "$PASSWORD" \
+DEPOSIT_TX=$(cast send --password "$PASSWORD" \
     $PAYMENTS_PROXY "deposit(address,address,uint256)" \
     $USDFC_TOKEN "$MY_ADDRESS" "1000000000000000000" \
     --gas-limit 3000000000 --nonce $CURRENT_NONCE)
@@ -77,12 +77,12 @@ echo "Next nonce: $CURRENT_NONCE"
 
 # Check Payments contract internal balance after deposit
 echo "Checking Payments contract internal balance after deposit..."
-ACCOUNT_INFO_AFTER_DEPOSIT=$(cast call --rpc-url "$RPC_URL" $PAYMENTS_PROXY "accounts(address,address)" $USDFC_TOKEN "$MY_ADDRESS")
+ACCOUNT_INFO_AFTER_DEPOSIT=$(cast call $PAYMENTS_PROXY "accounts(address,address)" $USDFC_TOKEN "$MY_ADDRESS")
 echo "Internal account balance after deposit: $ACCOUNT_INFO_AFTER_DEPOSIT"
 
 # Then set operator approval in the Payments contract for the PDP service
 echo "Setting operator approval for the PDP service..."
-OPERATOR_TX=$(cast send --rpc-url "$RPC_URL" --password "$PASSWORD" \
+OPERATOR_TX=$(cast send --password "$PASSWORD" \
     $PAYMENTS_PROXY "setOperatorApproval(address,address,bool,uint256,uint256)" \
     $USDFC_TOKEN $PDP_SERVICE_PROXY true "1000000000000000000" "1000000000000000000" \
     --gas-limit 3000000000 --nonce $CURRENT_NONCE)
@@ -99,7 +99,7 @@ echo "Next nonce: $CURRENT_NONCE"
 # Create the data set
 echo "Creating data set..."
 CALLDATA=$(cast calldata "createDataSet(address,bytes)" $PDP_SERVICE_PROXY "$EXTRA_DATA")
-CREATE_TX=$(cast send --rpc-url "$RPC_URL" --password "$PASSWORD" \
+CREATE_TX=$(cast send --password "$PASSWORD" \
     $PDP_VERIFIER_PROXY "$CALLDATA" --value "100000000000000000" --gas-limit 3000000000 --nonce $CURRENT_NONCE)
 echo "Create data set TX: $CREATE_TX"
 
@@ -110,7 +110,7 @@ sleep 15
 # Get the latest data set ID and rail ID
 echo "Getting the latest data set ID and rail ID..."
 # Extract the DataSetRailsCreated event to get the IDs
-LATEST_EVENTS=$(cast logs --rpc-url "$RPC_URL" --from-block "latest-50" --to-block latest $PDP_SERVICE_PROXY)
+LATEST_EVENTS=$(cast logs --from-block "latest-50" --to-block latest $PDP_SERVICE_PROXY)
 DATASET_ID=$(echo "$LATEST_EVENTS" | grep "DataSetRailsCreated" | tail -1 | cut -d' ' -f3)
 PDP_RAIL_ID=$(echo "$LATEST_EVENTS" | grep "DataSetRailsCreated" | tail -1 | cut -d' ' -f4)
 echo "Latest DataSet ID: $DATASET_ID"
@@ -118,18 +118,18 @@ echo "Rail ID: $PDP_RAIL_ID"
 
 # Check USDFC balance after
 echo "Checking USDFC balance after data set creation..."
-BALANCE_AFTER=$(cast call --rpc-url "$RPC_URL" $USDFC_TOKEN "balanceOf(address)" "$MY_ADDRESS")
+BALANCE_AFTER=$(cast call $USDFC_TOKEN "balanceOf(address)" "$MY_ADDRESS")
 echo "USDFC Balance after: $BALANCE_AFTER"
 
 # Check Payments contract internal balance after data set creation
 echo "Checking Payments contract internal balance after data set creation..."
-ACCOUNT_INFO_AFTER=$(cast call --rpc-url "$RPC_URL" $PAYMENTS_PROXY "accounts(address,address)" $USDFC_TOKEN "$MY_ADDRESS")
+ACCOUNT_INFO_AFTER=$(cast call $PAYMENTS_PROXY "accounts(address,address)" $USDFC_TOKEN "$MY_ADDRESS")
 echo "Payer internal account balance after: $ACCOUNT_INFO_AFTER"
 
 # Get the rail information to check who the payee is
 echo "Getting pdp rail information..."
 if [ -n "$PDP_RAIL_ID" ]; then
-    RAIL_INFO=$(cast call --rpc-url "$RPC_URL" $PAYMENTS_PROXY "getRail(uint256)" "$PDP_RAIL_ID")
+    RAIL_INFO=$(cast call $PAYMENTS_PROXY "getRail(uint256)" "$PDP_RAIL_ID")
     echo "PDP rail info: $RAIL_INFO"
     PAYEE_ADDRESS=$(echo "$RAIL_INFO" | grep -A2 "to:" | tail -1 | tr -d ' ')
     echo "Payee address from rail: $PAYEE_ADDRESS"
@@ -137,7 +137,7 @@ if [ -n "$PDP_RAIL_ID" ]; then
     # Check payee's internal balance
     if [ -n "$PAYEE_ADDRESS" ]; then
         echo "Checking payee's internal balance in Payments contract..."
-        PAYEE_BALANCE=$(cast call --rpc-url "$RPC_URL" $PAYMENTS_PROXY "accounts(address,address)" $USDFC_TOKEN "$PAYEE_ADDRESS")
+        PAYEE_BALANCE=$(cast call $PAYMENTS_PROXY "accounts(address,address)" $USDFC_TOKEN "$PAYEE_ADDRESS")
         echo "Payee internal balance: $PAYEE_BALANCE"
     else
         echo "Could not determine payee address"

--- a/service_contracts/tools/deploy-all-warm-storage.sh
+++ b/service_contracts/tools/deploy-all-warm-storage.sh
@@ -1,8 +1,8 @@
 #! /bin/bash
 # deploy-all-warm-storage deploys the PDP verifier, Payments contract, and Warm Storage service
 # Auto-detects network based on RPC chain ID and sets appropriate configuration
-# Assumption: KEYSTORE, PASSWORD, RPC_URL env vars are set to an appropriate eth keystore path and password
-# and to a valid RPC_URL for the target network.
+# Assumption: KEYSTORE, PASSWORD, ETH_RPC_URL env vars are set to an appropriate eth keystore path and password
+# and to a valid ETH_RPC_URL for the target network.
 # Assumption: forge, cast, jq are in the PATH
 # Assumption: called from contracts directory so forge paths work out
 #

--- a/service_contracts/tools/deploy-registry-calibnet.sh
+++ b/service_contracts/tools/deploy-registry-calibnet.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # deploy-registry-calibnet deploys the Service Provider Registry contract to calibration net
-# Assumption: ETH_KEYSTORE, PASSWORD, RPC_URL env vars are set to an appropriate eth keystore path and password
-# and to a valid RPC_URL for the calibnet.
+# Assumption: ETH_KEYSTORE, PASSWORD, ETH_RPC_URL env vars are set to an appropriate eth keystore path and password
+# and to a valid ETH_RPC_URL for the calibnet.
 # Assumption: forge, cast, jq are in the PATH
 # Assumption: called from contracts directory so forge paths work out
 #
@@ -89,14 +89,14 @@ else
 fi
 
 # Get contract version (this should be used instead of hardcoded version)
-CONTRACT_VERSION=$(cast call --rpc-url "$RPC_URL" $REGISTRY_PROXY_ADDRESS "VERSION()(string)")
+CONTRACT_VERSION=$(cast call $REGISTRY_PROXY_ADDRESS "VERSION()(string)")
 if [ -z "$CONTRACT_VERSION" ]; then
     echo "Warning: Could not retrieve contract version"
     CONTRACT_VERSION="Unknown"
 fi
 
 # Get contract version (this should be used instead of hardcoded version)
-CONTRACT_VERSION=$(cast call --rpc-url "$RPC_URL" $REGISTRY_PROXY_ADDRESS "VERSION()(string)")
+CONTRACT_VERSION=$(cast call $REGISTRY_PROXY_ADDRESS "VERSION()(string)")
 if [ -z "$CONTRACT_VERSION" ]; then
     echo "Warning: Could not retrieve contract version"
     CONTRACT_VERSION="Unknown"

--- a/service_contracts/tools/deploy-session-key-registry.sh
+++ b/service_contracts/tools/deploy-session-key-registry.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # env params:
-# RPC_URL
+# ETH_RPC_URL
 # ETH_KEYSTORE
 # PASSWORD
 

--- a/service_contracts/tools/deploy-warm-storage-calibnet.sh
+++ b/service_contracts/tools/deploy-warm-storage-calibnet.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 # deploy-warm-storage-calibnet deploys the Warm Storage service contract to calibration net
-# Assumption: ETH_KEYSTORE, PASSWORD, RPC_URL env vars are set to an appropriate eth keystore path and password
-# and to a valid RPC_URL for the calibnet.
+# Assumption: ETH_KEYSTORE, PASSWORD, ETH_RPC_URL env vars are set to an appropriate eth keystore path and password
+# and to a valid ETH_RPC_URL for the calibnet.
 # Assumption: forge, cast, jq are in the PATH
 # Assumption: called from contracts directory so forge paths work out
 #

--- a/service_contracts/tools/deploy-warm-storage-implementation-only.sh
+++ b/service_contracts/tools/deploy-warm-storage-implementation-only.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # deploy-warm-storage-implementation-only.sh - Deploy only FilecoinWarmStorageService implementation (no proxy)
 # This allows updating an existing proxy to point to the new implementation
-# Assumption: ETH_KEYSTORE, PASSWORD, RPC_URL env vars are set
+# Assumption: ETH_KEYSTORE, PASSWORD, ETH_RPC_URL env vars are set
 # Assumption: forge, cast are in the PATH
 # Assumption: called from service_contracts directory so forge paths work out
 

--- a/service_contracts/tools/deploy-warm-storage-view.sh
+++ b/service_contracts/tools/deploy-warm-storage-view.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # env params:
-# RPC_URL
+# ETH_RPC_URL
 # WARM_STORAGE_SERVICE_ADDRESS
 # ETH_KEYSTORE
 # PASSWORD

--- a/service_contracts/tools/set-warm-storage-view.sh
+++ b/service_contracts/tools/set-warm-storage-view.sh
@@ -4,21 +4,21 @@
 # with clean output (suppresses verbose transaction details)
 #
 # Environment variables required:
-# - RPC_URL: RPC endpoint URL
+# - ETH_RPC_URL: RPC endpoint URL
 # - WARM_STORAGE_SERVICE_ADDRESS: Address of the deployed FilecoinWarmStorageService proxy
 # - WARM_STORAGE_VIEW_ADDRESS: Address of the deployed FilecoinWarmStorageServiceStateView
 # - ETH_KEYSTORE: Path to keystore file
 # - PASSWORD: Keystore password
 # - NONCE: Transaction nonce (optional, will fetch if not provided)
 
-if [ -z "$RPC_URL" ]; then
-  echo "Error: RPC_URL is not set"
+if [ -z "$ETH_RPC_URL" ]; then
+  echo "Error: ETH_RPC_URL is not set"
   exit 1
 fi
 
 # Auto-detect chain ID from RPC if not already set
 if [ -z "$CHAIN" ]; then
-  CHAIN=$(cast chain-id --rpc-url "$RPC_URL")
+  CHAIN=$(cast chain-id)
   if [ -z "$CHAIN" ]; then
     echo "Error: Failed to detect chain ID from RPC"
     exit 1
@@ -45,13 +45,13 @@ ADDR=$(cast wallet address --password "$PASSWORD")
 
 # Get nonce if not provided
 if [ -z "$NONCE" ]; then
-  NONCE="$(cast nonce --rpc-url "$RPC_URL" "$ADDR")"
+  NONCE="$(cast nonce "$ADDR")"
 fi
 
 echo "Setting view contract address on FilecoinWarmStorageService..."
 
 # Execute transaction and capture output, only show errors if it fails
-TX_OUTPUT=$(cast send --rpc-url "$RPC_URL" --password "$PASSWORD" --nonce $NONCE --chain-id $CHAIN $WARM_STORAGE_SERVICE_ADDRESS "setViewContract(address)" $WARM_STORAGE_VIEW_ADDRESS 2>&1)
+TX_OUTPUT=$(cast send --password "$PASSWORD" --nonce $NONCE $WARM_STORAGE_SERVICE_ADDRESS "setViewContract(address)" $WARM_STORAGE_VIEW_ADDRESS 2>&1)
 
 if [ $? -eq 0 ]; then
     echo "View contract address set successfully"

--- a/service_contracts/tools/upgrade.sh
+++ b/service_contracts/tools/upgrade.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # upgrade.sh: Completes a pending upgrade
-# Required args: RPC_URL, WARM_STORAGE_PROXY_ADDRESS, ETH_KEYSTORE, PASSWORD, NEW_WARM_STORAGE_IMPLEMENTATION_ADDRESS
+# Required args: ETH_RPC_URL, WARM_STORAGE_PROXY_ADDRESS, ETH_KEYSTORE, PASSWORD, NEW_WARM_STORAGE_IMPLEMENTATION_ADDRESS
 # Optional args: NEW_WARM_STORAGE_VIEW_ADDRESS
 # Calculated if unset: CHAIN, WARM_STORAGE_VIEW_ADDRESS
 
@@ -9,8 +9,8 @@ if [ -z "$NEW_WARM_STORAGE_VIEW_ADDRESS" ]; then
   echo "Warning: NEW_WARM_STORAGE_VIEW_ADDRESS is not set. Keeping previous view contract." 
 fi
 
-if [ -z "$RPC_URL" ]; then
-  echo "Error: RPC_URL is not set"
+if [ -z "$ETH_RPC_URL" ]; then
+  echo "Error: ETH_RPC_URL is not set"
   exit 1
 fi
 
@@ -25,7 +25,7 @@ if [ -z "$PASSWORD" ]; then
 fi
 
 if [ -z "$CHAIN" ]; then
-  CHAIN=$(cast chain-id --rpc-url "$RPC_URL")
+  CHAIN=$(cast chain-id")
   if [ -z "$CHAIN" ]; then
     echo "Error: Failed to detect chain ID from RPC"
     exit 1
@@ -36,25 +36,25 @@ ADDR=$(cast wallet address --password "$PASSWORD")
 echo "Using owner address: $ADDR"
 
 # Get current nonce
-NONCE=$(cast nonce --rpc-url "$RPC_URL" "$ADDR")
+NONCE=$(cast nonce "$ADDR")
 
 if [ -z "$WARM_STORAGE_PROXY_ADDRESS" ]; then
   echo "Error: WARM_STORAGE_PROXY_ADDRESS is not set"
   exit 1
 fi
 
-PROXY_OWNER=$(cast call "$WARM_STORAGE_PROXY_ADDRESS" "owner()(address)" --rpc-url "$RPC_URL" 2>/dev/null)
+PROXY_OWNER=$(cast call "$WARM_STORAGE_PROXY_ADDRESS" "owner()(address)" 2>/dev/null)
 if [ "$PROXY_OWNER" != "$ADDR" ]; then
   echo "Supplied ETH_KEYSTORE ($ADDR) is not the proxy owner ($PROXY_OWNER)."
   exit 1
 fi
 
 if [ -z "$WARM_STORAGE_VIEW_ADDRESS" ]; then
-  WARM_STORAGE_VIEW_ADDRESS=$(cast call "$WARM_STORAGE_PROXY_ADDRESS" "viewContractAddress()(address)" --rpc-url "$RPC_URL" 2>/dev/null)
+  WARM_STORAGE_VIEW_ADDRESS=$(cast call "$WARM_STORAGE_PROXY_ADDRESS" "viewContractAddress()(address)" 2>/dev/null)
 fi
 
 # Get the upgrade plan
-UPGRADE_PLAN=($(cast call "$WARM_STORAGE_VIEW_ADDRESS" "nextUpgrade()(address,uint96)" --rpc-url "$RPC_URL" 2>/dev/null))
+UPGRADE_PLAN=($(cast call "$WARM_STORAGE_VIEW_ADDRESS" "nextUpgrade()(address,uint96)" 2>/dev/null))
 
 PLANNED_WARM_STORAGE_IMPLEMENTATION_ADDRESS=${UPGRADE_PLAN[0]}
 AFTER_EPOCH=${UPGRADE_PLAN[1]}
@@ -66,7 +66,7 @@ else
   echo "Upgrade plan matches ($NEW_WARM_STORAGE_IMPLEMENTATION_ADDRESS)"
 fi
 
-CURRENT_EPOCH=$(cast block-number --rpc-url $RPC_URL 2>/dev/null)
+CURRENT_EPOCH=$(cast block-number 2>/dev/null)
 
 if [ "$CURRENT_EPOCH" -lt "$AFTER_EPOCH" ]; then
   echo "Not time yet ($CURRENT_EPOCH < $AFTER_EPOCH)"
@@ -86,7 +86,6 @@ fi
 # Call upgradeToAndCall on the proxy with migrate function
 echo "Upgrading proxy and calling migrate..."
 TX_HASH=$(cast send "$WARM_STORAGE_PROXY_ADDRESS" "upgradeToAndCall(address,bytes)" "$NEW_WARM_STORAGE_IMPLEMENTATION_ADDRESS" "$MIGRATE_DATA" \
-  --rpc-url "$RPC_URL" \
   --password "$PASSWORD" \
   --nonce "$NONCE" \
   --json | jq -r '.transactionHash')
@@ -104,11 +103,11 @@ echo "Upgrade transaction sent: $TX_HASH"
 echo "Waiting for confirmation..."
 
 # Wait for transaction receipt
-cast receipt --rpc-url "$RPC_URL" "$TX_HASH" --confirmations 1 > /dev/null
+cast receipt "$TX_HASH" --confirmations 1 > /dev/null
 
 # Verify the upgrade by checking the implementation address
 echo "Verifying upgrade..."
-NEW_IMPL=$(cast rpc eth_getStorageAt "$WARM_STORAGE_PROXY_ADDRESS" 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc latest --rpc-url "$RPC_URL" | sed 's/"//g' | sed 's/0x000000000000000000000000/0x/')
+NEW_IMPL=$(cast rpc eth_getStorageAt "$WARM_STORAGE_PROXY_ADDRESS" 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc latest | sed 's/"//g' | sed 's/0x000000000000000000000000/0x/')
 
 # Compare to lowercase
 export EXPECTED_IMPL=$(echo $NEW_WARM_STORAGE_IMPLEMENTATION_ADDRESS | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION

Reviewer @DarkLord017 @rvagg
In #272 we switched the env var from KEYSTORE to ETH_KEYSTORE, RPC_URL to ETH_RPC_URL, and CHAIN_ID to CHAIN because `forge` and `cast` accept these parameters via environment variables without supplying them in the argv.
Some of these were missed during the change, possibly due to merge conflicts.
I also update some of the documentation.
#### Changes
* CHAIN_ID -> CHAIN
* KEYSTORE -> ETH_KEYSTORE
* RPC_URL -> ETH_RPC_URL