### PR TITLE
refactor(subgraph): use productData from events directly

### DIFF
--- a/subgraph/src/service-provider-registry.ts
+++ b/subgraph/src/service-provider-registry.ts
@@ -9,7 +9,7 @@ import {
 } from "../generated/ServiceProviderRegistry/ServiceProviderRegistry";
 import { Provider, ProviderProduct } from "../generated/schema";
 import { BIGINT_ONE } from "./utils/constants";
-import { getProviderProductData, getServiceProviderInfo } from "./utils/contract-calls";
+import { getServiceProviderInfo } from "./utils/contract-calls";
 import { decodePDPOfferingData } from "./utils/decoders";
 import { createProviderProduct, initiateProvider } from "./utils/entity";
 import { getProviderProductEntityId } from "./utils/keys";
@@ -99,9 +99,9 @@ export function handleProductAdded(event: ProductAddedEvent): void {
  * @param event The ProductUpdated event.
  */
 export function handleProductUpdated(event: ProductUpdatedEvent): void {
-  const providerId = event.params.providerId;
   const productType = event.params.productType;
   const serviceProvider = event.params.serviceProvider;
+  const productData = event.params.productData;
   const capabilityKeys = event.params.capabilityKeys;
   const capabilityValues = event.params.capabilityValues;
 
@@ -114,7 +114,6 @@ export function handleProductUpdated(event: ProductUpdatedEvent): void {
     return;
   }
 
-  const productData = getProviderProductData(event.address, providerId, productType);
   const decodedProductData = decodePDPOfferingData(productData);
 
   providerProduct.capabilityKeys = capabilityKeys;

--- a/subgraph/src/utils/contract-calls.ts
+++ b/subgraph/src/utils/contract-calls.ts
@@ -22,19 +22,6 @@ export function getServiceProviderInfo(registryAddress: Address, providerId: Big
   );
 }
 
-export function getProviderProductData(registryAddress: Address, providerId: BigInt, productType: number): Bytes {
-  const serviceProviderRegistryInstance = ServiceProviderRegistry.bind(registryAddress);
-
-  const productDataTry = serviceProviderRegistryInstance.try_getProduct(providerId, i32(productType));
-
-  if (productDataTry.reverted) {
-    log.warning("getProviderProductData: contract call reverted for providerId: {}", [providerId.toString()]);
-    return Bytes.empty();
-  }
-
-  return productDataTry.value.getProductData();
-}
-
 export function getPieceCidData(verifierAddress: Address, setId: BigInt, pieceId: BigInt): Bytes {
   const pdpVerifierInstance = PDPVerifier.bind(verifierAddress);
 

--- a/subgraph/src/utils/entity.ts
+++ b/subgraph/src/utils/entity.ts
@@ -4,7 +4,6 @@ import { ProductAdded as ProductAddedEvent } from "../../generated/ServiceProvid
 import { BIGINT_ZERO, BIGINT_ONE, ContractAddresses, LeafSize } from "./constants";
 import { ProviderStatus } from "./types";
 import { getProviderProductEntityId, getPieceEntityId, getDataSetEntityId } from "./keys";
-import { getProviderProductData } from "./contract-calls";
 import { decodePDPOfferingData } from "./decoders";
 import { validateCommPv2, unpaddedSize } from "./cid";
 
@@ -42,16 +41,14 @@ export function createRails(
 }
 
 export function createProviderProduct(event: ProductAddedEvent): void {
-  const providerId = event.params.providerId;
   const productType = event.params.productType;
   const serviceProvider = event.params.serviceProvider;
+  const productData = event.params.productData;
   const capabilityKeys = event.params.capabilityKeys;
   const capabilityValues = event.params.capabilityValues;
 
   const productId = getProviderProductEntityId(serviceProvider, productType);
   const providerProduct = new ProviderProduct(productId);
-
-  const productData = getProviderProductData(event.address, providerId, productType);
 
   providerProduct.provider = serviceProvider;
   providerProduct.productData = productData;


### PR DESCRIPTION
changes

- removed redundant contract calls to get product data
- use product data from events directly