### PR TITLE
feat: floor price set to the 0.06 USDFC/month

### DIFF
--- a/service_contracts/abi/FilecoinWarmStorageService.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageService.abi.json
@@ -101,7 +101,7 @@
   },
   {
     "type": "function",
-    "name": "calculateRatesPerEpoch",
+    "name": "calculateRatePerEpoch",
     "inputs": [
       {
         "name": "totalBytes",

--- a/service_contracts/abi/FilecoinWarmStorageService.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageService.abi.json
@@ -1709,6 +1709,94 @@
   },
   {
     "type": "error",
+    "name": "InsufficientLockupAllowance",
+    "inputs": [
+      {
+        "name": "payer",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "lockupAllowance",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "lockupUsage",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "minimumLockupRequired",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InsufficientMaxLockupPeriod",
+    "inputs": [
+      {
+        "name": "payer",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "maxLockupPeriod",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "requiredLockupPeriod",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InsufficientRateAllowance",
+    "inputs": [
+      {
+        "name": "payer",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "rateAllowance",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "rateUsage",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "minimumRateRequired",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
     "name": "InvalidChallengeCount",
     "inputs": [
       {
@@ -1978,6 +2066,22 @@
       },
       {
         "name": "actual",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "OperatorNotApproved",
+    "inputs": [
+      {
+        "name": "payer",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "operator",
         "type": "address",
         "internalType": "address"
       }

--- a/service_contracts/abi/FilecoinWarmStorageService.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageService.abi.json
@@ -357,6 +357,11 @@
             "name": "epochsPerMonth",
             "type": "uint256",
             "internalType": "uint256"
+          },
+          {
+            "name": "minimumPricePerMonth",
+            "type": "uint256",
+            "internalType": "uint256"
           }
         ]
       }
@@ -1676,6 +1681,27 @@
     "inputs": [
       {
         "name": "dataSetId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InsufficientFundsForMinimumRate",
+    "inputs": [
+      {
+        "name": "payer",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "minimumRequired",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "available",
         "type": "uint256",
         "internalType": "uint256"
       }

--- a/service_contracts/src/Errors.sol
+++ b/service_contracts/src/Errors.sol
@@ -292,4 +292,38 @@ library Errors {
     /// @param minimumRequired The minimum lockup required to cover the minimum storage rate
     /// @param available The available funds in the payer's account
     error InsufficientFundsForMinimumRate(address payer, uint256 minimumRequired, uint256 available);
+
+    /// @notice Operator is not approved for the payer
+    /// @param payer The payer address
+    /// @param operator The operator address (warm storage service)
+    error OperatorNotApproved(address payer, address operator);
+
+    /// @notice Operator has insufficient rate allowance for the minimum storage rate
+    /// @param payer The payer address
+    /// @param operator The operator address (warm storage service)
+    /// @param rateAllowance The total rate allowance approved
+    /// @param rateUsage The current rate usage
+    /// @param minimumRateRequired The minimum rate required per epoch
+    error InsufficientRateAllowance(
+        address payer, address operator, uint256 rateAllowance, uint256 rateUsage, uint256 minimumRateRequired
+    );
+
+    /// @notice Operator has insufficient lockup allowance for the minimum lockup
+    /// @param payer The payer address
+    /// @param operator The operator address (warm storage service)
+    /// @param lockupAllowance The total lockup allowance approved
+    /// @param lockupUsage The current lockup usage
+    /// @param minimumLockupRequired The minimum lockup required
+    error InsufficientLockupAllowance(
+        address payer, address operator, uint256 lockupAllowance, uint256 lockupUsage, uint256 minimumLockupRequired
+    );
+
+    /// @notice Operator's max lockup period is insufficient for the default lockup period
+    /// @param payer The payer address
+    /// @param operator The operator address (warm storage service)
+    /// @param maxLockupPeriod The maximum lockup period approved
+    /// @param requiredLockupPeriod The required lockup period
+    error InsufficientMaxLockupPeriod(
+        address payer, address operator, uint256 maxLockupPeriod, uint256 requiredLockupPeriod
+    );
 }

--- a/service_contracts/src/Errors.sol
+++ b/service_contracts/src/Errors.sol
@@ -286,4 +286,10 @@ library Errors {
     /// @param dataSetId The data set ID
     /// @param pdpEndEpoch The end epoch when the PDP payment rail will finalize
     error PaymentRailsNotFinalized(uint256 dataSetId, uint256 pdpEndEpoch);
+
+    /// @notice Payer has insufficient available funds to cover the minimum storage rate
+    /// @param payer The payer address
+    /// @param minimumRequired The minimum lockup required to cover the minimum storage rate
+    /// @param available The available funds in the payer's account
+    error InsufficientFundsForMinimumRate(address payer, uint256 minimumRequired, uint256 available);
 }

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -1161,8 +1161,7 @@ contract FilecoinWarmStorageService is
         uint256 totalBytes = leafCount * BYTES_PER_LEAF;
         FilecoinPayV1 payments = FilecoinPayV1(paymentsContractAddress);
 
-        // Update the PDP rail payment rate with the new rate and no one-time
-        // payment
+        // Update the PDP rail payment rate with the new rate and no one-time payment
         uint256 pdpRailId = dataSetInfo[dataSetId].pdpRailId;
         uint256 newStorageRatePerEpoch = _calculateStorageRate(totalBytes);
         payments.modifyRailPayment(
@@ -1239,7 +1238,7 @@ contract FilecoinWarmStorageService is
      * @param totalBytes Total size of the stored data in bytes
      * @return storageRate The PDP storage rate per epoch
      */
-    function calculateRatesPerEpoch(uint256 totalBytes) external view returns (uint256 storageRate) {
+    function calculateRatePerEpoch(uint256 totalBytes) external view returns (uint256 storageRate) {
         storageRate = _calculateStorageRate(totalBytes);
     }
 

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -557,13 +557,13 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
             mockUSDFC,
             address(pdpServiceWithPayments),
             true, // approved
-            1000e6, // rate allowance (1000 USDFC)
-            1000e6, // lockup allowance (1000 USDFC)
+            1000e18, // rate allowance (1000 USDFC)
+            1000e18, // lockup allowance (1000 USDFC)
             365 days // max lockup period
         );
 
         // Client deposits funds to the FilecoinPayV1 contract for future payments
-        uint256 depositAmount = 10e6; // Sufficient funds for initial lockup and future operations
+        uint256 depositAmount = 10e18; // Sufficient funds for initial lockup and future operations
         mockUSDFC.approve(address(payments), depositAmount);
         payments.deposit(mockUSDFC, client, depositAmount);
         vm.stopPrank();
@@ -682,13 +682,13 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
             mockUSDFC,
             address(pdpServiceWithPayments),
             true, // approved
-            1000e6, // rate allowance (1000 USDFC)
-            1000e6, // lockup allowance (1000 USDFC)
+            1000e18, // rate allowance (1000 USDFC)
+            1000e18, // lockup allowance (1000 USDFC)
             365 days // max lockup period
         );
 
         // Client deposits funds to the FilecoinPayV1 contract for future payments
-        uint256 depositAmount = 10e6; // Sufficient funds for initial lockup and future operations
+        uint256 depositAmount = 10e18; // Sufficient funds for initial lockup and future operations
         mockUSDFC.approve(address(payments), depositAmount);
         payments.deposit(mockUSDFC, client, depositAmount);
         vm.stopPrank();
@@ -795,11 +795,11 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
             mockUSDFC,
             address(pdpServiceWithPayments),
             true, // approved
-            1000e6, // rate allowance (1000 USDFC)
-            1000e6, // lockup allowance (1000 USDFC)
+            1000e18, // rate allowance (1000 USDFC)
+            1000e18, // lockup allowance (1000 USDFC)
             365 days // max lockup period
         );
-        uint256 depositAmount = 10e6; // Sufficient funds for initial lockup and future operations
+        uint256 depositAmount = 10e18; // Sufficient funds for initial lockup and future operations
         mockUSDFC.approve(address(payments), depositAmount);
         payments.deposit(mockUSDFC, client, depositAmount);
         vm.stopPrank();
@@ -909,10 +909,11 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         // Test the values returned by getServicePrice
         FilecoinWarmStorageService.ServicePricing memory pricing = pdpServiceWithPayments.getServicePrice();
 
-        uint256 decimals = 6; // MockUSDFC uses 6 decimals in tests
-        uint256 expectedNoCDN = 25 * 10 ** (decimals - 1); // 2.5 USDFC with 6 decimals
+        uint256 decimals = 18; // MockUSDFC uses 18 decimals in tests
+        uint256 expectedNoCDN = 25 * 10 ** (decimals - 1); // 2.5 USDFC with 18 decimals
         uint256 expectedCDNEgress = 7 * 10 ** decimals; // 7 USDFC per TiB of CDN egress
         uint256 expectedCacheMissEgress = 7 * 10 ** decimals; // 7 USDFC per TiB of cache miss egress
+        uint256 expectedMinimum = (6 * 10 ** decimals) / 100; // 0.06 USDFC minimum
 
         assertEq(pricing.pricePerTiBPerMonthNoCDN, expectedNoCDN, "No CDN price should be 2.5 * 10^decimals");
         assertEq(pricing.pricePerTiBCdnEgress, expectedCDNEgress, "CDN egress price should be 7 * 10^decimals per TiB");
@@ -923,19 +924,20 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         );
         assertEq(address(pricing.tokenAddress), address(mockUSDFC), "Token address should match USDFC");
         assertEq(pricing.epochsPerMonth, 86400, "Epochs per month should be 86400");
+        assertEq(pricing.minimumPricePerMonth, expectedMinimum, "Minimum price should be 0.06 * 10^decimals");
 
         // Verify the values are in expected range
-        assert(pricing.pricePerTiBPerMonthNoCDN < 10 ** 8); // Less than 10^8
-        assert(pricing.pricePerTiBCdnEgress < 10 ** 8); // Less than 10^8
-        assert(pricing.pricePerTiBCacheMissEgress < 10 ** 8); // Less than 10^8
+        assert(pricing.pricePerTiBPerMonthNoCDN < 10 ** 20); // Less than 10^20
+        assert(pricing.pricePerTiBCdnEgress < 10 ** 20); // Less than 10^20
+        assert(pricing.pricePerTiBCacheMissEgress < 10 ** 20); // Less than 10^20
     }
 
     function testGetEffectiveRatesValues() public view {
         // Test the values returned by getEffectiveRates
         (uint256 serviceFee, uint256 spPayment) = pdpServiceWithPayments.getEffectiveRates();
 
-        uint256 decimals = 6; // MockUSDFC uses 6 decimals in tests
-        // Total is 2.5 USDFC with 6 decimals
+        uint256 decimals = 18; // MockUSDFC uses 18 decimals in tests
+        // Total is 2.5 USDFC with 18 decimals
         uint256 expectedTotal = 25 * 10 ** (decimals - 1);
 
         // Test setup uses 0% commission
@@ -943,12 +945,106 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         uint256 expectedSpPayment = expectedTotal; // 100% goes to SP
 
         assertEq(serviceFee, expectedServiceFee, "Service fee should be 0 with 0% commission");
-        assertEq(spPayment, expectedSpPayment, "SP payment should be 2.5 * 10^6");
-        assertEq(serviceFee + spPayment, expectedTotal, "Total should equal 2.5 * 10^6");
+        assertEq(spPayment, expectedSpPayment, "SP payment should be 2.5 * 10^18");
+        assertEq(serviceFee + spPayment, expectedTotal, "Total should equal 2.5 * 10^18");
 
         // Verify the values are in expected range
-        assert(serviceFee + spPayment < 10 ** 8); // Less than 10^8
+        assert(serviceFee + spPayment < 10 ** 20); // Less than 10^20
     }
+
+    // Minimum Pricing Tests
+    function testMinimumPricing_SmallDataSetsPayFloorRate() public view {
+        // Small datasets should all pay the minimum floor rate of 0.06 USDFC/month
+        uint256 decimals = 18;
+        uint256 oneGiB = 1024 * 1024 * 1024;
+
+        // Expected minimum: 0.06 USDFC/month = 6/100 with 18 decimals
+        uint256 expectedMinPerMonth = (6 * 10 ** decimals) / 100;
+        uint256 expectedMinPerEpoch = expectedMinPerMonth / 86400; // Convert to per-epoch
+
+        // Test 0 bytes
+        uint256 rateZero = pdpServiceWithPayments.calculateRatesPerEpoch(0);
+        assertEq(rateZero, expectedMinPerEpoch, "0 bytes should return 0.06 USDFC/month minimum");
+
+        // Test 1 GiB
+        uint256 rateOneGiB = pdpServiceWithPayments.calculateRatesPerEpoch(oneGiB);
+        assertEq(rateOneGiB, expectedMinPerEpoch, "1 GiB should return minimum rate");
+
+        // Test 10 GiB
+        uint256 rateTenGiB = pdpServiceWithPayments.calculateRatesPerEpoch(10 * oneGiB);
+        assertEq(rateTenGiB, expectedMinPerEpoch, "10 GiB should return minimum rate");
+
+        // Test 24 GiB (below crossover)
+        uint256 rateTwentyFourGiB = pdpServiceWithPayments.calculateRatesPerEpoch(24 * oneGiB);
+        assertEq(rateTwentyFourGiB, expectedMinPerEpoch, "24 GiB should return minimum rate");
+    }
+
+    function testMinimumPricing_CrossoverPoint() public view {
+        // Test the crossover where natural pricing exceeds minimum
+        // At 2.5 USDFC/TiB: 0.06/2.5*1024 = 24.576 GiB is the crossover
+        uint256 oneGiB = 1024 * 1024 * 1024;
+        uint256 decimals = 18;
+        uint256 expectedMinPerMonth = (6 * 10 ** decimals) / 100;
+        uint256 expectedMinPerEpoch = expectedMinPerMonth / 86400;
+
+        // 24 GiB: natural rate (0.0586) < minimum (0.06), so returns minimum
+        uint256 rate24GiB = pdpServiceWithPayments.calculateRatesPerEpoch(24 * oneGiB);
+        assertEq(rate24GiB, expectedMinPerEpoch, "24 GiB should use minimum floor");
+
+        // 25 GiB: natural rate (0.0610) > minimum (0.06), so returns natural rate
+        uint256 rate25GiB = pdpServiceWithPayments.calculateRatesPerEpoch(25 * oneGiB);
+        assert(rate25GiB > expectedMinPerEpoch);
+
+        // Verify it's actually proportional (not minimum)
+        uint256 expectedNatural25 = rate25GiB * 86400; // Convert to monthly
+        uint256 expected25Monthly = (25 * 10 ** decimals * 25) / (1024 * 10); // 25 GiB at 2.5 USDFC/TiB
+        // Tolerance: actual loss is ~16,000 from integer division, allow 100,000 for safety
+        assertApproxEqAbs(expectedNatural25, expected25Monthly, 100000, "25 GiB should use natural rate");
+    }
+
+    function testMinimumPricing_LargeDataSetsUseProportionalPricing() public view {
+        // Large datasets should use proportional pricing (natural rate > minimum)
+        uint256 oneGiB = 1024 * 1024 * 1024;
+        uint256 decimals = 18;
+        uint256 expectedMinPerMonth = (6 * 10 ** decimals) / 100;
+        uint256 expectedMinPerEpoch = expectedMinPerMonth / 86400;
+
+        // Test 48 GiB
+        uint256 rate48GiB = pdpServiceWithPayments.calculateRatesPerEpoch(48 * oneGiB);
+        assert(rate48GiB > expectedMinPerEpoch);
+
+        // Test 100 GiB
+        uint256 rate100GiB = pdpServiceWithPayments.calculateRatesPerEpoch(100 * oneGiB);
+        assert(rate100GiB > rate48GiB);
+
+        // Test 1 TiB
+        uint256 oneTiB = oneGiB * 1024;
+        uint256 rateOneTiB = pdpServiceWithPayments.calculateRatesPerEpoch(oneTiB);
+        assert(rateOneTiB > rate100GiB);
+
+        // Verify proportional scaling
+        assertApproxEqRel(rate100GiB, rate48GiB * 100 / 48, 0.01e18, "Rates should scale proportionally");
+    }
+
+    function testMinimumPricing_ExactlyPoint06USDFC() public view {
+        // Verify that minimum pricing is exactly 0.06 USDFC/month for small datasets
+        uint256 decimals = 18; // MockUSDFC uses 18 decimals in tests
+        uint256 oneGiB = 1024 * 1024 * 1024;
+
+        // Get rate per epoch for dataset below crossover point
+        uint256 ratePerEpoch = pdpServiceWithPayments.calculateRatesPerEpoch(oneGiB);
+
+        // Convert to rate per month (86400 epochs per month)
+        uint256 ratePerMonth = ratePerEpoch * 86400;
+
+        // Expected: exactly 0.06 USDFC with 18 decimals = 60000000000000000
+        // Allow tiny tolerance for integer division rounding (0.06 / 86400 rounds down)
+        uint256 expected = (6 * 10 ** decimals) / 100;
+        uint256 tolerance = 1; // Allow 1 per epoch difference = 86400 total
+
+        assertApproxEqAbs(ratePerMonth, expected, tolerance * 86400, "Minimum rate should be 0.06 USDFC/month");
+    }
+
 
     uint256 nextClientDataSetId = 0;
 
@@ -978,9 +1074,9 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
 
         // Setup client payment approval if not already done
         vm.startPrank(clientAddress);
-        payments.setOperatorApproval(mockUSDFC, address(pdpServiceWithPayments), true, 1000e6, 1000e6, 365 days);
-        mockUSDFC.approve(address(payments), 100e6);
-        payments.deposit(mockUSDFC, clientAddress, 100e6);
+        payments.setOperatorApproval(mockUSDFC, address(pdpServiceWithPayments), true, 1000e18, 1000e18, 365 days);
+        mockUSDFC.approve(address(payments), 100e18);
+        payments.deposit(mockUSDFC, clientAddress, 100e18);
         vm.stopPrank();
 
         // Create data set as approved provider
@@ -1164,9 +1260,9 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
 
         // Setup client payment approval if not already done
         vm.startPrank(clientAddress);
-        payments.setOperatorApproval(mockUSDFC, address(pdpServiceWithPayments), true, 1000e6, 1000e6, 365 days);
-        mockUSDFC.approve(address(payments), 100e6);
-        payments.deposit(mockUSDFC, clientAddress, 100e6);
+        payments.setOperatorApproval(mockUSDFC, address(pdpServiceWithPayments), true, 1000e18, 1000e18, 365 days);
+        mockUSDFC.approve(address(payments), 100e18);
+        payments.deposit(mockUSDFC, clientAddress, 100e18);
         vm.stopPrank();
 
         // Create data set as approved provider
@@ -1309,11 +1405,11 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
             mockUSDFC,
             address(pdpServiceWithPayments),
             true,
-            1000e6, // rate allowance
-            1000e6, // lockup allowance
+            1000e18, // rate allowance
+            1000e18, // lockup allowance
             365 days // max lockup period
         );
-        uint256 depositAmount = 100e6;
+        uint256 depositAmount = 100e18;
         mockUSDFC.approve(address(payments), depositAmount);
         payments.deposit(mockUSDFC, client, depositAmount);
         vm.stopPrank();
@@ -1489,11 +1585,11 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
             mockUSDFC,
             address(pdpServiceWithPayments),
             true,
-            1000e6, // rate allowance
-            1000e6, // lockup allowance
+            1000e18, // rate allowance
+            1000e18, // lockup allowance
             365 days // max lockup period
         );
-        uint256 depositAmount = 100e6;
+        uint256 depositAmount = 100e18;
         mockUSDFC.approve(address(payments), depositAmount);
         payments.deposit(mockUSDFC, client, depositAmount);
         vm.stopPrank();
@@ -1610,11 +1706,11 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
             mockUSDFC,
             address(pdpServiceWithPayments),
             true,
-            1000e6, // rate allowance
-            1000e6, // lockup allowance
+            1000e18, // rate allowance
+            1000e18, // lockup allowance
             365 days // max lockup period
         );
-        uint256 depositAmount = 100e6;
+        uint256 depositAmount = 100e18;
         mockUSDFC.approve(address(payments), depositAmount);
         payments.deposit(mockUSDFC, client, depositAmount);
         vm.stopPrank();
@@ -2829,8 +2925,8 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         );
 
         vm.startPrank(client);
-        payments.setOperatorApproval(mockUSDFC, address(pdpServiceWithPayments), true, 1000e6, 1000e6, 365 days);
-        uint256 depositAmount = 1e6;
+        payments.setOperatorApproval(mockUSDFC, address(pdpServiceWithPayments), true, 1000e18, 1000e18, 365 days);
+        uint256 depositAmount = 1e18;
         mockUSDFC.approve(address(payments), depositAmount);
         payments.deposit(mockUSDFC, client, depositAmount);
         vm.stopPrank();
@@ -2882,8 +2978,8 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         );
 
         vm.startPrank(client);
-        payments.setOperatorApproval(mockUSDFC, address(pdpServiceWithPayments), true, 1000e6, 1000e6, 365 days);
-        uint256 depositAmount = 1e6;
+        payments.setOperatorApproval(mockUSDFC, address(pdpServiceWithPayments), true, 1000e18, 1000e18, 365 days);
+        uint256 depositAmount = 1e18;
         mockUSDFC.approve(address(payments), depositAmount);
         payments.deposit(mockUSDFC, client, depositAmount);
         vm.stopPrank();
@@ -2933,8 +3029,8 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         );
 
         vm.startPrank(client);
-        payments.setOperatorApproval(mockUSDFC, address(pdpServiceWithPayments), true, 1000e6, 1000e6, 365 days);
-        uint256 depositAmount = 10e6;
+        payments.setOperatorApproval(mockUSDFC, address(pdpServiceWithPayments), true, 1000e18, 1000e18, 365 days);
+        uint256 depositAmount = 10e18;
         mockUSDFC.approve(address(payments), depositAmount);
         payments.deposit(mockUSDFC, client, depositAmount);
         vm.stopPrank();
@@ -4204,7 +4300,7 @@ contract FilecoinWarmStorageServiceSignatureTest is Test {
         pdpService = SignatureCheckingService(address(serviceProxy));
 
         // Fund the payer
-        mockUSDFC.safeTransfer(payer, 1000 * 10 ** 6); // 1000 USDFC
+        mockUSDFC.safeTransfer(payer, 1000 * 10 ** 18); // 1000 USDFC
     }
 
     // Test the recoverSigner function indirectly through signature verification

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -963,19 +963,19 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         uint256 expectedMinPerEpoch = expectedMinPerMonth / 86400; // Convert to per-epoch
 
         // Test 0 bytes
-        uint256 rateZero = pdpServiceWithPayments.calculateRatesPerEpoch(0);
+        uint256 rateZero = pdpServiceWithPayments.calculateRatePerEpoch(0);
         assertEq(rateZero, expectedMinPerEpoch, "0 bytes should return 0.06 USDFC/month minimum");
 
         // Test 1 GiB
-        uint256 rateOneGiB = pdpServiceWithPayments.calculateRatesPerEpoch(oneGiB);
+        uint256 rateOneGiB = pdpServiceWithPayments.calculateRatePerEpoch(oneGiB);
         assertEq(rateOneGiB, expectedMinPerEpoch, "1 GiB should return minimum rate");
 
         // Test 10 GiB
-        uint256 rateTenGiB = pdpServiceWithPayments.calculateRatesPerEpoch(10 * oneGiB);
+        uint256 rateTenGiB = pdpServiceWithPayments.calculateRatePerEpoch(10 * oneGiB);
         assertEq(rateTenGiB, expectedMinPerEpoch, "10 GiB should return minimum rate");
 
         // Test 24 GiB (below crossover)
-        uint256 rateTwentyFourGiB = pdpServiceWithPayments.calculateRatesPerEpoch(24 * oneGiB);
+        uint256 rateTwentyFourGiB = pdpServiceWithPayments.calculateRatePerEpoch(24 * oneGiB);
         assertEq(rateTwentyFourGiB, expectedMinPerEpoch, "24 GiB should return minimum rate");
     }
 
@@ -988,11 +988,11 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         uint256 expectedMinPerEpoch = expectedMinPerMonth / 86400;
 
         // 24 GiB: natural rate (0.0586) < minimum (0.06), so returns minimum
-        uint256 rate24GiB = pdpServiceWithPayments.calculateRatesPerEpoch(24 * oneGiB);
+        uint256 rate24GiB = pdpServiceWithPayments.calculateRatePerEpoch(24 * oneGiB);
         assertEq(rate24GiB, expectedMinPerEpoch, "24 GiB should use minimum floor");
 
         // 25 GiB: natural rate (0.0610) > minimum (0.06), so returns natural rate
-        uint256 rate25GiB = pdpServiceWithPayments.calculateRatesPerEpoch(25 * oneGiB);
+        uint256 rate25GiB = pdpServiceWithPayments.calculateRatePerEpoch(25 * oneGiB);
         assert(rate25GiB > expectedMinPerEpoch);
 
         // Verify it's actually proportional (not minimum)
@@ -1010,16 +1010,16 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         uint256 expectedMinPerEpoch = expectedMinPerMonth / 86400;
 
         // Test 48 GiB
-        uint256 rate48GiB = pdpServiceWithPayments.calculateRatesPerEpoch(48 * oneGiB);
+        uint256 rate48GiB = pdpServiceWithPayments.calculateRatePerEpoch(48 * oneGiB);
         assert(rate48GiB > expectedMinPerEpoch);
 
         // Test 100 GiB
-        uint256 rate100GiB = pdpServiceWithPayments.calculateRatesPerEpoch(100 * oneGiB);
+        uint256 rate100GiB = pdpServiceWithPayments.calculateRatePerEpoch(100 * oneGiB);
         assert(rate100GiB > rate48GiB);
 
         // Test 1 TiB
         uint256 oneTiB = oneGiB * 1024;
-        uint256 rateOneTiB = pdpServiceWithPayments.calculateRatesPerEpoch(oneTiB);
+        uint256 rateOneTiB = pdpServiceWithPayments.calculateRatePerEpoch(oneTiB);
         assert(rateOneTiB > rate100GiB);
 
         // Verify proportional scaling
@@ -1032,7 +1032,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         uint256 oneGiB = 1024 * 1024 * 1024;
 
         // Get rate per epoch for dataset below crossover point
-        uint256 ratePerEpoch = pdpServiceWithPayments.calculateRatesPerEpoch(oneGiB);
+        uint256 ratePerEpoch = pdpServiceWithPayments.calculateRatePerEpoch(oneGiB);
 
         // Convert to rate per month (86400 epochs per month)
         uint256 ratePerMonth = ratePerEpoch * 86400;

--- a/service_contracts/test/FilecoinWarmStorageServiceOwner.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageServiceOwner.t.sol
@@ -124,7 +124,7 @@ contract FilecoinWarmStorageServiceOwnerTest is MockFVMTest {
         serviceContract.addApprovedProvider(providerId3);
 
         // Setup USDFC tokens for client
-        usdfcToken.safeTransfer(client, 10000e6);
+        usdfcToken.safeTransfer(client, 10000e18);
 
         // Make signatures pass
         makeSignaturePass(client);
@@ -190,9 +190,9 @@ contract FilecoinWarmStorageServiceOwnerTest is MockFVMTest {
 
         // Setup payment approval
         vm.startPrank(payer);
-        payments.setOperatorApproval(usdfcToken, address(serviceContract), true, 1000e6, 1000e6, 365 days);
-        usdfcToken.approve(address(payments), 100e6);
-        payments.deposit(usdfcToken, payer, 100e6);
+        payments.setOperatorApproval(usdfcToken, address(serviceContract), true, 1000e18, 1000e18, 365 days);
+        usdfcToken.approve(address(payments), 100e18);
+        payments.deposit(usdfcToken, payer, 100e18);
         vm.stopPrank();
 
         // Create data set

--- a/service_contracts/test/ProviderValidation.t.sol
+++ b/service_contracts/test/ProviderValidation.t.sol
@@ -91,7 +91,7 @@ contract ProviderValidationTest is MockFVMTest {
         viewContract = new FilecoinWarmStorageServiceStateView(warmStorage);
 
         // Transfer tokens to client
-        usdfc.safeTransfer(client, 10000 * 10 ** 6);
+        usdfc.safeTransfer(client, 10000 * 10 ** 18);
     }
 
     function testProviderNotRegistered() public {
@@ -141,12 +141,12 @@ contract ProviderValidationTest is MockFVMTest {
             usdfc,
             address(warmStorage),
             true,
-            1000 * 10 ** 6, // rate allowance
-            1000 * 10 ** 6, // lockup allowance
+            1000 * 10 ** 18, // rate allowance
+            1000 * 10 ** 18, // lockup allowance
             365 days // max lockup period
         );
-        usdfc.approve(address(payments), 100 * 10 ** 6);
-        payments.deposit(usdfc, client, 100 * 10 ** 6);
+        usdfc.approve(address(payments), 100 * 10 ** 18);
+        payments.deposit(usdfc, client, 100 * 10 ** 18);
         vm.stopPrank();
 
         // Create dataset without approval should now succeed
@@ -195,15 +195,15 @@ contract ProviderValidationTest is MockFVMTest {
 
         // Approve USDFC spending, deposit and set operator
         vm.startPrank(client);
-        usdfc.approve(address(payments), 10000 * 10 ** 6);
-        payments.deposit(usdfc, client, 10000 * 10 ** 6); // Deposit funds
+        usdfc.approve(address(payments), 10000 * 10 ** 18);
+        payments.deposit(usdfc, client, 10000 * 10 ** 18); // Deposit funds
         payments.setOperatorApproval(
             usdfc, // token
             address(warmStorage), // operator
             true, // approved
-            10000 * 10 ** 6, // rateAllowance
-            10000 * 10 ** 6, // lockupAllowance
-            10000 * 10 ** 6 // allowance
+            10000 * 10 ** 18, // rateAllowance
+            10000 * 10 ** 18, // lockupAllowance
+            10000 * 10 ** 18 // allowance
         );
         vm.stopPrank();
 

--- a/service_contracts/test/mocks/SharedMocks.sol
+++ b/service_contracts/test/mocks/SharedMocks.sol
@@ -10,7 +10,7 @@ import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IER
 contract MockERC20 is IERC20, IERC20Metadata {
     string private _name = "USD Filecoin";
     string private _symbol = "USDFC";
-    uint8 private _decimals = 6;
+    uint8 private _decimals = 18;
 
     mapping(address => uint256) private _balances;
     mapping(address => mapping(address => uint256)) private _allowances;


### PR DESCRIPTION
_Edit: This got switched to having 0.06 USDFC as the floor, not the bytes; so now the bytes works out as ~24.576 GiB and we get to talk about it in terms of cents per month._

(PR on top of #316, that should be merged first)

Amounts below this pay as if they are storing 24 GiB, which is 0.05859375 USDFC / month.

Closes: https://github.com/FilOzone/filecoin-services/issues/319

---

*  24 GiB = 24/1024 TiB = 0.0234375 TiB
* At 2.5 USDFC/TiB/month, price = 0.0234375 * 2.5 = 0.05859375 USDFC/month

Are we OK with 0.05859375? I have an option here of either setting 24GiB as the floor _size_ or 0.06 as the floor _price_.

If we go with 0.06 as the floor then we're working with 24.576 GiB floor size.

---

I also had to change the mock token from 6 decimal places to 18, cause there's already a floor rounding bit of code in here and it was getting stuck on a higher floor due to not enough decimal places, so everything came out wrong.