### PR TITLE
fix: reduce challenge window from 30 to 20 epochs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   - **Details**: `Inactive` represents non-existent datasets or datasets with no pieces yet. `Active` represents all datasets with pieces, including terminated ones.
   - Use `getDataSetStatusDetails()` to check termination status separately from Active/Inactive status
 - Subgraph schema updated with status enum and history tracking
+- **Calibnet**: Reduced DEFAULT_CHALLENGE_WINDOW_SIZE from 30 epochs to 20 epochs for faster testing iteration
 
 ## [0.3.0] - 2025-10-08 - M3.1 Calibration Network Deployment
 

--- a/service_contracts/tools/README.md
+++ b/service_contracts/tools/README.md
@@ -31,7 +31,7 @@ The following parameters are critical for proof generation and validation. They 
 |-----------|----------------------|---------------------|-------|
 | `DEFAULT_CHALLENGE_FINALITY` | `150` | `10` | **Security parameter.** Always set to `150` in production. Enforces that the challenge epoch is far enough in the future to prevent reorg-based attacks. See [PDP Implementation Design Doc](https://filoznotebook.notion.site/PDP-Implementation-Design-Doc-64a66516416441c69b9d8e5d63120f1c?pvs=21). |
 | `DEFAULT_MAX_PROVING_PERIOD` | `2880` | `240` | **Product parameter.** Defines how often proofs must be submitted. Mainnet default is 2880 epochs ≈ 24h (one proof/day). On Calibnet we use shorter proving periods for faster iteration. See [Simple PDP Service Fault Model](https://filoznotebook.notion.site/Simple-PDP-Service-Fault-Model-1a9dc41950c180c4bdc7ef2d91db73b6?pvs=21). |
-| `DEFAULT_CHALLENGE_WINDOW_SIZE` | `60` | `30` | **Security parameter.** Defines the grace window within the proving period. Typically ~2% of the proving period. On Mainnet: 60 epochs (≈2% of 2880). On Calibnet: 30 epochs. See [Simple PDP Service Fault Model](https://filoznotebook.notion.site/Simple-PDP-Service-Fault-Model-1a9dc41950c180c4bdc7ef2d91db73b6?pvs=21). |
+| `DEFAULT_CHALLENGE_WINDOW_SIZE` | `60` | `20` | **Security parameter.** Defines the grace window within the proving period. On Mainnet: 60 epochs. On Calibnet: 20 epochs. See [Simple PDP Service Fault Model](https://filoznotebook.notion.site/Simple-PDP-Service-Fault-Model-1a9dc41950c180c4bdc7ef2d91db73b6?pvs=21). |
 
 ### Quick Reference
 
@@ -46,7 +46,7 @@ The following parameters are critical for proof generation and validation. They 
   ```bash
   DEFAULT_CHALLENGE_FINALITY="10"        # Low value for fast testing (should be 150 in production)
   DEFAULT_MAX_PROVING_PERIOD="240"       # 240 epochs
-  DEFAULT_CHALLENGE_WINDOW_SIZE="30"     # 30 epochs
+  DEFAULT_CHALLENGE_WINDOW_SIZE="20"     # 20 epochs
   ```
 
 ## Environment Variables
@@ -85,7 +85,7 @@ export CHALLENGE_FINALITY="10"  # Use "150" for mainnet
 
 # Optional: Custom proving periods
 export MAX_PROVING_PERIOD="240"        # 240 epochs for calibnet, 2880 for mainnet
-export CHALLENGE_WINDOW_SIZE="30"      # 30 epochs for calibnet, 60 for mainnet
+export CHALLENGE_WINDOW_SIZE="20"      # 20 epochs for calibnet, 60 for mainnet
 
 ./deploy-all-warm-storage.sh
 ```
@@ -112,7 +112,7 @@ export WARM_STORAGE_SERVICE_PROXY_ADDRESS="0x789..."
 
 # Optional: Custom proving periods
 export MAX_PROVING_PERIOD="240"        # 240 epochs for calibnet, 2880 for mainnet
-export CHALLENGE_WINDOW_SIZE="30"      # 30 epochs for calibnet, 60 for mainnet
+export CHALLENGE_WINDOW_SIZE="20"      # 20 epochs for calibnet, 60 for mainnet
 
 ./upgrade-warm-storage-calibnet.sh
 ```

--- a/service_contracts/tools/deploy-all-warm-storage.sh
+++ b/service_contracts/tools/deploy-all-warm-storage.sh
@@ -51,7 +51,7 @@ case "$CHAIN" in
     # Default challenge and proving configuration for calibnet (testing values)
     DEFAULT_CHALLENGE_FINALITY="10"          # Low value for fast testing (should be 150 in production)
     DEFAULT_MAX_PROVING_PERIOD="240"         # 240 epochs on calibnet
-    DEFAULT_CHALLENGE_WINDOW_SIZE="30"       # 30 epochs
+    DEFAULT_CHALLENGE_WINDOW_SIZE="20"       # 20 epochs
     ;;
   "314")
     NETWORK_NAME="mainnet"

--- a/service_contracts/tools/deploy-warm-storage-calibnet.sh
+++ b/service_contracts/tools/deploy-warm-storage-calibnet.sh
@@ -86,7 +86,7 @@ USDFC_TOKEN_ADDRESS="0xb3042734b608a1B16e9e86B374A3f3e389B4cDf0" # USDFC token a
 
 # Proving period configuration - use defaults if not set
 MAX_PROVING_PERIOD="${MAX_PROVING_PERIOD:-240}"       # Default 240 epochs (120 minutes on calibnet)
-CHALLENGE_WINDOW_SIZE="${CHALLENGE_WINDOW_SIZE:-30}" # Default 30 epochs
+CHALLENGE_WINDOW_SIZE="${CHALLENGE_WINDOW_SIZE:-20}" # Default 20 epochs
 
 # Query the actual challengeFinality from PDPVerifier
 echo "Querying PDPVerifier's challengeFinality..."

--- a/service_contracts/tools/dev-release-contracts
+++ b/service_contracts/tools/dev-release-contracts
@@ -13,6 +13,6 @@ FilBeam beneficiary address: 0x1D60d2F5960Af6341e842C539985FA297E10d6eA
 ServiceProviderRegistry address: 0xc758dB755f59189d8FB3C166Ee372b77d7CFA9D3
 SessionKeyRegistry address: 0x97Dd879F5a97A8c761B94746d7F5cfF50AAd4452
 Max proving period: 240 epochs
-Challenge window size: 30 epochs
+Challenge window size: 20 epochs
 Service name: FWSS - M4 staging contracts
 Service description: Calibration FWSS - M4 staging contracts


### PR DESCRIPTION
Reduces the `DEFAULT_CHALLENGE_WINDOW_SIZE` parameter for Calibration network from 30 epochs to 20 epochs.