### PR TITLE
feat(sp-registry): getProvidersWithProductByIds() to get multiple providers

### DIFF
--- a/service_contracts/abi/ServiceProviderRegistry.abi.json
+++ b/service_contracts/abi/ServiceProviderRegistry.abi.json
@@ -738,6 +738,101 @@
   },
   {
     "type": "function",
+    "name": "getProvidersWithProductByIds",
+    "inputs": [
+      {
+        "name": "providerIds",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "productType",
+        "type": "uint8",
+        "internalType": "enum ServiceProviderRegistryStorage.ProductType"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "providersWithProducts",
+        "type": "tuple[]",
+        "internalType": "struct ServiceProviderRegistryStorage.ProviderWithProduct[]",
+        "components": [
+          {
+            "name": "providerId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "providerInfo",
+            "type": "tuple",
+            "internalType": "struct ServiceProviderRegistryStorage.ServiceProviderInfo",
+            "components": [
+              {
+                "name": "serviceProvider",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "payee",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "description",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "isActive",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          },
+          {
+            "name": "product",
+            "type": "tuple",
+            "internalType": "struct ServiceProviderRegistryStorage.ServiceProduct",
+            "components": [
+              {
+                "name": "productType",
+                "type": "uint8",
+                "internalType": "enum ServiceProviderRegistryStorage.ProductType"
+              },
+              {
+                "name": "capabilityKeys",
+                "type": "string[]",
+                "internalType": "string[]"
+              },
+              {
+                "name": "isActive",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          },
+          {
+            "name": "productCapabilityValues",
+            "type": "bytes[]",
+            "internalType": "bytes[]"
+          }
+        ]
+      },
+      {
+        "name": "validIds",
+        "type": "bool[]",
+        "internalType": "bool[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "initialize",
     "inputs": [],
     "outputs": [],

--- a/service_contracts/test/ServiceProviderRegistry.t.sol
+++ b/service_contracts/test/ServiceProviderRegistry.t.sol
@@ -468,6 +468,277 @@ contract ServiceProviderRegistryTest is MockFVMTest {
         assertFalse(providerInfos[0].info.isActive, "Inactive provider should be inactive");
     }
 
+    // ========== Tests for getProvidersWithProductByIds ==========
+
+    function testGetProvidersWithProductByIdsEmptyArray() public view {
+        uint256[] memory emptyIds = new uint256[](0);
+
+        (ServiceProviderRegistryStorage.ProviderWithProduct[] memory providersWithProducts, bool[] memory validIds) =
+            registry.getProvidersWithProductByIds(emptyIds, ServiceProviderRegistryStorage.ProductType.PDP);
+
+        assertEq(providersWithProducts.length, 0, "Should return empty array for empty input");
+        assertEq(validIds.length, 0, "Should return empty validIds array for empty input");
+    }
+
+    function testGetProvidersWithProductByIdsSingleValidProvider() public {
+        // Register a provider first
+        vm.deal(user1, 10 ether);
+
+        (string[] memory keys, bytes[] memory values) = _createValidPDPOffering().toCapabilities();
+
+        vm.prank(user1);
+        uint256 providerId = registry.registerProvider{value: 5 ether}(
+            user1, "Test Provider", "Test Description", ServiceProviderRegistryStorage.ProductType.PDP, keys, values
+        );
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = providerId;
+
+        (ServiceProviderRegistryStorage.ProviderWithProduct[] memory providersWithProducts, bool[] memory validIds) =
+            registry.getProvidersWithProductByIds(ids, ServiceProviderRegistryStorage.ProductType.PDP);
+
+        assertEq(providersWithProducts.length, 1, "Should return one provider");
+        assertEq(validIds.length, 1, "Should return one validity flag");
+        assertTrue(validIds[0], "Provider should be valid");
+        assertEq(providersWithProducts[0].providerId, providerId, "Provider ID should match");
+        assertEq(providersWithProducts[0].providerInfo.serviceProvider, user1, "Service provider address should match");
+        assertEq(providersWithProducts[0].providerInfo.name, "Test Provider", "Provider name should match");
+        assertEq(
+            providersWithProducts[0].providerInfo.description, "Test Description", "Provider description should match"
+        );
+        assertTrue(providersWithProducts[0].providerInfo.isActive, "Provider should be active");
+        assertTrue(providersWithProducts[0].product.isActive, "Product should be active");
+        assertEq(
+            uint256(providersWithProducts[0].product.productType),
+            uint256(ServiceProviderRegistryStorage.ProductType.PDP),
+            "Product type should be PDP"
+        );
+        assertGt(providersWithProducts[0].product.capabilityKeys.length, 0, "Should have capability keys");
+        assertGt(providersWithProducts[0].productCapabilityValues.length, 0, "Should have capability values");
+    }
+
+    function testGetProvidersWithProductByIdsMultipleValidProviders() public {
+        // Register multiple providers
+        vm.deal(user1, 10 ether);
+        vm.deal(user2, 10 ether);
+
+        (string[] memory keys, bytes[] memory values) = _createValidPDPOffering().toCapabilities();
+        vm.prank(user1);
+        uint256 providerId1 = registry.registerProvider{value: 5 ether}(
+            user1, "Provider 1", "Description 1", ServiceProviderRegistryStorage.ProductType.PDP, keys, values
+        );
+
+        vm.prank(user2);
+        uint256 providerId2 = registry.registerProvider{value: 5 ether}(
+            user2, "Provider 2", "Description 2", ServiceProviderRegistryStorage.ProductType.PDP, keys, values
+        );
+
+        uint256[] memory ids = new uint256[](2);
+        ids[0] = providerId1;
+        ids[1] = providerId2;
+
+        (ServiceProviderRegistryStorage.ProviderWithProduct[] memory providersWithProducts, bool[] memory validIds) =
+            registry.getProvidersWithProductByIds(ids, ServiceProviderRegistryStorage.ProductType.PDP);
+
+        assertEq(providersWithProducts.length, 2, "Should return two providers");
+        assertEq(validIds.length, 2, "Should return two validity flags");
+
+        // Check first provider
+        assertTrue(validIds[0], "First provider should be valid");
+        assertEq(providersWithProducts[0].providerId, providerId1, "First provider ID should match");
+        assertEq(providersWithProducts[0].providerInfo.serviceProvider, user1, "First provider address should match");
+        assertEq(providersWithProducts[0].providerInfo.name, "Provider 1", "First provider name should match");
+        assertTrue(providersWithProducts[0].product.isActive, "First product should be active");
+
+        // Check second provider
+        assertTrue(validIds[1], "Second provider should be valid");
+        assertEq(providersWithProducts[1].providerId, providerId2, "Second provider ID should match");
+        assertEq(providersWithProducts[1].providerInfo.serviceProvider, user2, "Second provider address should match");
+        assertEq(providersWithProducts[1].providerInfo.name, "Provider 2", "Second provider name should match");
+        assertTrue(providersWithProducts[1].product.isActive, "Second product should be active");
+    }
+
+    function testGetProvidersWithProductByIdsInvalidIds() public view {
+        uint256[] memory ids = new uint256[](3);
+        ids[0] = 0; // Invalid ID (0)
+        ids[1] = 999; // Non-existent ID
+        ids[2] = 1; // Valid ID but no provider registered yet
+
+        (ServiceProviderRegistryStorage.ProviderWithProduct[] memory providersWithProducts, bool[] memory validIds) =
+            registry.getProvidersWithProductByIds(ids, ServiceProviderRegistryStorage.ProductType.PDP);
+
+        assertEq(providersWithProducts.length, 3, "Should return three results");
+        assertEq(validIds.length, 3, "Should return three validity flags");
+
+        // All should be invalid
+        assertFalse(validIds[0], "ID 0 should be invalid");
+        assertFalse(validIds[1], "Non-existent ID should be invalid");
+        assertFalse(validIds[2], "Unregistered ID should be invalid");
+
+        // All should have empty structs
+        for (uint256 i = 0; i < 3; i++) {
+            assertEq(
+                providersWithProducts[i].providerInfo.serviceProvider,
+                address(0),
+                "Invalid provider should have zero address"
+            );
+            assertEq(providersWithProducts[i].providerId, 0, "Invalid provider should have zero ID");
+            assertFalse(providersWithProducts[i].providerInfo.isActive, "Invalid provider should be inactive");
+            assertFalse(providersWithProducts[i].product.isActive, "Invalid product should be inactive");
+        }
+    }
+
+    function testGetProvidersWithProductByIdsMixedValidAndInvalid() public {
+        // Register one provider
+        vm.deal(user1, 10 ether);
+        (string[] memory keys, bytes[] memory values) = _createValidPDPOffering().toCapabilities();
+        vm.prank(user1);
+        uint256 validProviderId = registry.registerProvider{value: 5 ether}(
+            user1, "Valid Provider", "Valid Description", ServiceProviderRegistryStorage.ProductType.PDP, keys, values
+        );
+
+        uint256[] memory ids = new uint256[](4);
+        ids[0] = validProviderId; // Valid
+        ids[1] = 0; // Invalid
+        ids[2] = 999; // Invalid
+        ids[3] = validProviderId; // Valid (duplicate)
+
+        (ServiceProviderRegistryStorage.ProviderWithProduct[] memory providersWithProducts, bool[] memory validIds) =
+            registry.getProvidersWithProductByIds(ids, ServiceProviderRegistryStorage.ProductType.PDP);
+
+        assertEq(providersWithProducts.length, 4, "Should return four results");
+        assertEq(validIds.length, 4, "Should return four validity flags");
+
+        // Check valid providers
+        assertTrue(validIds[0], "First provider should be valid");
+        assertEq(providersWithProducts[0].providerId, validProviderId, "First provider ID should match");
+        assertEq(providersWithProducts[0].providerInfo.serviceProvider, user1, "First provider address should match");
+        assertTrue(providersWithProducts[0].product.isActive, "First product should be active");
+
+        // Check invalid providers
+        assertFalse(validIds[1], "Second provider should be invalid");
+        assertFalse(validIds[2], "Third provider should be invalid");
+
+        // Check duplicate valid provider
+        assertTrue(validIds[3], "Fourth provider should be valid");
+        assertEq(providersWithProducts[3].providerId, validProviderId, "Fourth provider ID should match");
+        assertEq(providersWithProducts[3].providerInfo.serviceProvider, user1, "Fourth provider address should match");
+        assertTrue(providersWithProducts[3].product.isActive, "Fourth product should be active");
+    }
+
+    function testGetProvidersWithProductByIdsInactiveProvider() public {
+        // Register a provider
+        vm.deal(user1, 10 ether);
+        (string[] memory keys, bytes[] memory values) = _createValidPDPOffering().toCapabilities();
+        vm.prank(user1);
+        uint256 providerId = registry.registerProvider{value: 5 ether}(
+            user1, "Test Provider", "Test Description", ServiceProviderRegistryStorage.ProductType.PDP, keys, values
+        );
+
+        // Remove the provider (make it inactive)
+        vm.prank(user1);
+        registry.removeProvider();
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = providerId;
+
+        (ServiceProviderRegistryStorage.ProviderWithProduct[] memory providersWithProducts, bool[] memory validIds) =
+            registry.getProvidersWithProductByIds(ids, ServiceProviderRegistryStorage.ProductType.PDP);
+
+        assertEq(providersWithProducts.length, 1, "Should return one result");
+        assertEq(validIds.length, 1, "Should return one validity flag");
+        assertFalse(validIds[0], "Inactive provider should be invalid");
+        assertEq(
+            providersWithProducts[0].providerInfo.serviceProvider,
+            address(0),
+            "Inactive provider should have zero address"
+        );
+        assertEq(providersWithProducts[0].providerId, 0, "Inactive provider should have zero ID");
+        assertFalse(providersWithProducts[0].providerInfo.isActive, "Inactive provider should be inactive");
+        assertFalse(providersWithProducts[0].product.isActive, "Inactive product should be inactive");
+    }
+
+    function testGetProvidersWithProductByIdsProviderWithoutProduct() public {
+        // Register a provider with a product
+        vm.deal(user1, 10 ether);
+        (string[] memory keys, bytes[] memory values) = _createValidPDPOffering().toCapabilities();
+        vm.prank(user1);
+        uint256 providerId = registry.registerProvider{value: 5 ether}(
+            user1, "Test Provider", "Test Description", ServiceProviderRegistryStorage.ProductType.PDP, keys, values
+        );
+
+        // Remove the product
+        vm.prank(user1);
+        registry.removeProduct(ServiceProviderRegistryStorage.ProductType.PDP);
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = providerId;
+
+        (ServiceProviderRegistryStorage.ProviderWithProduct[] memory providersWithProducts, bool[] memory validIds) =
+            registry.getProvidersWithProductByIds(ids, ServiceProviderRegistryStorage.ProductType.PDP);
+
+        assertEq(providersWithProducts.length, 1, "Should return one result");
+        assertEq(validIds.length, 1, "Should return one validity flag");
+        assertFalse(validIds[0], "Provider without product should be invalid");
+        assertEq(
+            providersWithProducts[0].providerInfo.serviceProvider,
+            address(0),
+            "Provider without product should have zero address"
+        );
+        assertEq(providersWithProducts[0].providerId, 0, "Provider without product should have zero ID");
+        assertFalse(providersWithProducts[0].product.isActive, "Product should be inactive");
+    }
+
+    function testGetProvidersWithProductByIdsCapabilitiesIncluded() public {
+        // Register a provider with specific capabilities
+        vm.deal(user1, 10 ether);
+
+        PDPOffering.Schema memory pdpData = _createValidPDPOffering();
+
+        (string[] memory capabilityKeys, bytes[] memory capabilityValues) = pdpData.toCapabilities(2);
+        capabilityKeys[0] = "region";
+        capabilityKeys[1] = "tier";
+        capabilityValues[0] = bytes("us-west-2");
+        capabilityValues[1] = bytes("premium");
+
+        vm.prank(user1);
+        uint256 providerId = registry.registerProvider{value: 5 ether}(
+            user1,
+            "Test Provider",
+            "Test Description",
+            ServiceProviderRegistryStorage.ProductType.PDP,
+            capabilityKeys,
+            capabilityValues
+        );
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = providerId;
+
+        (ServiceProviderRegistryStorage.ProviderWithProduct[] memory providersWithProducts, bool[] memory validIds) =
+            registry.getProvidersWithProductByIds(ids, ServiceProviderRegistryStorage.ProductType.PDP);
+
+        assertTrue(validIds[0], "Provider should be valid");
+
+        // Verify capability values are returned
+        assertGt(providersWithProducts[0].productCapabilityValues.length, 0, "Should have capability values");
+
+        // Find and verify the custom capabilities
+        bool foundRegion = false;
+        bool foundTier = false;
+        for (uint256 i = 0; i < providersWithProducts[0].product.capabilityKeys.length; i++) {
+            if (keccak256(bytes(providersWithProducts[0].product.capabilityKeys[i])) == keccak256(bytes("region"))) {
+                assertEq(providersWithProducts[0].productCapabilityValues[i], bytes("us-west-2"), "Region should match");
+                foundRegion = true;
+            }
+            if (keccak256(bytes(providersWithProducts[0].product.capabilityKeys[i])) == keccak256(bytes("tier"))) {
+                assertEq(providersWithProducts[0].productCapabilityValues[i], bytes("premium"), "Tier should match");
+                foundTier = true;
+            }
+        }
+        assertTrue(foundRegion, "Should have region capability");
+        assertTrue(foundTier, "Should have tier capability");
+    }
+
     // Helper function to create a valid PDP offering for tests
     function _createValidPDPOffering() internal pure returns (PDPOffering.Schema memory schema) {
         PDPOffering.Schema memory pdpOffering = PDPOffering.Schema({


### PR DESCRIPTION
This should have been in #328 I realise now. It's only now I'm looking at the SDK that I see that this is actually the most important speed-up we need to select a random provider. It's a big chunk of data so wouldn't scale to a very large list but I assume our approved provider list will be small enough for a while to call this with one batch and one can paginate on the client side if there's a lot of them.