### PR TITLE
chore: additional BigEndian tests

### DIFF
--- a/service_contracts/test/BigEndian.t.sol
+++ b/service_contracts/test/BigEndian.t.sol
@@ -22,6 +22,19 @@ contract BigEndianTest is Test {
         assertEq(test.decode(), 4352);
         test = hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
         assertEq(test.decode(), 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);
+        test = hex"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        assertEq(test.decode(), 0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef);
+        // size too large
+        test =
+            hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+        assertEq(address(uint160(test.decode())), address(0x0000000000000000000000000000000000000000));
+        test = hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+        assertEq(address(uint160(test.decode())), address(0x0000000000000000000000000000000000000000));
+        test = hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+        assertEq(address(uint160(test.decode())), address(0x0000000000000000000000000000000000000000));
+        // leading zeros
+        test = hex"00ff";
+        assertEq(address(uint160(test.decode())), address(0x00000000000000000000000000000000000000ff));
     }
 
     using BigEndian for uint256;


### PR DESCRIPTION

Reviewer @rvagg
I wrote these tests last week and I think they're worth committing.
They cover some edge cases such as the bytestring being longer than 32 bytes.
I was curious how the library behaves in this case because I wanted to ensure that integer encoding and decoding would be consistent on and off chain.
#### Changes
* add some tests for BigEndian