### PR TITLE
refactor: replaced filfox with blockscout as default block explorer

### DIFF
--- a/service_contracts/src/lib/FilecoinWarmStorageServiceLayout.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceLayout.sol
@@ -27,4 +27,3 @@ bytes32 constant FIL_BEAM_CONTROLLER_ADDRESS_SLOT = bytes32(uint256(18));
 bytes32 constant NEXT_UPGRADE_SLOT = bytes32(uint256(19));
 bytes32 constant STORAGE_PRICE_PER_TIB_PER_MONTH_SLOT = bytes32(uint256(20));
 bytes32 constant MINIMUM_STORAGE_RATE_PER_MONTH_SLOT = bytes32(uint256(21));
-


### PR DESCRIPTION
# Fixes #347 
- Replaced the filfox to blockscout as the default block explorer