### PR TITLE
docs(fwss): document precision loss in minimum rate calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # VIM
 *.swp
+
+# git worktrees
+.trees/

--- a/SPEC.md
+++ b/SPEC.md
@@ -29,6 +29,8 @@ finalRate     = max(sizeBasedRate, minimumRate)
 
 The default minimum floor ensures datasets below ~24.58 GiB still generate the minimum payment of 0.06 USDFC/month.
 
+**Precision note**: Integer division when computing `minimumRate` causes minor precision loss. The actual monthly payment (`minimumRate × EPOCHS_PER_MONTH`) is slightly less than `minimumStorageRatePerMonth`—under 0.0001% for typical floor prices. This is acceptable; see the lockup section below for how pre-flight checks handle this.
+
 ### Pricing Updates
 
 Only the contract owner can update pricing by calling `updatePricing(newStoragePrice, newMinimumRate)`. Maximum allowed values are 10 USDFC for storage price and 0.24 USDFC for minimum rate.
@@ -52,7 +54,9 @@ Clients pay for storage by depositing USDFC into the Filecoin Pay contract. Thes
 lockupRequired = finalRate × EPOCHS_PER_MONTH
 ```
 
-At minimum pricing, this equals 0.06 USDFC. For larger datasets, the lockup equals one month's storage cost.
+At minimum pricing, this equals `minimumStorageRatePerMonth` (0.06 USDFC at default settings). For larger datasets, the lockup equals one month's storage cost.
+
+**Pre-flight check precision**: The pre-flight validation uses a multiply-first formula `(minimumStorageRatePerMonth × EPOCHS_PER_MONTH) ÷ EPOCHS_PER_MONTH` which preserves the exact monthly value. This produces cleaner error messages (the configured floor price rather than a value with precision loss artifacts) and is slightly more conservative than the actual rail lockup. The difference is under 0.0001% and always in the user's favor—they are never required to have less than needed.
 
 **Storage duration** extends as clients deposit additional funds:
 

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -1199,7 +1199,12 @@ contract FilecoinWarmStorageService is
         internal
         view
     {
-        // Calculate required lockup for minimum pricing
+        // Calculate required lockup for minimum pricing.
+        // We use multiply-first here to preserve the exact monthly value for cleaner error messages
+        // (a round number like the configured floor price, rather than a value with many trailing digits
+        // from precision loss). This is slightly more conservative than the actual rail lockup (which
+        // uses the truncated per-epoch rate), but the difference is under 0.0001% and always in the
+        // user's favor - they are never required to have less than what the rail will actually lock.
         uint256 minimumLockupRequired = (minimumStorageRatePerMonth * DEFAULT_LOCKUP_PERIOD) / EPOCHS_PER_MONTH;
 
         // If CDN is enabled, include the fixed cache-miss and CDN lockup amounts
@@ -1375,7 +1380,11 @@ contract FilecoinWarmStorageService is
         // Calculate natural size-based rate
         uint256 naturalRate = calculateStorageSizeBasedRatePerEpoch(totalBytes, storagePricePerTibPerMonth);
 
-        // Calculate minimum rate (floor price converted to per-epoch)
+        // Calculate minimum rate (floor price converted to per-epoch).
+        // Integer division truncates, so (minimumRate × EPOCHS_PER_MONTH) yields slightly less than
+        // minimumStorageRatePerMonth. For typical floor prices this precision loss is under 0.0001%.
+        // The pre-flight lockup check in validatePayerOperatorApprovalAndFunds uses a multiply-first
+        // formula that preserves the full monthly value, ensuring users always have sufficient funds.
         uint256 minimumRate = minimumStorageRatePerMonth / EPOCHS_PER_MONTH;
 
         // Return whichever is higher: natural rate or minimum rate


### PR DESCRIPTION
Closes: https://github.com/FilOzone/filecoin-services/issues/374