### PR TITLE
refactor(fwss): defer rate recalculation to piece operations

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -35,6 +35,8 @@ The default minimum floor ensures datasets below ~24.58 GiB still generate the m
 
 Only the contract owner can update pricing by calling `updatePricing(newStoragePrice, newMinimumRate)`. Maximum allowed values are 10 USDFC for storage price and 0.24 USDFC for minimum rate.
 
+**Effect on existing datasets**: Pricing changes do not immediately update rates for existing datasets. New rates take effect when pieces are next added or removed. This avoids gas-expensive rate recalculations across all active datasets while ensuring new pricing applies to all future storage operations.
+
 ### Rate Update Timing
 
 Rate recalculation timing differs for additions and deletions due to proving semantics:


### PR DESCRIPTION
* Payment rate updates now only occur during piecesAdded or when pieces are removed in nextProvingPeriod.
* Owner pricing changes now only apply on next piece operation.
* RailRateUpdated events only emit when rates actually change.

Prompted by 2 things:

 * We rely on `FilecoinPayV1#modifyRailPayment` being a noop when we're not changing rate. But it's not free, and we know the two points at which the rate changes, so why not use that? The side effect here is as above, owner pricing changes don't take effect until the user modifies the data set in some way.
 * Noticing that `RailRateUpdated` is emitted every time that `updatePaymentRates` gets called, even if there are no rate changes, and it gets called every `nextProvingPeriod`, so we have one of these events per proving period.