### PR TITLE
feat: deploy implementation contract workflow

### DIFF
--- a/.github/workflows/deploy-contract.yml
+++ b/.github/workflows/deploy-contract.yml
@@ -1,0 +1,177 @@
+name: Deploy Contract
+
+on:
+  workflow_dispatch:
+    inputs:
+      network:
+        description: 'Target network'
+        required: true
+        type: choice
+        options:
+          - Calibnet
+          - Mainnet
+      contract:
+        description: 'Contract to deploy'
+        required: true
+        type: choice
+        options:
+          - FWSS Implementation
+          - FWSS StateView
+          - ServiceProviderRegistry
+          - SessionKeyRegistry
+      dry_run:
+        description: 'Dry run (build only, no deployment)'
+        required: false
+        type: boolean
+        default: true
+
+# Required repository secrets:
+#   CALIBNET_CONTRACT_DEPLOYER_PRIVATE_KEY  - Raw private key for the Calibnet deployer wallet
+#   MAINNET_CONTRACT_DEPLOYER_PRIVATE_KEY   - Raw private key for the Mainnet deployer wallet
+#   CALIBNET_RPC_URL                        - RPC endpoint for Calibnet (already exists)
+#   MAINNET_RPC_URL                         - RPC endpoint for Mainnet
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.network == 'Mainnet' && 'mainnet' || '' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.3.5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Set network variables
+        id: network
+        run: |
+          if [ "${{ inputs.network }}" = "Calibnet" ]; then
+            echo "chain_id=314159" >> "$GITHUB_OUTPUT"
+            echo "explorer_url=https://calibration.filfox.info/en" >> "$GITHUB_OUTPUT"
+          else
+            echo "chain_id=314" >> "$GITHUB_OUTPUT"
+            echo "explorer_url=https://filfox.info/en" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set deploy script
+        id: script
+        run: |
+          case "${{ inputs.contract }}" in
+            "FWSS Implementation")
+              echo "path=tools/warm-storage-deploy-implementation.sh" >> "$GITHUB_OUTPUT"
+              echo "label=FilecoinWarmStorageService Implementation" >> "$GITHUB_OUTPUT"
+              ;;
+            "FWSS StateView")
+              echo "path=tools/warm-storage-deploy-view.sh" >> "$GITHUB_OUTPUT"
+              echo "label=FilecoinWarmStorageServiceStateView" >> "$GITHUB_OUTPUT"
+              ;;
+            "ServiceProviderRegistry")
+              echo "path=tools/service-provider-registry-deploy.sh" >> "$GITHUB_OUTPUT"
+              echo "label=ServiceProviderRegistry" >> "$GITHUB_OUTPUT"
+              ;;
+            "SessionKeyRegistry")
+              echo "path=tools/session-key-registry-deploy.sh" >> "$GITHUB_OUTPUT"
+              echo "label=SessionKeyRegistry" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      - name: Install dependencies
+        run: |
+          cd service_contracts
+          make install
+
+      - name: Build contracts
+        run: |
+          cd service_contracts
+          make build
+
+      - name: Create temporary keystore
+        if: inputs.dry_run == false
+        env:
+          DEPLOYER_PRIVATE_KEY: ${{ inputs.network == 'Calibnet' && secrets.CALIBNET_CONTRACT_DEPLOYER_PRIVATE_KEY || secrets.MAINNET_CONTRACT_DEPLOYER_PRIVATE_KEY }}
+        run: |
+          KEYSTORE_PASSWORD="gha-deploy-$(date +%s)"
+          echo "::add-mask::$KEYSTORE_PASSWORD"
+          mkdir -p "$RUNNER_TEMP/keystore"
+          cast wallet import deployer \
+            --private-key "$DEPLOYER_PRIVATE_KEY" \
+            --keystore-dir "$RUNNER_TEMP/keystore" \
+            --unsafe-password "$KEYSTORE_PASSWORD"
+          echo "ETH_KEYSTORE=$RUNNER_TEMP/keystore/deployer" >> "$GITHUB_ENV"
+          echo "PASSWORD=$KEYSTORE_PASSWORD" >> "$GITHUB_ENV"
+
+      - name: Deploy contract
+        if: inputs.dry_run == false
+        env:
+          ETH_RPC_URL: ${{ inputs.network == 'Calibnet' && secrets.CALIBNET_RPC_URL || secrets.MAINNET_RPC_URL }}
+          CHAIN: ${{ steps.network.outputs.chain_id }}
+        run: |
+          cd service_contracts
+          bash "${{ steps.script.outputs.path }}" 2>&1 | tee "$RUNNER_TEMP/deploy-output.txt"
+
+      - name: Clean up keystore
+        if: always()
+        run: rm -rf "$RUNNER_TEMP/keystore"
+
+      - name: Generate job summary
+        if: always()
+        env:
+          EXPLORER_URL: ${{ steps.network.outputs.explorer_url }}
+        run: |
+          {
+            if [ "${{ inputs.dry_run }}" = "true" ]; then
+              echo "## Dry Run: ${{ steps.script.outputs.label }}"
+              echo ""
+              echo "> Build completed successfully. Ready to deploy."
+            else
+              echo "## Deployment: ${{ steps.script.outputs.label }}"
+            fi
+
+            echo ""
+            echo "| Parameter | Value |"
+            echo "|-----------|-------|"
+            echo "| **Network** | ${{ inputs.network }} (${{ steps.network.outputs.chain_id }}) |"
+            echo "| **Contract** | ${{ steps.script.outputs.label }} |"
+            echo "| **Commit** | \`${GITHUB_SHA::8}\` |"
+            echo "| **Actor** | @${{ github.actor }} |"
+            echo "| **Dry Run** | ${{ inputs.dry_run }} |"
+
+            if [ "${{ inputs.dry_run }}" = "false" ] && [ -f "$RUNNER_TEMP/deploy-output.txt" ]; then
+              echo ""
+              echo "### Deployed Addresses"
+              echo ""
+              echo '```'
+              grep -iE "deployed (to|at):?\s*0x[a-fA-F0-9]{40}" "$RUNNER_TEMP/deploy-output.txt" || echo "No addresses found in output"
+              echo '```'
+
+              echo ""
+              echo "### Explorer Links"
+              echo ""
+              grep -iE "deployed (to|at):?\s*0x[a-fA-F0-9]{40}" "$RUNNER_TEMP/deploy-output.txt" \
+                | grep -ioE "0x[a-fA-F0-9]{40}" | sort -u | while read -r addr; do
+                  echo "- [$addr]($EXPLORER_URL/address/$addr)"
+                done
+
+              DIFF=$(cd service_contracts && git diff deployments.json 2>/dev/null || true)
+              if [ -n "$DIFF" ]; then
+                echo ""
+                echo "### deployments.json Changes"
+                echo ""
+                echo '```diff'
+                echo "$DIFF"
+                echo '```'
+                echo ""
+                echo "> **Note:** deployments.json was updated locally but NOT committed. Update it manually in your upgrade PR."
+              fi
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/service_contracts/tools/UPGRADE-PROCESS.md
+++ b/service_contracts/tools/UPGRADE-PROCESS.md
@@ -66,20 +66,25 @@ Always test the upgrade on Calibnet before mainnet.
 
 ### Deploy Implementation
 
-```bash
-cd service_contracts/tools
-export ETH_RPC_URL="https://api.calibration.node.glif.io/rpc/v1"
+Deploy via the [Deploy Contract](https://github.com/FilOzone/filecoin-services/actions/workflows/deploy-contract.yml) GitHub Actions workflow:
 
-./warm-storage-deploy-implementation.sh
-```
+1. Go to **Actions → Deploy Contract → Run workflow**
+2. Select **Calibnet** and **FWSS Implementation**
+3. Run with **dry run** enabled first to verify the build succeeds
+4. Disable dry run and run again to perform the actual deployment
+5. Copy the deployed address from the job summary — you will need it as `NEW_WARM_STORAGE_IMPLEMENTATION_ADDRESS` in the next step
 
-The script updates `deployments.json` automatically. Commit the changes in the branch of the "upgrade PR" above.
+> To deploy locally instead, see [Manual Deployment with Local Scripts](#manual-deployment-with-local-scripts). The local scripts update `deployments.json` automatically.
 
 ### Announce Upgrade
 
+Export the deployed address as `NEW_WARM_STORAGE_IMPLEMENTATION_ADDRESS`. The announce script will automatically update `deployments.json` — commit the changes in the branch of the upgrade PR.
+
 ```bash
+cd service_contracts/tools
+export ETH_RPC_URL="https://api.calibration.node.glif.io/rpc/v1"
 export WARM_STORAGE_PROXY_ADDRESS="0x..."
-export NEW_WARM_STORAGE_IMPLEMENTATION_ADDRESS="0x..."
+export NEW_WARM_STORAGE_IMPLEMENTATION_ADDRESS="0x..."  # from the deploy step above
 export AFTER_EPOCH="123456"
 
 ./warm-storage-announce-upgrade.sh
@@ -100,21 +105,25 @@ Verify the upgrade on [Calibnet Blockscout](https://calibration.filfox.info/).
 
 ## Phase 3: Mainnet Deployment
 
-```bash
-cd service_contracts/tools
-export ETH_RPC_URL="https://api.node.glif.io/rpc/v1"
+Deploy via the [Deploy Contract](https://github.com/FilOzone/filecoin-services/actions/workflows/deploy-contract.yml) GitHub Actions workflow:
 
-./warm-storage-deploy-implementation.sh
-```
+1. Go to **Actions → Deploy Contract → Run workflow**
+2. Select **Mainnet** and **FWSS Implementation**
+3. Run with **dry run** enabled first to verify the build succeeds
+4. Disable dry run and run again (requires approval if the `mainnet` environment is configured)
+5. Copy the deployed address from the job summary — you will need it as `NEW_WARM_STORAGE_IMPLEMENTATION_ADDRESS` in the next step
 
-Commit the updated `deployments.json` in the branch of the "upgrade PR" above.
+> To deploy locally instead, see [Manual Deployment with Local Scripts](#manual-deployment-with-local-scripts). The local scripts update `deployments.json` automatically.
 
 ## Phase 4: Announce Mainnet Upgrade
 
+Export the deployed address as `NEW_WARM_STORAGE_IMPLEMENTATION_ADDRESS`. The announce script will automatically update `deployments.json` — commit the changes in the branch of the upgrade PR.
+
 ```bash
+cd service_contracts/tools
 export ETH_RPC_URL="https://api.node.glif.io/rpc/v1"
 export WARM_STORAGE_PROXY_ADDRESS="0x..."
-export NEW_WARM_STORAGE_IMPLEMENTATION_ADDRESS="0x..."
+export NEW_WARM_STORAGE_IMPLEMENTATION_ADDRESS="0x..."  # from the deploy step above
 export AFTER_EPOCH="123456"
 
 ./warm-storage-announce-upgrade.sh
@@ -127,6 +136,7 @@ Notify stakeholders (see [Stakeholder Communication](#stakeholder-communication)
 After `AFTER_EPOCH` passes:
 
 ```bash
+cd service_contracts/tools
 export ETH_RPC_URL="https://api.node.glif.io/rpc/v1"
 export WARM_STORAGE_PROXY_ADDRESS="0x..."
 export NEW_WARM_STORAGE_IMPLEMENTATION_ADDRESS="0x..."
@@ -178,7 +188,7 @@ The registry uses the same two-step upgrade mechanism as FWSS. Only upgrade it w
 - There are changes to provider registration logic
 - Storage or validation rules need updating
 
-**Deploy new implementation:**
+**Deploy new implementation** via the [Deploy Contract](https://github.com/FilOzone/filecoin-services/actions/workflows/deploy-contract.yml) workflow (select **ServiceProviderRegistry**), or locally:
 ```bash
 ./service-provider-registry-deploy.sh
 ```
@@ -215,7 +225,7 @@ StateView is a helper contract (not upgradeable). Redeploy it when:
 - The view logic changes
 - FWSS changes require updated read functions
 
-**Deploy new StateView:**
+**Deploy new StateView** via the [Deploy Contract](https://github.com/FilOzone/filecoin-services/actions/workflows/deploy-contract.yml) workflow (select **FWSS StateView**), or locally:
 ```bash
 ./warm-storage-deploy-view.sh
 ```
@@ -243,9 +253,37 @@ If any of these need to change, it requires redeploying FWSS entirely. This shou
 
 ---
 
+## Manual Deployment with Local Scripts
+
+If you cannot use the GitHub Actions workflow (e.g., network issues, different wallet setup), you can deploy contracts locally. Make sure `ETH_KEYSTORE`, `PASSWORD`, and `ETH_RPC_URL` are set (see [Environment Variables Reference](#environment-variables-reference)).
+
+### Calibnet
+
+```bash
+cd service_contracts/tools
+export ETH_RPC_URL="https://api.calibration.node.glif.io/rpc/v1"
+
+./warm-storage-deploy-implementation.sh
+```
+
+### Mainnet
+
+```bash
+cd service_contracts/tools
+export ETH_RPC_URL="https://api.node.glif.io/rpc/v1"
+
+./warm-storage-deploy-implementation.sh
+```
+
+The scripts update `deployments.json` automatically. Commit the changes in the branch of the upgrade PR.
+
+---
+
 ## Environment Variables Reference
 
 ### Common Variables
+
+> **Note:** When deploying via the [GitHub Actions workflow](#phase-2-calibnet-rehearsal), these variables are configured automatically from repository secrets. You only need to set them for [local deployments](#manual-deployment-with-local-scripts).
 
 | Variable | Description |
 |----------|-------------|


### PR DESCRIPTION
Closes: https://github.com/FilOzone/filecoin-services/issues/413

Creates GitHub Actions workflow to deploy FWSS-related contracts, streamlining the upgrade process by eliminating the need to fork the repo, set up local environment variables, and run scripts manually.

Secrets added to the GH-repo:

- CALIBNET_CONTRACT_DEPLOYER_PRIVATE_KEY
- MAINNET_CONTRACT_DEPLOYER_PRIVATE_KEY
- CALIBNET_RPC_URL (was already a ORG-secret)
- MAINNET_RPC_URL