### PR TITLE
test(fwss): rework signature fixtures for synapse-sdk parity, add DeleteDataSet

### DIFF
--- a/service_contracts/src/lib/SignatureVerificationLib.sol
+++ b/service_contracts/src/lib/SignatureVerificationLib.sol
@@ -14,18 +14,18 @@ library SignatureVerificationLib {
     // EIP-712 Type hashes
     // ============================================================================
 
-    bytes32 private constant METADATA_ENTRY_TYPEHASH = keccak256("MetadataEntry(string key,string value)");
+    bytes32 internal constant METADATA_ENTRY_TYPEHASH = keccak256("MetadataEntry(string key,string value)");
 
-    bytes32 private constant CREATE_DATA_SET_TYPEHASH = keccak256(
+    bytes32 internal constant CREATE_DATA_SET_TYPEHASH = keccak256(
         "CreateDataSet(uint256 clientDataSetId,address payee,MetadataEntry[] metadata)MetadataEntry(string key,string value)"
     );
 
-    bytes32 private constant CID_TYPEHASH = keccak256("Cid(bytes data)");
+    bytes32 internal constant CID_TYPEHASH = keccak256("Cid(bytes data)");
 
-    bytes32 private constant PIECE_METADATA_TYPEHASH =
+    bytes32 internal constant PIECE_METADATA_TYPEHASH =
         keccak256("PieceMetadata(uint256 pieceIndex,MetadataEntry[] metadata)MetadataEntry(string key,string value)");
 
-    bytes32 private constant ADD_PIECES_TYPEHASH = keccak256(
+    bytes32 internal constant ADD_PIECES_TYPEHASH = keccak256(
         "AddPieces(uint256 clientDataSetId,uint256 nonce,Cid[] pieceData,PieceMetadata[] pieceMetadata)"
         "Cid(bytes data)" "MetadataEntry(string key,string value)"
         "PieceMetadata(uint256 pieceIndex,MetadataEntry[] metadata)"

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -85,8 +85,6 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
     bytes32 private constant SCHEDULE_PIECE_REMOVALS_TYPEHASH =
         keccak256("SchedulePieceRemovals(uint256 clientDataSetId,uint256[] pieceIds)");
 
-    bytes32 private constant DELETE_DATA_SET_TYPEHASH = keccak256("DeleteDataSet(uint256 clientDataSetId)");
-
     // Expected lockup amounts for CDN rails
     uint256 defaultCDNLockup;
     uint256 defaultCacheMissLockup;

--- a/service_contracts/test/SignatureFixtureTest.t.sol
+++ b/service_contracts/test/SignatureFixtureTest.t.sol
@@ -4,66 +4,79 @@ pragma solidity ^0.8.13;
 /**
  * USAGE INSTRUCTIONS:
  *
- * 1. Generate new signature fixtures:
+ * 1. Generate signature fixtures + JSON:
  *    forge test --match-test testGenerateFixtures -vv
  *
- * 2. Copy the JavaScript output from console to update synapse-sdk tests
- *    Look for the "Copy to synapse-sdk tests:" section in the output
+ * 2. Update synapse-sdk fixtures (typed-data.test.ts FIXTURES const):
+ *    Copy the "Copy to typed-data.test.ts FIXTURES:" section verbatim.
  *
  * 3. Update external_signatures.json:
- *    - Run: forge test --match-test testGenerateFixtures -vv
- *    - Look for "JSON format for external_signatures.json:" section in output
- *    - Copy the complete JSON output to replace test/external_signatures.json
+ *    Copy the "JSON format for external_signatures.json:" section verbatim.
  *
- * 4. Verify external signatures work:
+ * 4. Verify external signatures still verify against the contract:
  *    forge test --match-test testExternalSignatures -vv
  *
  * 5. View EIP-712 type structures:
  *    forge test --match-test testEIP712TypeStructures -vv
  *
- * NOTE: This test generates deterministic signatures using a well-known test private key.
- * The signatures are compatible with FilecoinWarmStorageService but generated independently
- * to avoid heavy dependency compilation issues.
+ * NOTE: Fixtures use the **calibration** chain domain (chainId 314159, FWSS
+ * address 0x02925630df557F957f70E112bA06e50965417CA0) so they match what the
+ * SDK produces by default for that chain. Do not change without updating the
+ * SDK fixtures in lockstep.
  */
 import {Test, console} from "forge-std/Test.sol";
 import {Cids} from "@pdp/Cids.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+import {SignatureVerificationLib} from "../src/lib/SignatureVerificationLib.sol";
 
 /**
  * @title EIP-712 Signature Fixture Generator
- * @dev Standalone contract for generating reference signatures
+ * @dev Standalone contract for generating reference signatures.
  *
- * This contract generates EIP-712 signatures that are compatible with FilecoinWarmStorageService
- * but doesn't import the full contract to avoid compilation stack depth issues in dependencies.
+ * Computes the EIP-712 domain separator manually from a constructor-supplied
+ * (chainId, verifyingContract) pair so we can mirror an arbitrary deployed
+ * domain (e.g. calibration FWSS) without redeploying at that address.
+ *
+ * Typehashes for operations the FWSS contract implements come from
+ * SignatureVerificationLib so any rename in the library will surface here as
+ * a fixture mismatch (caught by external_signatures.json + the SDK fixtures).
+ * DELETE_DATA_SET_TYPEHASH is declared locally because the FWSS contract
+ * doesn't currently implement DeleteDataSet (handler removed in #255); move
+ * it into the library when the impl returns.
  */
-contract MetadataSignatureTestContract is EIP712 {
-    constructor() EIP712("FilecoinWarmStorageService", "1") {}
+contract MetadataSignatureTestContract {
+    bytes32 private constant EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
 
-    // EIP-712 type hashes - must match FilecoinWarmStorageService exactly
-    bytes32 private constant METADATA_ENTRY_TYPEHASH = keccak256("MetadataEntry(string key,string value)");
+    bytes32 private constant DELETE_DATA_SET_TYPEHASH = keccak256("DeleteDataSet(uint256 dataSetId)");
 
-    bytes32 private constant CREATE_DATA_SET_TYPEHASH = keccak256(
-        "CreateDataSet(uint256 clientDataSetId,address payee,MetadataEntry[] metadata)MetadataEntry(string key,string value)"
-    );
+    bytes32 private immutable _domainSeparator;
 
-    bytes32 private constant CID_TYPEHASH = keccak256("Cid(bytes data)");
+    constructor(uint256 chainId, address verifyingContract) {
+        _domainSeparator = keccak256(
+            abi.encode(
+                EIP712_DOMAIN_TYPEHASH,
+                keccak256(bytes("FilecoinWarmStorageService")),
+                keccak256(bytes("1")),
+                chainId,
+                verifyingContract
+            )
+        );
+    }
 
-    bytes32 private constant PIECE_METADATA_TYPEHASH =
-        keccak256("PieceMetadata(uint256 pieceIndex,MetadataEntry[] metadata)MetadataEntry(string key,string value)");
+    function getDomainSeparator() public view returns (bytes32) {
+        return _domainSeparator;
+    }
 
-    bytes32 private constant ADD_PIECES_TYPEHASH = keccak256(
-        "AddPieces(uint256 clientDataSetId,uint256 nonce,Cid[] pieceData,PieceMetadata[] pieceMetadata)"
-        "Cid(bytes data)" "MetadataEntry(string key,string value)"
-        "PieceMetadata(uint256 pieceIndex,MetadataEntry[] metadata)"
-    );
-
-    bytes32 private constant SCHEDULE_PIECE_REMOVALS_TYPEHASH =
-        keccak256("SchedulePieceRemovals(uint256 clientDataSetId,uint256[] pieceIds)");
+    function _hashTypedData(bytes32 structHash) internal view returns (bytes32) {
+        return keccak256(abi.encodePacked("\x19\x01", _domainSeparator, structHash));
+    }
 
     // Metadata hashing functions
     function hashMetadataEntry(string memory key, string memory value) internal pure returns (bytes32) {
-        return keccak256(abi.encode(METADATA_ENTRY_TYPEHASH, keccak256(bytes(key)), keccak256(bytes(value))));
+        return keccak256(
+            abi.encode(SignatureVerificationLib.METADATA_ENTRY_TYPEHASH, keccak256(bytes(key)), keccak256(bytes(value)))
+        );
     }
 
     function hashMetadataEntries(string[] memory keys, string[] memory values) internal pure returns (bytes32) {
@@ -82,7 +95,7 @@ contract MetadataSignatureTestContract is EIP712 {
         returns (bytes32)
     {
         bytes32 metadataHash = hashMetadataEntries(keys, values);
-        return keccak256(abi.encode(PIECE_METADATA_TYPEHASH, pieceIndex, metadataHash));
+        return keccak256(abi.encode(SignatureVerificationLib.PIECE_METADATA_TYPEHASH, pieceIndex, metadataHash));
     }
 
     function hashAllPieceMetadata(string[][] memory allKeys, string[][] memory allValues)
@@ -108,9 +121,7 @@ contract MetadataSignatureTestContract is EIP712 {
         string[] memory metadataValues,
         bytes memory signature
     ) public view returns (bool) {
-        bytes32 metadataHash = hashMetadataEntries(metadataKeys, metadataValues);
-        bytes32 structHash = keccak256(abi.encode(CREATE_DATA_SET_TYPEHASH, clientDataSetId, payee, metadataHash));
-        bytes32 digest = _hashTypedDataV4(structHash);
+        bytes32 digest = getCreateDataSetDigest(clientDataSetId, payee, metadataKeys, metadataValues);
         address signer = ECDSA.recover(digest, signature);
         return signer == payer;
     }
@@ -129,6 +140,27 @@ contract MetadataSignatureTestContract is EIP712 {
         return signer == payer;
     }
 
+    function verifySchedulePieceRemovalsSignature(
+        address payer,
+        uint256 clientDataSetId,
+        uint256[] memory pieceIds,
+        bytes memory signature
+    ) public view returns (bool) {
+        bytes32 digest = getSchedulePieceRemovalsDigest(clientDataSetId, pieceIds);
+        address signer = ECDSA.recover(digest, signature);
+        return signer == payer;
+    }
+
+    function verifyDeleteDataSetSignature(address payer, uint256 dataSetId, bytes memory signature)
+        public
+        view
+        returns (bool)
+    {
+        bytes32 digest = getDeleteDataSetDigest(dataSetId);
+        address signer = ECDSA.recover(digest, signature);
+        return signer == payer;
+    }
+
     // Digest creation functions
     function getCreateDataSetDigest(
         uint256 clientDataSetId,
@@ -137,8 +169,10 @@ contract MetadataSignatureTestContract is EIP712 {
         string[] memory metadataValues
     ) public view returns (bytes32) {
         bytes32 metadataHash = hashMetadataEntries(metadataKeys, metadataValues);
-        bytes32 structHash = keccak256(abi.encode(CREATE_DATA_SET_TYPEHASH, clientDataSetId, payee, metadataHash));
-        return _hashTypedDataV4(structHash);
+        bytes32 structHash = keccak256(
+            abi.encode(SignatureVerificationLib.CREATE_DATA_SET_TYPEHASH, clientDataSetId, payee, metadataHash)
+        );
+        return _hashTypedData(structHash);
     }
 
     function getAddPiecesDigest(
@@ -148,23 +182,23 @@ contract MetadataSignatureTestContract is EIP712 {
         string[][] memory metadataKeys,
         string[][] memory metadataValues
     ) public view returns (bytes32) {
-        // Hash each PieceCid struct
         bytes32[] memory pieceCidsHashes = new bytes32[](pieceCidsArray.length);
         for (uint256 i = 0; i < pieceCidsArray.length; i++) {
-            pieceCidsHashes[i] = keccak256(abi.encode(CID_TYPEHASH, keccak256(pieceCidsArray[i].data)));
+            pieceCidsHashes[i] =
+                keccak256(abi.encode(SignatureVerificationLib.CID_TYPEHASH, keccak256(pieceCidsArray[i].data)));
         }
 
         bytes32 pieceMetadataHash = hashAllPieceMetadata(metadataKeys, metadataValues);
         bytes32 structHash = keccak256(
             abi.encode(
-                ADD_PIECES_TYPEHASH,
+                SignatureVerificationLib.ADD_PIECES_TYPEHASH,
                 clientDataSetId,
                 nonce,
                 keccak256(abi.encodePacked(pieceCidsHashes)),
                 pieceMetadataHash
             )
         );
-        return _hashTypedDataV4(structHash);
+        return _hashTypedData(structHash);
     }
 
     function getSchedulePieceRemovalsDigest(uint256 clientDataSetId, uint256[] memory pieceIds)
@@ -173,13 +207,18 @@ contract MetadataSignatureTestContract is EIP712 {
         returns (bytes32)
     {
         bytes32 structHash = keccak256(
-            abi.encode(SCHEDULE_PIECE_REMOVALS_TYPEHASH, clientDataSetId, keccak256(abi.encodePacked(pieceIds)))
+            abi.encode(
+                SignatureVerificationLib.SCHEDULE_PIECE_REMOVALS_TYPEHASH,
+                clientDataSetId,
+                keccak256(abi.encodePacked(pieceIds))
+            )
         );
-        return _hashTypedDataV4(structHash);
+        return _hashTypedData(structHash);
     }
 
-    function getDomainSeparator() public view returns (bytes32) {
-        return _domainSeparatorV4();
+    function getDeleteDataSetDigest(uint256 dataSetId) public view returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(DELETE_DATA_SET_TYPEHASH, dataSetId));
+        return _hashTypedData(structHash);
     }
 }
 
@@ -190,96 +229,81 @@ contract MetadataSignatureFixturesTest is Test {
     uint256 constant TEST_PRIVATE_KEY = 0x1234567890123456789012345678901234567890123456789012345678901234;
     address constant TEST_SIGNER = 0x2e988A386a799F506693793c6A5AF6B54dfAaBfB;
 
+    // Mirror the SDK's calibration chain configuration so SDK fixtures
+    // (synapse-core/test/typed-data.test.ts) can be regenerated by copy-paste.
+    uint256 constant DOMAIN_CHAIN_ID = 314_159;
+    address constant DOMAIN_VERIFYING_CONTRACT = 0x02925630df557F957f70E112bA06e50965417CA0;
+
     // Test data
     uint256 constant CLIENT_DATA_SET_ID = 12345;
     address constant PAYEE = 0x70997970C51812dc3A010C7d01b50e0d17dc79C8;
     uint256 constant FIRST_ADDED = 1;
 
     function setUp() public {
-        testContract = new MetadataSignatureTestContract();
+        testContract = new MetadataSignatureTestContract(DOMAIN_CHAIN_ID, DOMAIN_VERIFYING_CONTRACT);
     }
 
     function testGenerateFixtures() public view {
-        console.log("=== EIP-712 SIGNATURE FIXTURES ===");
-        console.log("Contract Address:", address(testContract));
-        console.log("Test Signer:", TEST_SIGNER);
-        console.log("Chain ID:", block.chainid);
-        console.log("Domain Separator:", vm.toString(testContract.getDomainSeparator()));
-        console.log("");
-
-        // Create test metadata
+        // Create test inputs
         (string[] memory dataSetKeys, string[] memory dataSetValues) = createTestDataSetMetadata();
         (string[][] memory pieceKeys, string[][] memory pieceValues) = createTestPieceMetadata();
+        Cids.Cid[] memory pieceCidsArray = createTestPieceCids();
 
-        // Generate all signatures
-        bytes memory createDataSetSig = generateCreateDataSetSignature(dataSetKeys, dataSetValues);
-        bytes memory addPiecesSig = generateAddPiecesSignature(pieceKeys, pieceValues);
-
-        // Generate additional signatures for JSON compatibility
         uint256[] memory testPieceIds = new uint256[](3);
         testPieceIds[0] = 1;
         testPieceIds[1] = 3;
         testPieceIds[2] = 5;
+
+        // Generate raw signatures
+        bytes memory createDataSetSig = generateCreateDataSetSignature(dataSetKeys, dataSetValues);
+        bytes memory addPiecesSig = generateAddPiecesSignature(pieceKeys, pieceValues);
         bytes memory scheduleRemovalsSig = generateSchedulePieceRemovalsSignature(testPieceIds);
+        bytes memory deleteDataSetSig = generateDeleteDataSetSignature(CLIENT_DATA_SET_ID);
 
-        // Get all digests
-        bytes32 createDataSetDigest =
-            testContract.getCreateDataSetDigest(CLIENT_DATA_SET_ID, PAYEE, dataSetKeys, dataSetValues);
-        Cids.Cid[] memory pieceCidsArray = createTestPieceCids();
-        bytes32 addPiecesDigest =
-            testContract.getAddPiecesDigest(CLIENT_DATA_SET_ID, FIRST_ADDED, pieceCidsArray, pieceKeys, pieceValues);
-        bytes32 scheduleRemovalsDigest = testContract.getSchedulePieceRemovalsDigest(CLIENT_DATA_SET_ID, testPieceIds);
+        // Compute SDK-format extraData (abi-encoded, matching synapse-core sign-* helpers)
+        bytes memory createDataSetExtraData =
+            encodeCreateDataSetExtraData(TEST_SIGNER, CLIENT_DATA_SET_ID, dataSetKeys, dataSetValues, createDataSetSig);
+        bytes memory addPiecesExtraData = encodeAddPiecesExtraData(FIRST_ADDED, pieceKeys, pieceValues, addPiecesSig);
+        bytes memory scheduleRemovalsExtraData = encodeSignatureBytes(scheduleRemovalsSig);
+        bytes memory deleteDataSetExtraData = encodeSignatureBytes(deleteDataSetSig);
 
-        // Output JavaScript format for copying to synapse-sdk tests
-        console.log("Copy this JavaScript const to synapse-sdk src/test/pdp-auth.test.ts:");
+        // Output FIXTURES const for synapse-sdk (typed-data.test.ts)
+        console.log("Copy to typed-data.test.ts FIXTURES:");
         console.log("const FIXTURES = {");
         console.log("  // Test private key from Solidity (never use in production!)");
-        console.log("  privateKey: '%x',", TEST_PRIVATE_KEY);
-        console.log("  signerAddress: '%s',", TEST_SIGNER);
-        console.log("  contractAddress: '%s',", address(testContract));
-        console.log("  chainId: %d,", block.chainid);
-        console.log("  domainSeparator: '%s',", vm.toString(testContract.getDomainSeparator()));
-        console.log("");
-        console.log("  // EIP-712 domain separator components");
-        console.log("  domain: {");
-        console.log("    name: 'FilecoinWarmStorageService',");
-        console.log("    version: '1',");
-        console.log("    chainId: %d,", block.chainid);
-        console.log("    verifyingContract: '%s'", address(testContract));
-        console.log("  },");
+        console.log("  privateKey: '%x' as Hex,", TEST_PRIVATE_KEY);
         console.log("");
         console.log("  // Expected EIP-712 signatures");
         console.log("  signatures: {");
         console.log("    createDataSet: {");
-        console.log("      signature: '%s',", vm.toString(createDataSetSig));
-        console.log("      digest: '%s',", vm.toString(createDataSetDigest));
-        console.log("      clientDataSetId: %d,", CLIENT_DATA_SET_ID);
-        console.log("      payee: '%s',", PAYEE);
-        console.log("      metadata: [{ key: '%s', value: '%s' }]", dataSetKeys[0], dataSetValues[0]);
+        console.log("      extraData:");
+        console.log("        '%s' as Hex,", vm.toString(createDataSetExtraData));
+        console.log("      clientDataSetId: %dn,", CLIENT_DATA_SET_ID);
+        console.log("      payee: '%s' as Address,", PAYEE);
+        console.log("      metadata: [{ key: '%s', value: '%s' }],", dataSetKeys[0], dataSetValues[0]);
         console.log("    },");
         console.log("    addPieces: {");
-        console.log("      signature: '%s',", vm.toString(addPiecesSig));
-        console.log("      digest: '%s',", vm.toString(addPiecesDigest));
-        console.log("      clientDataSetId: %d,", CLIENT_DATA_SET_ID);
-        console.log("      nonce: %d,", FIRST_ADDED);
-        console.log(
-            "      pieceCidBytes: ['%s', '%s'],",
-            vm.toString(pieceCidsArray[0].data),
-            vm.toString(pieceCidsArray[1].data)
-        );
-        console.log("      metadata: [[], []]");
+        console.log("      extraData:");
+        console.log("        '%s' as Hex,", vm.toString(addPiecesExtraData));
+        console.log("      clientDataSetId: %dn,", CLIENT_DATA_SET_ID);
+        console.log("      nonce: %dn,", FIRST_ADDED);
         console.log("    },");
         console.log("    schedulePieceRemovals: {");
-        console.log("      signature: '%s',", vm.toString(scheduleRemovalsSig));
-        console.log("      digest: '%s',", vm.toString(scheduleRemovalsDigest));
-        console.log("      clientDataSetId: %d,", CLIENT_DATA_SET_ID);
-        console.log("      pieceIds: [%d, %d, %d]", testPieceIds[0], testPieceIds[1], testPieceIds[2]);
-        console.log("    }");
-        console.log("  }");
+        console.log("      extraData:");
+        console.log("        '%s' as Hex,", vm.toString(scheduleRemovalsExtraData));
+        console.log("      clientDataSetId: %dn,", CLIENT_DATA_SET_ID);
+        console.log("      pieceIds: [%dn, %dn, %dn],", testPieceIds[0], testPieceIds[1], testPieceIds[2]);
+        console.log("    },");
+        console.log("    deleteDataSet: {");
+        console.log("      extraData:");
+        console.log("        '%s' as Hex,", vm.toString(deleteDataSetExtraData));
+        console.log("      dataSetId: %dn,", CLIENT_DATA_SET_ID);
+        console.log("    },");
+        console.log("  },");
         console.log("}");
         console.log("");
 
-        // Output JSON format for easy copy to external_signatures.json
+        // Output JSON for external_signatures.json (raw signatures, used by testExternalSignatures)
         console.log("JSON format for external_signatures.json:");
         console.log("{");
         console.log("  \"signer\": \"%s\",", TEST_SIGNER);
@@ -315,10 +339,14 @@ contract MetadataSignatureFixturesTest is Test {
         console.log("      %d,", testPieceIds[1]);
         console.log("      %d", testPieceIds[2]);
         console.log("    ]");
+        console.log("  },");
+        console.log("  \"deleteDataSet\": {");
+        console.log("    \"signature\": \"%s\",", vm.toString(deleteDataSetSig));
+        console.log("    \"dataSetId\": %d", CLIENT_DATA_SET_ID);
         console.log("  }");
         console.log("}");
 
-        // Verify signatures work
+        // Verify signatures recover correctly
         assertTrue(
             testContract.verifyCreateDataSetSignature(
                 TEST_SIGNER, CLIENT_DATA_SET_ID, PAYEE, dataSetKeys, dataSetValues, createDataSetSig
@@ -333,11 +361,21 @@ contract MetadataSignatureFixturesTest is Test {
             "AddPieces signature verification failed"
         );
 
-        console.log("All signature verifications passed!");
+        assertTrue(
+            testContract.verifySchedulePieceRemovalsSignature(
+                TEST_SIGNER, CLIENT_DATA_SET_ID, testPieceIds, scheduleRemovalsSig
+            ),
+            "SchedulePieceRemovals signature verification failed"
+        );
+
+        assertTrue(
+            testContract.verifyDeleteDataSetSignature(TEST_SIGNER, CLIENT_DATA_SET_ID, deleteDataSetSig),
+            "DeleteDataSet signature verification failed"
+        );
     }
 
     /**
-     * @dev Test external signatures against contract verification
+     * @dev Test external signatures (from external_signatures.json) verify against the contract.
      */
     function testExternalSignatures() public view {
         string memory json = vm.readFile("./test/external_signatures.json");
@@ -345,26 +383,25 @@ contract MetadataSignatureFixturesTest is Test {
 
         console.log("Testing external signatures for signer:", signer);
 
-        // Test CreateDataSet signature
         testCreateDataSetSignature(json, signer);
-
-        // Test AddPieces signature
         testAddPiecesSignature(json, signer);
+        testSchedulePieceRemovalsSignature(json, signer);
+        testDeleteDataSetSignature(json, signer);
 
         console.log("All external signature tests PASSED!");
     }
 
     /**
-     * @dev Show EIP-712 type structures for external developers
+     * @dev Show EIP-712 type structures for external developers.
      */
-    function testEIP712TypeStructures() public view {
+    function testEIP712TypeStructures() public pure {
         console.log("=== EIP-712 TYPE STRUCTURES ===");
         console.log("");
         console.log("Domain:");
         console.log("  name: 'FilecoinWarmStorageService'");
         console.log("  version: '1'");
-        console.log("  chainId: %d", block.chainid);
-        console.log("  verifyingContract: %s", address(testContract));
+        console.log("  chainId: %d", DOMAIN_CHAIN_ID);
+        console.log("  verifyingContract: %s", DOMAIN_VERIFYING_CONTRACT);
         console.log("");
         console.log("Types:");
         console.log("  MetadataEntry: [");
@@ -392,6 +429,9 @@ contract MetadataSignatureFixturesTest is Test {
         console.log("  SchedulePieceRemovals: [");
         console.log("    { name: 'clientDataSetId', type: 'uint256' },");
         console.log("    { name: 'pieceIds', type: 'uint256[]' }");
+        console.log("  ],");
+        console.log("  DeleteDataSet: [");
+        console.log("    { name: 'dataSetId', type: 'uint256' }");
         console.log("  ]");
     }
 
@@ -407,7 +447,6 @@ contract MetadataSignatureFixturesTest is Test {
         keys = new string[][](2);
         values = new string[][](2);
 
-        // Empty metadata for both pieces to keep it simple
         keys[0] = new string[](0);
         values[0] = new string[](0);
         keys[1] = new string[](0);
@@ -453,13 +492,44 @@ contract MetadataSignatureFixturesTest is Test {
         return abi.encodePacked(r, s, v);
     }
 
-    // External signature validation functions
+    function generateDeleteDataSetSignature(uint256 dataSetId) internal view returns (bytes memory) {
+        bytes32 digest = testContract.getDeleteDataSetDigest(dataSetId);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(TEST_PRIVATE_KEY, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    // SDK extraData encoders (must match synapse-core sign-* helpers exactly)
+
+    function encodeCreateDataSetExtraData(
+        address payer,
+        uint256 clientDataSetId,
+        string[] memory keys,
+        string[] memory values,
+        bytes memory signature
+    ) internal pure returns (bytes memory) {
+        return abi.encode(payer, clientDataSetId, keys, values, signature);
+    }
+
+    function encodeAddPiecesExtraData(
+        uint256 nonce,
+        string[][] memory keys,
+        string[][] memory values,
+        bytes memory signature
+    ) internal pure returns (bytes memory) {
+        return abi.encode(nonce, keys, values, signature);
+    }
+
+    function encodeSignatureBytes(bytes memory signature) internal pure returns (bytes memory) {
+        return abi.encode(signature);
+    }
+
+    // External signature validators (verify external_signatures.json against the contract)
+
     function testCreateDataSetSignature(string memory json, address signer) internal view {
         string memory signature = vm.parseJsonString(json, ".createDataSet.signature");
         uint256 clientDataSetId = vm.parseJsonUint(json, ".createDataSet.clientDataSetId");
         address payee = vm.parseJsonAddress(json, ".createDataSet.payee");
 
-        // Parse metadata from JSON - simplified for single entry
         string[] memory keys = new string[](1);
         string[] memory values = new string[](1);
         keys[0] = vm.parseJsonString(json, ".createDataSet.metadata[0].key");
@@ -478,16 +548,13 @@ contract MetadataSignatureFixturesTest is Test {
         uint256 clientDataSetId = vm.parseJsonUint(json, ".addPieces.clientDataSetId");
         uint256 nonce = vm.parseJsonUint(json, ".addPieces.nonce");
 
-        // Parse piece data arrays
         bytes[] memory pieceCidBytes = vm.parseJsonBytesArray(json, ".addPieces.pieceCidBytes");
 
-        // Create Cids array
         Cids.Cid[] memory pieceData = new Cids.Cid[](pieceCidBytes.length);
         for (uint256 i = 0; i < pieceCidBytes.length; i++) {
             pieceData[i] = Cids.Cid({data: pieceCidBytes[i]});
         }
 
-        // For now, use empty metadata (as per the JSON)
         string[][] memory keys = new string[][](pieceData.length);
         string[][] memory values = new string[][](pieceData.length);
         for (uint256 i = 0; i < pieceData.length; i++) {
@@ -501,5 +568,28 @@ contract MetadataSignatureFixturesTest is Test {
 
         assertTrue(isValid, "AddPieces signature verification failed");
         console.log("  AddPieces: PASSED");
+    }
+
+    function testSchedulePieceRemovalsSignature(string memory json, address signer) internal view {
+        string memory signature = vm.parseJsonString(json, ".schedulePieceRemovals.signature");
+        uint256 clientDataSetId = vm.parseJsonUint(json, ".schedulePieceRemovals.clientDataSetId");
+        uint256[] memory pieceIds = vm.parseJsonUintArray(json, ".schedulePieceRemovals.pieceIds");
+
+        bool isValid = testContract.verifySchedulePieceRemovalsSignature(
+            signer, clientDataSetId, pieceIds, vm.parseBytes(signature)
+        );
+
+        assertTrue(isValid, "SchedulePieceRemovals signature verification failed");
+        console.log("  SchedulePieceRemovals: PASSED");
+    }
+
+    function testDeleteDataSetSignature(string memory json, address signer) internal view {
+        string memory signature = vm.parseJsonString(json, ".deleteDataSet.signature");
+        uint256 dataSetId = vm.parseJsonUint(json, ".deleteDataSet.dataSetId");
+
+        bool isValid = testContract.verifyDeleteDataSetSignature(signer, dataSetId, vm.parseBytes(signature));
+
+        assertTrue(isValid, "DeleteDataSet signature verification failed");
+        console.log("  DeleteDataSet: PASSED");
     }
 }

--- a/service_contracts/test/SignatureFixtureTest.t.sol
+++ b/service_contracts/test/SignatureFixtureTest.t.sol
@@ -72,46 +72,6 @@ contract MetadataSignatureTestContract {
         return keccak256(abi.encodePacked("\x19\x01", _domainSeparator, structHash));
     }
 
-    // Metadata hashing functions
-    function hashMetadataEntry(string memory key, string memory value) internal pure returns (bytes32) {
-        return keccak256(
-            abi.encode(SignatureVerificationLib.METADATA_ENTRY_TYPEHASH, keccak256(bytes(key)), keccak256(bytes(value)))
-        );
-    }
-
-    function hashMetadataEntries(string[] memory keys, string[] memory values) internal pure returns (bytes32) {
-        if (keys.length == 0) return keccak256("");
-
-        bytes32[] memory hashes = new bytes32[](keys.length);
-        for (uint256 i = 0; i < keys.length; i++) {
-            hashes[i] = hashMetadataEntry(keys[i], values[i]);
-        }
-        return keccak256(abi.encodePacked(hashes));
-    }
-
-    function hashPieceMetadata(uint256 pieceIndex, string[] memory keys, string[] memory values)
-        internal
-        pure
-        returns (bytes32)
-    {
-        bytes32 metadataHash = hashMetadataEntries(keys, values);
-        return keccak256(abi.encode(SignatureVerificationLib.PIECE_METADATA_TYPEHASH, pieceIndex, metadataHash));
-    }
-
-    function hashAllPieceMetadata(string[][] memory allKeys, string[][] memory allValues)
-        internal
-        pure
-        returns (bytes32)
-    {
-        if (allKeys.length == 0) return keccak256("");
-
-        bytes32[] memory pieceHashes = new bytes32[](allKeys.length);
-        for (uint256 i = 0; i < allKeys.length; i++) {
-            pieceHashes[i] = hashPieceMetadata(i, allKeys[i], allValues[i]);
-        }
-        return keccak256(abi.encodePacked(pieceHashes));
-    }
-
     // Signature verification functions
     function verifyCreateDataSetSignature(
         address payer,
@@ -168,11 +128,9 @@ contract MetadataSignatureTestContract {
         string[] memory metadataKeys,
         string[] memory metadataValues
     ) public view returns (bytes32) {
-        bytes32 metadataHash = hashMetadataEntries(metadataKeys, metadataValues);
-        bytes32 structHash = keccak256(
-            abi.encode(SignatureVerificationLib.CREATE_DATA_SET_TYPEHASH, clientDataSetId, payee, metadataHash)
+        return _hashTypedData(
+            SignatureVerificationLib.createDataSetStructHash(clientDataSetId, payee, metadataKeys, metadataValues)
         );
-        return _hashTypedData(structHash);
     }
 
     function getAddPiecesDigest(
@@ -182,25 +140,15 @@ contract MetadataSignatureTestContract {
         string[][] memory metadataKeys,
         string[][] memory metadataValues
     ) public view returns (bytes32) {
-        bytes32[] memory pieceCidsHashes = new bytes32[](pieceCidsArray.length);
-        for (uint256 i = 0; i < pieceCidsArray.length; i++) {
-            pieceCidsHashes[i] =
-                keccak256(abi.encode(SignatureVerificationLib.CID_TYPEHASH, keccak256(pieceCidsArray[i].data)));
-        }
-
-        bytes32 pieceMetadataHash = hashAllPieceMetadata(metadataKeys, metadataValues);
-        bytes32 structHash = keccak256(
-            abi.encode(
-                SignatureVerificationLib.ADD_PIECES_TYPEHASH,
-                clientDataSetId,
-                nonce,
-                keccak256(abi.encodePacked(pieceCidsHashes)),
-                pieceMetadataHash
+        return _hashTypedData(
+            SignatureVerificationLib.addPiecesStructHash(
+                clientDataSetId, nonce, pieceCidsArray, metadataKeys, metadataValues
             )
         );
-        return _hashTypedData(structHash);
     }
 
+    // SchedulePieceRemovals struct hash isn't exposed by the library (FWSS computes
+    // it inline at the call site); re-derived here from the shared typehash.
     function getSchedulePieceRemovalsDigest(uint256 clientDataSetId, uint256[] memory pieceIds)
         public
         view
@@ -235,7 +183,12 @@ contract MetadataSignatureFixturesTest is Test {
     address constant DOMAIN_VERIFYING_CONTRACT = 0x02925630df557F957f70E112bA06e50965417CA0;
 
     // Test data
+    // CLIENT_DATA_SET_ID is the per-client nonce signed for create/add/schedule
+    // operations (assigned by the client, opaque to the contract). DATA_SET_ID
+    // is the canonical PDPVerifier-assigned id signed for delete. Distinct
+    // values keep the conceptual separation visible in the fixtures.
     uint256 constant CLIENT_DATA_SET_ID = 12345;
+    uint256 constant DATA_SET_ID = 67890;
     address constant PAYEE = 0x70997970C51812dc3A010C7d01b50e0d17dc79C8;
     uint256 constant FIRST_ADDED = 1;
 
@@ -258,7 +211,7 @@ contract MetadataSignatureFixturesTest is Test {
         bytes memory createDataSetSig = generateCreateDataSetSignature(dataSetKeys, dataSetValues);
         bytes memory addPiecesSig = generateAddPiecesSignature(pieceKeys, pieceValues);
         bytes memory scheduleRemovalsSig = generateSchedulePieceRemovalsSignature(testPieceIds);
-        bytes memory deleteDataSetSig = generateDeleteDataSetSignature(CLIENT_DATA_SET_ID);
+        bytes memory deleteDataSetSig = generateDeleteDataSetSignature(DATA_SET_ID);
 
         // Compute SDK-format extraData (abi-encoded, matching synapse-core sign-* helpers)
         bytes memory createDataSetExtraData =
@@ -297,7 +250,7 @@ contract MetadataSignatureFixturesTest is Test {
         console.log("    deleteDataSet: {");
         console.log("      extraData:");
         console.log("        '%s' as Hex,", vm.toString(deleteDataSetExtraData));
-        console.log("      dataSetId: %dn,", CLIENT_DATA_SET_ID);
+        console.log("      dataSetId: %dn,", DATA_SET_ID);
         console.log("    },");
         console.log("  },");
         console.log("}");
@@ -342,7 +295,7 @@ contract MetadataSignatureFixturesTest is Test {
         console.log("  },");
         console.log("  \"deleteDataSet\": {");
         console.log("    \"signature\": \"%s\",", vm.toString(deleteDataSetSig));
-        console.log("    \"dataSetId\": %d", CLIENT_DATA_SET_ID);
+        console.log("    \"dataSetId\": %d", DATA_SET_ID);
         console.log("  }");
         console.log("}");
 
@@ -369,7 +322,7 @@ contract MetadataSignatureFixturesTest is Test {
         );
 
         assertTrue(
-            testContract.verifyDeleteDataSetSignature(TEST_SIGNER, CLIENT_DATA_SET_ID, deleteDataSetSig),
+            testContract.verifyDeleteDataSetSignature(TEST_SIGNER, DATA_SET_ID, deleteDataSetSig),
             "DeleteDataSet signature verification failed"
         );
     }

--- a/service_contracts/test/external_signatures.json
+++ b/service_contracts/test/external_signatures.json
@@ -1,7 +1,7 @@
 {
   "signer": "0x2e988A386a799F506693793c6A5AF6B54dfAaBfB",
   "createDataSet": {
-    "signature": "0xc77965e2b6efd594629c44eb61127bc3133b65d08c25f8aa33e3021e7f46435845ab67ffbac96afc4b4671ecbd32d4869ca7fe1c0eaa5affa942d0abbfd98d601b",
+    "signature": "0x71b76dc59fda32a090b48744f047748725f1989d69c24b25713ff7c175f365255d96f112712439fc01a2a9c6fb6cd5e0e78bd57888677cb5172f08acebfc34e21b",
     "clientDataSetId": 12345,
     "payee": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
     "metadata": [
@@ -12,7 +12,7 @@
     ]
   },
   "addPieces": {
-    "signature": "0x1f09427806dc1e4c073a9fd7345fdd1919973abe3f3021594964134887c964d82e7b242019c79b21a8fa40331d14b59219b431846e4cdc08adb2e9470e7273161c",
+    "signature": "0x27e3a89a2b33f19c04986d9b3d705bd9312c1a0be123b1646aacc5bba46246e07de6cad74cfb4755d97bbb1aeb64bd8adb2f0f1d85afdf7b51feae7f184dd6131b",
     "clientDataSetId": 12345,
     "nonce": 1,
     "pieceCidBytes": [
@@ -25,7 +25,7 @@
     ]
   },
   "schedulePieceRemovals": {
-    "signature": "0xcb8e645f2894fde89de54d4a54eb1e0d9871901c6fa1c2ee8a0390dc3a29e6cb2244d0561e3eca6452fa59efaab3d4b18a0b5b59ab52e233b3469422556ae9c61c",
+    "signature": "0x16df3928604421914122d3ad071558e6e704b9d28bd38bdf93b02ca8760497351981d111edc0d7a470213e8cf235a72c2ae4dd8dc426a144b2b9fdd4a4035f091c",
     "clientDataSetId": 12345,
     "pieceIds": [
       1,
@@ -34,7 +34,7 @@
     ]
   },
   "deleteDataSet": {
-    "signature": "0x94e366bd2f9bfc933a87575126715bccf128b77d9c6937e194023e13b54272eb7a74b7e6e26acf4341d9c56e141ff7ba154c37ea03e9c35b126fff1efe1a0c831c",
-    "clientDataSetId": 12345
+    "signature": "0x052f7cfbc1a6b34ee786e619f97817f095a003910f089b992365226039b05dca36280f4ccc198e9c8fd5131f6dc234cd6abb8f16dbbce59736c871cc7e988c881b",
+    "dataSetId": 12345
   }
 }

--- a/service_contracts/test/external_signatures.json
+++ b/service_contracts/test/external_signatures.json
@@ -34,7 +34,7 @@
     ]
   },
   "deleteDataSet": {
-    "signature": "0x052f7cfbc1a6b34ee786e619f97817f095a003910f089b992365226039b05dca36280f4ccc198e9c8fd5131f6dc234cd6abb8f16dbbce59736c871cc7e988c881b",
-    "dataSetId": 12345
+    "signature": "0x82d85f7517c3ebcf68b9ebe200a46627d451219a3a71a95ea7ffce1cd661cc6d553db47958d27c33ccf1105388e1b640cf575a966b0bd4814ed0ec428daa628a1b",
+    "dataSetId": 67890
   }
 }


### PR DESCRIPTION
Does not require a contract upgrade; this is a small part of https://github.com/FilOzone/filecoin-services/issues/457 but it inlines the `DeleteDataSet` typehash into the test while the existing ones use `internal` consts from SignatureVerificationLib; we can move Delete when we do #457. The output is now aligned to the new Synapse test fixture so it's a direct copypasta from here to make sure they match.

````
$ forge test --match-test testGenerateFixtures -vv
  ...
  Copy to typed-data.test.ts FIXTURES:
  const FIXTURES = {
    // Test private key from Solidity (never use in production!)
    privateKey: '0x1234567890123456789012345678901234567890123456789012345678901234' as Hex,
       
    // Expected EIP-712 signatures
    signatures: {     
      createDataSet: {                                                                                                                                     
        extraData:      
          '0x0000000000000000000000002e988a386a799f506693793c6a5af6b54dfaabfb000000000000000000000000000000000000000000000000000000000000303900000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000012000000000000000000000000000000000000000000
000000000000000000001a00000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000057469746c650000000000000000000000000000000000000000000000000000000000000000000000000000000000000
0000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b5465737444617461536574000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004171b76dc59fda32a090b48
744f047748725f1989d69c24b25713ff7c175f365255d96f112712439fc01a2a9c6fb6cd5e0e78bd57888677cb5172f08acebfc34e21b00000000000000000000000000000000000000000000000000000000000000' as Hex,
        clientDataSetId: 12345n,
        payee: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8' as Address,                                                                                    
        metadata: [{ key: 'title', value: 'TestDataSet' }],                                                                                                
      },
   ...
```