### PR TITLE
fix(fwss): price PDP rails on raw bytes, not Fr32-expanded leaf size

### DIFF
--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -22,7 +22,6 @@ import {Extsload} from "./Extsload.sol";
 import {SignatureVerificationLib} from "./lib/SignatureVerificationLib.sol";
 
 uint256 constant NO_PROVING_DEADLINE = 0;
-uint256 constant BYTES_PER_LEAF = 32; // Each leaf is 32 bytes
 uint64 constant CHALLENGES_PER_PROOF = 5;
 uint256 constant COMMISSION_MAX_BPS = 10000; // 100% in basis points
 
@@ -1299,7 +1298,7 @@ contract FilecoinWarmStorageService is
         // Revert if no payment rail is configured for this data set
         require(dataSetInfo[dataSetId].pdpRailId != 0, Errors.NoPDPPaymentRail(dataSetId));
 
-        uint256 totalBytes = leafCount * BYTES_PER_LEAF;
+        uint256 totalBytes = Cids.leafCountToRawSize(leafCount);
         FilecoinPayV1 payments = FilecoinPayV1(paymentsContractAddress);
 
         // Update the PDP rail payment rate with the new rate and no one-time payment

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
@@ -5,12 +5,10 @@ pragma solidity ^0.8.20;
 // This file is a generated binding and any changes will be lost.
 // Generated with make src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
 
+import {Cids} from "@pdp/Cids.sol";
 import {Errors} from "../Errors.sol";
 import {
-    BYTES_PER_LEAF,
-    CHALLENGES_PER_PROOF,
-    NO_PROVING_DEADLINE,
-    FilecoinWarmStorageService
+    CHALLENGES_PER_PROOF, NO_PROVING_DEADLINE, FilecoinWarmStorageService
 } from "../FilecoinWarmStorageService.sol";
 import "./FilecoinWarmStorageServiceLayout.sol" as StorageLayout;
 
@@ -66,12 +64,17 @@ library FilecoinWarmStorageServiceStateInternalLibrary {
     // --- Public getter functions ---
 
     /**
-     * @notice Get the total size of a data set in bytes
-     * @param leafCount Number of leaves in the data set
-     * @return totalBytes Total size in bytes
+     * @notice Approximate raw (pre-Fr32-expansion) data set size in bytes.
+     * @custom:deprecated Use Cids.leafCountToRawSize directly. Will be removed in a future release.
+     * @dev Overestimates by up to 31 bytes per piece. See leafCountToRawSize in the pdp Cids
+     *      library (lib/pdp/src/Cids.sol) for derivation.
+     * @param leafCount Sum of data-bearing leaves currently recorded in the data set
+     *      (PDPVerifier.getDataSetLeafCount). Decreases only when nextProvingPeriod
+     *      processes scheduled removals.
+     * @return totalBytes Approximate raw byte size
      */
     function getDataSetSizeInBytes(uint256 leafCount) internal pure returns (uint256) {
-        return leafCount * BYTES_PER_LEAF;
+        return Cids.leafCountToRawSize(leafCount);
     }
 
     function clientNonces(FilecoinWarmStorageService service, address payer, uint256 nonce)

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceStateLibrary.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceStateLibrary.sol
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 pragma solidity ^0.8.20;
 
+import {Cids} from "@pdp/Cids.sol";
 import {Errors} from "../Errors.sol";
 import {
-    BYTES_PER_LEAF,
-    CHALLENGES_PER_PROOF,
-    NO_PROVING_DEADLINE,
-    FilecoinWarmStorageService
+    CHALLENGES_PER_PROOF, NO_PROVING_DEADLINE, FilecoinWarmStorageService
 } from "../FilecoinWarmStorageService.sol";
 import "./FilecoinWarmStorageServiceLayout.sol" as StorageLayout;
 
@@ -62,12 +60,17 @@ library FilecoinWarmStorageServiceStateLibrary {
     // --- Public getter functions ---
 
     /**
-     * @notice Get the total size of a data set in bytes
-     * @param leafCount Number of leaves in the data set
-     * @return totalBytes Total size in bytes
+     * @notice Approximate raw (pre-Fr32-expansion) data set size in bytes.
+     * @custom:deprecated Use Cids.leafCountToRawSize directly. Will be removed in a future release.
+     * @dev Overestimates by up to 31 bytes per piece. See leafCountToRawSize in the pdp Cids
+     *      library (lib/pdp/src/Cids.sol) for derivation.
+     * @param leafCount Sum of data-bearing leaves currently recorded in the data set
+     *      (PDPVerifier.getDataSetLeafCount). Decreases only when nextProvingPeriod
+     *      processes scheduled removals.
+     * @return totalBytes Approximate raw byte size
      */
     function getDataSetSizeInBytes(uint256 leafCount) public pure returns (uint256) {
-        return leafCount * BYTES_PER_LEAF;
+        return Cids.leafCountToRawSize(leafCount);
     }
 
     function clientNonces(FilecoinWarmStorageService service, address payer, uint256 nonce)

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -1325,7 +1325,8 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         assertEq(actualRate, expectedRate, "rail rate should price on raw bytes");
         assertLt(actualRate, buggyRate, "raw-size rate must be lower than the Fr32-size rate");
         // 127/128 ratio: buggy rate is 128/127 = ~1.00787x the correct rate.
-        assertEq(actualRate, (buggyRate * 127) / 128, "ratio between raw and Fr32 rates is exactly 127/128");
+        // Tolerance of 1 covers integer-division truncation differences between the two paths.
+        assertApproxEqAbs(actualRate, (buggyRate * 127) / 128, 1, "ratio between raw and Fr32 rates is 127/128");
     }
 
     function testUpdatePaymentRates_NextProvingPeriodAfterRemovalUsesRawSize() public {
@@ -1375,8 +1376,8 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         uint256 expectedRate = pdpServiceWithPayments.calculateRatePerEpoch(Cids.leafCountToRawSize(perPieceLeaves));
         uint256 buggyRate = pdpServiceWithPayments.calculateRatePerEpoch(perPieceLeaves * 32);
         assertEq(actualRate, expectedRate, "post-removal rate should price on raw bytes");
-        assertEq(
-            actualRate, (buggyRate * 127) / 128, "post-removal ratio between raw and Fr32 rates is exactly 127/128"
+        assertApproxEqAbs(
+            actualRate, (buggyRate * 127) / 128, 1, "post-removal ratio between raw and Fr32 rates is 127/128"
         );
     }
 

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -1290,6 +1290,104 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         assertGt(rateAfterAdd, initialRate, "Rate should increase immediately after adding piece");
     }
 
+    // Per-byte rate calculation: leafCount is in Fr32-expanded leaves and must be reduced by
+    // the 127/128 expansion ratio before pricing. See FilOzone/filecoin-services#451.
+
+    function testUpdatePaymentRates_PiecesAddedUsesRawSize() public {
+        address payer = makeAddr("rawSizeClient");
+        mockUSDFC.safeTransfer(payer, 100e18);
+        vm.startPrank(payer);
+        payments.setOperatorApproval(mockUSDFC, address(pdpServiceWithPayments), true, 1000e18, 1000e18, 365 days);
+        mockUSDFC.approve(address(payments), 100e18);
+        payments.deposit(mockUSDFC, payer, 100e18);
+        vm.stopPrank();
+
+        (string[] memory dsKeys, string[] memory dsValues) = _getSingleMetadataKV("label", "Raw Size Test");
+        bytes memory createData = abi.encode(payer, uint256(7001), dsKeys, dsValues, FAKE_SIGNATURE);
+        makeSignaturePass(payer);
+        vm.prank(serviceProvider);
+        uint256 dataSetId = mockPDPVerifier.createDataSet(pdpServiceWithPayments, createData);
+
+        // height=35, padding=0: 1<<30 leaves, well above the floor crossover.
+        Cids.Cid[] memory pieceData = new Cids.Cid[](1);
+        pieceData[0] = Cids.CommPv2FromDigest(0, 35, keccak256("raw_size_piece"));
+        uint256 leafCount = Cids.leafCount(0, 35);
+
+        makeSignaturePass(payer);
+        mockPDPVerifier.addPieces(
+            pdpServiceWithPayments, dataSetId, 0, pieceData, 1, FAKE_SIGNATURE, new string[](0), new string[](0)
+        );
+
+        uint256 actualRate = payments.getRail(viewContract.getDataSet(dataSetId).pdpRailId).paymentRate;
+        uint256 expectedRate = pdpServiceWithPayments.calculateRatePerEpoch(Cids.leafCountToRawSize(leafCount));
+        uint256 buggyRate = pdpServiceWithPayments.calculateRatePerEpoch(leafCount * 32);
+
+        assertEq(actualRate, expectedRate, "rail rate should price on raw bytes");
+        assertLt(actualRate, buggyRate, "raw-size rate must be lower than the Fr32-size rate");
+        // 127/128 ratio: buggy rate is 128/127 = ~1.00787x the correct rate.
+        assertEq(actualRate, (buggyRate * 127) / 128, "ratio between raw and Fr32 rates is exactly 127/128");
+    }
+
+    function testUpdatePaymentRates_NextProvingPeriodAfterRemovalUsesRawSize() public {
+        address payer = makeAddr("rawSizeRemovalClient");
+        mockUSDFC.safeTransfer(payer, 100e18);
+        vm.startPrank(payer);
+        payments.setOperatorApproval(mockUSDFC, address(pdpServiceWithPayments), true, 1000e18, 1000e18, 365 days);
+        mockUSDFC.approve(address(payments), 100e18);
+        payments.deposit(mockUSDFC, payer, 100e18);
+        vm.stopPrank();
+
+        (string[] memory dsKeys, string[] memory dsValues) = _getSingleMetadataKV("label", "Removal Raw Size Test");
+        bytes memory createData = abi.encode(payer, uint256(7002), dsKeys, dsValues, FAKE_SIGNATURE);
+        makeSignaturePass(payer);
+        vm.prank(serviceProvider);
+        uint256 dataSetId = mockPDPVerifier.createDataSet(pdpServiceWithPayments, createData);
+
+        // Two pieces; we'll remove one and verify nextProvingPeriod recomputes on the remaining.
+        Cids.Cid[] memory pieceData = new Cids.Cid[](2);
+        pieceData[0] = Cids.CommPv2FromDigest(0, 35, keccak256("piece_a"));
+        pieceData[1] = Cids.CommPv2FromDigest(0, 35, keccak256("piece_b"));
+        uint256 perPieceLeaves = Cids.leafCount(0, 35);
+
+        makeSignaturePass(payer);
+        mockPDPVerifier.addPieces(
+            pdpServiceWithPayments, dataSetId, 0, pieceData, 1, FAKE_SIGNATURE, new string[](0), new string[](0)
+        );
+
+        (uint64 provingPeriod,,,) = viewContract.getPDPConfig();
+        uint256 firstDeadline = block.number + provingPeriod;
+        vm.prank(address(mockPDPVerifier));
+        pdpServiceWithPayments.nextProvingPeriod(dataSetId, firstDeadline, 2 * perPieceLeaves, "");
+
+        uint256[] memory pieceIds = new uint256[](1);
+        pieceIds[0] = 1;
+        makeSignaturePass(payer);
+        mockPDPVerifier.piecesScheduledRemove(
+            dataSetId, pieceIds, address(pdpServiceWithPayments), abi.encode(FAKE_SIGNATURE)
+        );
+
+        // Advance past the deadline and call nextProvingPeriod with the post-removal leaf count.
+        vm.roll(firstDeadline + 1);
+        vm.prank(address(mockPDPVerifier));
+        pdpServiceWithPayments.nextProvingPeriod(dataSetId, firstDeadline + provingPeriod, perPieceLeaves, "");
+
+        uint256 actualRate = payments.getRail(viewContract.getDataSet(dataSetId).pdpRailId).paymentRate;
+        uint256 expectedRate = pdpServiceWithPayments.calculateRatePerEpoch(Cids.leafCountToRawSize(perPieceLeaves));
+        uint256 buggyRate = pdpServiceWithPayments.calculateRatePerEpoch(perPieceLeaves * 32);
+        assertEq(actualRate, expectedRate, "post-removal rate should price on raw bytes");
+        assertEq(
+            actualRate, (buggyRate * 127) / 128, "post-removal ratio between raw and Fr32 rates is exactly 127/128"
+        );
+    }
+
+    function testGetDataSetSizeInBytes_ReturnsRawSize() public view {
+        // Deprecated helper now returns an upper-bound raw size (was previously Fr32-expanded size).
+        assertEq(viewContract.getDataSetSizeInBytes(0), 0);
+        assertEq(viewContract.getDataSetSizeInBytes(4), 127);
+        uint256 leaves1GiB = 1 << 25;
+        assertEq(viewContract.getDataSetSizeInBytes(leaves1GiB), Cids.leafCountToRawSize(leaves1GiB));
+    }
+
     // Operator Approval Validation Tests
     function testOperatorApproval_NotApproved() public {
         // Setup: Client with sufficient funds but no operator approval


### PR DESCRIPTION
`updatePaymentRates` was multiplying leafCount by 32 to derive total bytes, which is the Fr32-expanded size, not the raw payload size. Switch to the new `Cids.leafCountToRawSize` to apply the 127/128 ratio, removing the ~0.787% per-byte overcharge.

Also marks `getDataSetSizeInBytes` deprecated and to-be-removed; it now delegates to the same helper rather than computing Fr32 size. Drops the `BYTES_PER_LEAF` constant.

Bumps lib/pdp submodule to FilOzone/pdp#266.

Fixes: #451

~_Pending: we're going to tag + release pdp with that change, but not deploy it, so I'll update here with a new head commit when that's done but it'll be the same code._~