### PR TITLE
feat!: Rails library

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ This repository contains smart contracts and services for the Filecoin ecosystem
 
 ## Pricing
 
-The service uses static global pricing set by the contract owner (default: 2.5 USDFC per TiB/month). Rail payment rates are calculated based on data size with a minimum floor. See [SPEC.md](SPEC.md) for details on rate calculation, pricing updates, and top-up/renewal behavior.
+The service uses static global pricing set by the contract owner (currently 2.5 USDFC per TiB/month).
+Rail payment rates are calculated based on data size with a minimum floor. See [SPEC.md](SPEC.md) for details on rate calculation, pricing updates, and top-up/renewal behavior.
 
 ## 🚀 Quick Start
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -18,13 +18,13 @@ EPOCHS_PER_MONTH              = 86400         # 2880 epochs/day × 30 days
 TiB                           = 1099511627776 # bytes
 
 # Default pricing (owner-adjustable)
-pricePerTiBPerMonth           = 2.5 USDFC
-minimumStorageRatePerMonth    = 0.06 USDFC
+STORAGE_PRICE_PER_TIB_PER_MONTH = 2.5 USDFC
+MINIMUM_STORAGE_RATE_PER_MONTH  = 0.06 USDFC
 
 # Per-epoch rate calculation
-sizeBasedRate = totalBytes × pricePerTiBPerMonth ÷ TiB ÷ EPOCHS_PER_MONTH
-minimumRate   = minimumStorageRatePerMonth ÷ EPOCHS_PER_MONTH
-finalRate     = max(sizeBasedRate, minimumRate)
+sizeBasedRate                  = totalBytes × STORAGE_PRICE_PER_TIB_PER_MONTH ÷ TiB ÷ EPOCHS_PER_MONTH
+MINIMUM_STORAGE_RATE_PER_EPOCH = MINIMUM_STORAGE_RATE_PER_MONTH ÷ EPOCHS_PER_MONTH
+finalRate                      = max(sizeBasedRate, MINIMUM_STORAGE_RATE_PER_EPOCH)
 ```
 
 The default minimum floor ensures datasets below ~24.58 GiB still generate the minimum payment of 0.06 USDFC/month.
@@ -33,7 +33,7 @@ The default minimum floor ensures datasets below ~24.58 GiB still generate the m
 
 ### Pricing Updates
 
-Only the contract owner can update pricing by calling `updatePricing(newStoragePrice, newMinimumRate)`. Maximum allowed values are 10 USDFC for storage price and 0.24 USDFC for minimum rate.
+Only the contract owner can update pricing, by upgrading the contract.
 
 **Effect on existing datasets**: Pricing changes do not immediately update rates for existing datasets. New rates take effect when pieces are next added or removed. This avoids gas-expensive rate recalculations across all active datasets while ensuring new pricing applies to all future storage operations.
 

--- a/service_contracts/abi/Errors.abi.json
+++ b/service_contracts/abi/Errors.abi.json
@@ -12,11 +12,6 @@
   },
   {
     "type": "error",
-    "name": "AtLeastOnePriceMustBeNonZero",
-    "inputs": []
-  },
-  {
-    "type": "error",
     "name": "CDNPaymentAlreadyTerminated",
     "inputs": [
       {
@@ -206,11 +201,6 @@
         "internalType": "uint256"
       }
     ]
-  },
-  {
-    "type": "error",
-    "name": "DivisionByZero",
-    "inputs": []
   },
   {
     "type": "error",
@@ -742,27 +732,6 @@
       },
       {
         "name": "pdpEndEpoch",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "PriceExceedsMaximum",
-    "inputs": [
-      {
-        "name": "priceType",
-        "type": "uint8",
-        "internalType": "enum Errors.PriceType"
-      },
-      {
-        "name": "maxAllowed",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "actual",
         "type": "uint256",
         "internalType": "uint256"
       }

--- a/service_contracts/abi/FilecoinWarmStorageService.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageService.abi.json
@@ -106,25 +106,6 @@
   },
   {
     "type": "function",
-    "name": "calculateRatePerEpoch",
-    "inputs": [
-      {
-        "name": "totalBytes",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "storageRate",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
     "name": "configureProvingPeriod",
     "inputs": [
       {
@@ -302,7 +283,7 @@
         "internalType": "uint256"
       }
     ],
-    "stateMutability": "view"
+    "stateMutability": "pure"
   },
   {
     "type": "function",
@@ -800,37 +781,6 @@
   },
   {
     "type": "function",
-    "name": "updatePricing",
-    "inputs": [
-      {
-        "name": "newStoragePrice",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "newMinimumRate",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "updateServiceCommission",
-    "inputs": [
-      {
-        "name": "newCommissionBps",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
     "name": "upgradeToAndCall",
     "inputs": [
       {
@@ -931,43 +881,6 @@
   },
   {
     "type": "event",
-    "name": "CDNPaymentRailsToppedUp",
-    "inputs": [
-      {
-        "name": "dataSetId",
-        "type": "uint256",
-        "indexed": true,
-        "internalType": "uint256"
-      },
-      {
-        "name": "cdnAmountAdded",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "totalCdnLockup",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "cacheMissAmountAdded",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "totalCacheMissLockup",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
     "name": "CDNPaymentTerminated",
     "inputs": [
       {
@@ -980,37 +893,6 @@
         "name": "endEpoch",
         "type": "uint256",
         "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "cacheMissRailId",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "cdnRailId",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "CDNServiceTerminated",
-    "inputs": [
-      {
-        "name": "caller",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "dataSetId",
-        "type": "uint256",
-        "indexed": true,
         "internalType": "uint256"
       },
       {
@@ -1311,25 +1193,6 @@
   },
   {
     "type": "event",
-    "name": "PricingUpdated",
-    "inputs": [
-      {
-        "name": "storagePrice",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "minimumRate",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
     "name": "ProviderApproved",
     "inputs": [
       {
@@ -1349,31 +1212,6 @@
         "name": "providerId",
         "type": "uint256",
         "indexed": true,
-        "internalType": "uint256"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "RailRateUpdated",
-    "inputs": [
-      {
-        "name": "dataSetId",
-        "type": "uint256",
-        "indexed": true,
-        "internalType": "uint256"
-      },
-      {
-        "name": "railId",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "newRate",
-        "type": "uint256",
-        "indexed": false,
         "internalType": "uint256"
       }
     ],
@@ -1480,33 +1318,6 @@
   },
   {
     "type": "error",
-    "name": "AtLeastOnePriceMustBeNonZero",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "CDNPaymentAlreadyTerminated",
-    "inputs": [
-      {
-        "name": "dataSetId",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "CacheMissPaymentAlreadyTerminated",
-    "inputs": [
-      {
-        "name": "dataSetId",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
     "name": "CallerNotPayer",
     "inputs": [
       {
@@ -1602,27 +1413,6 @@
   },
   {
     "type": "error",
-    "name": "CommissionExceedsMaximum",
-    "inputs": [
-      {
-        "name": "commissionType",
-        "type": "uint8",
-        "internalType": "enum Errors.CommissionType"
-      },
-      {
-        "name": "max",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "actual",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
     "name": "DataSetNotFoundForRail",
     "inputs": [
       {
@@ -1674,11 +1464,6 @@
         "internalType": "uint256"
       }
     ]
-  },
-  {
-    "type": "error",
-    "name": "DivisionByZero",
-    "inputs": []
   },
   {
     "type": "error",
@@ -1744,115 +1529,6 @@
     "inputs": [
       {
         "name": "dataSetId",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "InsufficientLockupAllowance",
-    "inputs": [
-      {
-        "name": "payer",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "lockupAllowance",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "lockupUsage",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "minimumLockupRequired",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "InsufficientLockupFunds",
-    "inputs": [
-      {
-        "name": "payer",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "minimumRequired",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "available",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "InsufficientMaxLockupPeriod",
-    "inputs": [
-      {
-        "name": "payer",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "maxLockupPeriod",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "requiredLockupPeriod",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "InsufficientRateAllowance",
-    "inputs": [
-      {
-        "name": "payer",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "rateAllowance",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "rateUsage",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "minimumRateRequired",
         "type": "uint256",
         "internalType": "uint256"
       }
@@ -1970,17 +1646,6 @@
     "inputs": [
       {
         "name": "length",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "InvalidTopUpAmount",
-    "inputs": [
-      {
-        "name": "dataSetId",
         "type": "uint256",
         "internalType": "uint256"
       }
@@ -2136,22 +1801,6 @@
   },
   {
     "type": "error",
-    "name": "OperatorNotApproved",
-    "inputs": [
-      {
-        "name": "payer",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
-    ]
-  },
-  {
-    "type": "error",
     "name": "OwnableInvalidOwner",
     "inputs": [
       {
@@ -2183,27 +1832,6 @@
       },
       {
         "name": "pdpEndEpoch",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "PriceExceedsMaximum",
-    "inputs": [
-      {
-        "name": "priceType",
-        "type": "uint8",
-        "internalType": "enum Errors.PriceType"
-      },
-      {
-        "name": "maxAllowed",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "actual",
         "type": "uint256",
         "internalType": "uint256"
       }

--- a/service_contracts/abi/FilecoinWarmStorageServiceStateLibrary.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageServiceStateLibrary.abi.json
@@ -1,6 +1,25 @@
 [
   {
     "type": "function",
+    "name": "calculateRatePerEpoch",
+    "inputs": [
+      {
+        "name": "totalBytes",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "storageRate",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
     "name": "clientDataSets",
     "inputs": [
       {
@@ -417,7 +436,7 @@
     "name": "getCurrentPricingRates",
     "inputs": [
       {
-        "name": "service",
+        "name": "",
         "type": "FilecoinWarmStorageService",
         "internalType": "contract FilecoinWarmStorageService"
       }
@@ -434,7 +453,7 @@
         "internalType": "uint256"
       }
     ],
-    "stateMutability": "view"
+    "stateMutability": "pure"
   },
   {
     "type": "function",
@@ -869,7 +888,7 @@
     "name": "serviceCommissionBps",
     "inputs": [
       {
-        "name": "service",
+        "name": "",
         "type": "FilecoinWarmStorageService",
         "internalType": "contract FilecoinWarmStorageService"
       }
@@ -881,7 +900,7 @@
         "internalType": "uint256"
       }
     ],
-    "stateMutability": "view"
+    "stateMutability": "pure"
   },
   {
     "type": "error",

--- a/service_contracts/abi/FilecoinWarmStorageServiceStateView.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageServiceStateView.abi.json
@@ -12,6 +12,25 @@
   },
   {
     "type": "function",
+    "name": "calculateRatePerEpoch",
+    "inputs": [
+      {
+        "name": "totalBytes",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "storageRate",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
     "name": "clientDataSets",
     "inputs": [
       {

--- a/service_contracts/src/Errors.sol
+++ b/service_contracts/src/Errors.sol
@@ -195,9 +195,6 @@ library Errors {
     /// @param dataSetId The data set ID
     error NoPDPPaymentRail(uint256 dataSetId);
 
-    /// @notice Division by zero: denominator was zero
-    error DivisionByZero();
-
     /// @notice Signature has an invalid length
     /// @param actualLength The length of the provided signature (should be 65)
     error InvalidSignatureLength(uint256 expectedLength, uint256 actualLength);
@@ -350,15 +347,6 @@ library Errors {
     error InsufficientMaxLockupPeriod(
         address payer, address operator, uint256 maxLockupPeriod, uint256 requiredLockupPeriod
     );
-
-    /// @notice At least one price parameter must be non-zero when updating pricing
-    error AtLeastOnePriceMustBeNonZero();
-
-    /// @notice Price update exceeds the maximum allowed value
-    /// @param priceType The type of price being updated (see enum {PriceType})
-    /// @param maxAllowed The maximum allowed value for this price type
-    /// @param actual The attempted value that exceeds the maximum
-    error PriceExceedsMaximum(PriceType priceType, uint256 maxAllowed, uint256 actual);
 
     error ProviderIdMismatchAtIndex(uint256 index, uint256 providerId);
 

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -22,15 +22,13 @@ import {Extsload} from "./Extsload.sol";
 import {
     CACHE_MISS_EGRESS_PRICE_PER_TIB,
     CDN_EGRESS_PRICE_PER_TIB,
-    DEFAULT_CACHE_MISS_LOCKUP_AMOUNT,
-    DEFAULT_CDN_LOCKUP_AMOUNT,
-    DEFAULT_LOCKUP_PERIOD,
     EPOCHS_PER_MONTH,
     MINIMUM_STORAGE_RATE_PER_MONTH,
+    SERVICE_COMMISSION_BPS,
     STORAGE_PRICE_PER_TIB_PER_MONTH,
     TOKEN_DECIMALS
 } from "./lib/PriceListUSDFC.sol";
-import {CDNPaymentRailsToppedUp, Rails} from "./lib/Rails.sol";
+import {Rails} from "./lib/Rails.sol";
 import {SignatureVerificationLib} from "./lib/SignatureVerificationLib.sol";
 
 uint256 constant NO_PROVING_DEADLINE = 0;
@@ -229,7 +227,7 @@ contract FilecoinWarmStorageService is
     uint256 private challengeWindowSize;
 
     // Commission rate
-    uint256 private serviceCommissionBps;
+    uint256 private serviceCommissionBps; // deprecated
 
     // Track which proving periods have valid proofs with bitmap
     mapping(uint256 dataSetId => mapping(uint256 periodId => uint256)) private provenPeriods;
@@ -381,11 +379,6 @@ contract FilecoinWarmStorageService is
 
         maxProvingPeriod = _maxProvingPeriod;
         challengeWindowSize = _challengeWindowSize;
-
-        // Set commission rate
-        serviceCommissionBps = 0; // 0%
-
-        // Initialize mutable pricing variables
     }
 
     function announcePlannedUpgrade(PlannedUpgrade calldata plannedUpgrade) external onlyOwner {
@@ -455,19 +448,6 @@ contract FilecoinWarmStorageService is
 
         viewContractAddress = _viewContract;
         emit ViewContractSet(_viewContract);
-    }
-
-    /**
-     * @notice Updates the service commission rates
-     * @dev Only callable by the contract owner
-     * @param newCommissionBps New commission rate in basis points
-     */
-    function updateServiceCommission(uint256 newCommissionBps) external onlyOwner {
-        require(
-            newCommissionBps <= COMMISSION_MAX_BPS,
-            Errors.CommissionExceedsMaximum(Errors.CommissionType.Service, COMMISSION_MAX_BPS, newCommissionBps)
-        );
-        serviceCommissionBps = newCommissionBps;
     }
 
     /**
@@ -555,7 +535,7 @@ contract FilecoinWarmStorageService is
         info.payer = createData.payer;
         info.payee = payee; // Using payee address from registry
         info.serviceProvider = serviceProvider; // Set the service provider
-        info.commissionBps = serviceCommissionBps;
+        info.commissionBps = SERVICE_COMMISSION_BPS;
         info.clientDataSetId = createData.clientDataSetId;
         info.providerId = providerId;
 
@@ -598,66 +578,16 @@ contract FilecoinWarmStorageService is
         // Determine once whether CDN is enabled in metadata and reuse the result
         bool hasCDN = hasCDNMetadataKey(createData.metadataKeys);
 
-        // Validate payer has sufficient funds and operator approvals for minimum pricing
-        // If CDN is enabled, validation must account for the additional fixed lockup amounts
-        validatePayerOperatorApprovalAndFunds(payments, createData.payer, hasCDN);
-
-        uint256 pdpRailId = payments.createRail(
-            usdfcTokenAddress, // token address
-            createData.payer, // from (payer)
-            payee, // payee address from registry
-            address(this), // this contract acts as the validator
-            info.commissionBps, // commission rate based on CDN usage
-            address(this)
+        (uint256 pdpRailId, uint256 cacheMissRailId, uint256 cdnRailId) = payments.createRails(
+            dataSetId, usdfcTokenAddress, createData.payer, payee, hasCDN ? filBeamBeneficiaryAddress : address(0)
         );
 
-        // Store the rail ID
-        info.pdpRailId = pdpRailId;
-
-        // Store reverse mapping from rail ID to data set ID for validation
         railToDataSet[pdpRailId] = dataSetId;
-
-        // Set lockup period for the rail
-        payments.modifyRailLockup(pdpRailId, DEFAULT_LOCKUP_PERIOD, 0);
-
-        // --- Burn rail: extract USDFC sybil fee from client into payments auction pool ---
-        payments.burnSybil(usdfcTokenAddress, createData.payer);
-
-        uint256 cacheMissRailId = 0;
-        uint256 cdnRailId = 0;
-
+        info.pdpRailId = pdpRailId;
         if (hasCDN) {
-            cacheMissRailId = payments.createRail(
-                usdfcTokenAddress, // token address
-                createData.payer, // from (payer)
-                payee, // payee address from registry
-                address(0), // no validator
-                0, // no service commission
-                address(this) // controller
-            );
             info.cacheMissRailId = cacheMissRailId;
-            payments.modifyRailLockup(cacheMissRailId, DEFAULT_LOCKUP_PERIOD, DEFAULT_CACHE_MISS_LOCKUP_AMOUNT);
-
-            cdnRailId = payments.createRail(
-                usdfcTokenAddress, // token address
-                createData.payer, // from (payer)
-                filBeamBeneficiaryAddress, // to FilBeam beneficiary
-                address(0), // no validator
-                0, // no service commission
-                address(this) // controller
-            );
             info.cdnRailId = cdnRailId;
-            payments.modifyRailLockup(cdnRailId, DEFAULT_LOCKUP_PERIOD, DEFAULT_CDN_LOCKUP_AMOUNT);
-
-            emit CDNPaymentRailsToppedUp(
-                dataSetId,
-                DEFAULT_CDN_LOCKUP_AMOUNT,
-                DEFAULT_CDN_LOCKUP_AMOUNT,
-                DEFAULT_CACHE_MISS_LOCKUP_AMOUNT,
-                DEFAULT_CACHE_MISS_LOCKUP_AMOUNT
-            );
         }
-
         // Emit event for tracking
         emit DataSetCreated(
             dataSetId,
@@ -1109,73 +1039,6 @@ contract FilecoinWarmStorageService is
     function _terminateCDNRails(uint256 dataSetId, DataSetInfo storage info, FilecoinPayV1 payments) internal {
         payments.terminateCDNRails(dataSetId, info.cacheMissRailId, info.cdnRailId);
         delete dataSetMetadata[dataSetId][METADATA_KEY_WITH_CDN];
-    }
-
-    /// @notice Validates that the payer has sufficient funds and operator approvals for minimum pricing
-    /// @param payments The FilecoinPayV1 contract instance
-    /// @param payer The address of the payer
-    function validatePayerOperatorApprovalAndFunds(FilecoinPayV1 payments, address payer, bool includeCDN)
-        internal
-        view
-    {
-        // Calculate required lockup for minimum pricing.
-        // We use multiply-first here to preserve the exact monthly value for cleaner error messages
-        // (a round number like the configured floor price, rather than a value with many trailing digits
-        // from precision loss). This is slightly more conservative than the actual rail lockup (which
-        // uses the truncated per-epoch rate), but the difference is under 0.0001% and always in the
-        // user's favor - they are never required to have less than what the rail will actually lock.
-        uint256 minimumLockupRequired = (MINIMUM_STORAGE_RATE_PER_MONTH * DEFAULT_LOCKUP_PERIOD) / EPOCHS_PER_MONTH;
-
-        // If CDN is enabled, include the fixed cache-miss and CDN lockup amounts
-        if (includeCDN) {
-            minimumLockupRequired += DEFAULT_CACHE_MISS_LOCKUP_AMOUNT + DEFAULT_CDN_LOCKUP_AMOUNT;
-        }
-
-        // Include sybil fee (burn rail lockup consumes funds and lockup allowance)
-        minimumLockupRequired += IPDPVerifier(pdpVerifierAddress).USDFC_SYBIL_FEE();
-
-        // Check that payer has sufficient available funds
-        (,, uint256 availableFunds,) = payments.getAccountInfoIfSettled(usdfcTokenAddress, payer);
-        require(
-            availableFunds >= minimumLockupRequired,
-            Errors.InsufficientLockupFunds(payer, minimumLockupRequired, availableFunds)
-        );
-
-        // Check operator approval settings
-        (
-            bool isApproved,
-            uint256 rateAllowance,
-            uint256 lockupAllowance,
-            uint256 rateUsage,
-            uint256 lockupUsage,
-            uint256 maxLockupPeriod
-        ) = payments.operatorApprovals(usdfcTokenAddress, payer, address(this));
-
-        // Verify operator is approved
-        require(isApproved, Errors.OperatorNotApproved(payer, address(this)));
-
-        // Calculate minimum rate per epoch
-        uint256 minimumRatePerEpoch = MINIMUM_STORAGE_RATE_PER_MONTH / EPOCHS_PER_MONTH;
-
-        // Verify rate allowance is sufficient
-        require(
-            rateAllowance >= rateUsage + minimumRatePerEpoch,
-            Errors.InsufficientRateAllowance(payer, address(this), rateAllowance, rateUsage, minimumRatePerEpoch)
-        );
-
-        // Verify lockup allowance is sufficient
-        require(
-            lockupAllowance >= lockupUsage + minimumLockupRequired,
-            Errors.InsufficientLockupAllowance(
-                payer, address(this), lockupAllowance, lockupUsage, minimumLockupRequired
-            )
-        );
-
-        // Verify max lockup period is sufficient
-        require(
-            maxLockupPeriod >= DEFAULT_LOCKUP_PERIOD,
-            Errors.InsufficientMaxLockupPeriod(payer, address(this), maxLockupPeriod, DEFAULT_LOCKUP_PERIOD)
-        );
     }
 
     function updatePaymentRates(uint256 dataSetId, uint256 leafCount) internal {

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -227,7 +227,7 @@ contract FilecoinWarmStorageService is
     uint256 private challengeWindowSize;
 
     // Commission rate
-    uint256 private serviceCommissionBps; // deprecated
+    uint256 private deprecatedServiceCommissionBps;
 
     // Track which proving periods have valid proofs with bitmap
     mapping(uint256 dataSetId => mapping(uint256 periodId => uint256)) private provenPeriods;
@@ -273,8 +273,8 @@ contract FilecoinWarmStorageService is
     PlannedUpgrade private nextUpgrade;
 
     // Pricing rates (mutable for future adjustments)
-    uint256 private storagePricePerTibPerMonth; // deprecated
-    uint256 private minimumStorageRatePerMonth; // deprecated
+    uint256 private deprecatedStoragePricePerTibPerMonth;
+    uint256 private deprecatedMinimumStorageRatePerMonth;
 
     // Piece IDs awaiting metadata cleanup; cleared each nextProvingPeriod call
     mapping(uint256 dataSetId => uint256[] pieceIds) internal scheduledPieceMetadataRemovals;
@@ -1230,10 +1230,10 @@ contract FilecoinWarmStorageService is
      * @return serviceFee Service fee (per TiB per month)
      * @return spPayment SP payment (per TiB per month)
      */
-    function getEffectiveRates() external view returns (uint256 serviceFee, uint256 spPayment) {
+    function getEffectiveRates() external pure returns (uint256 serviceFee, uint256 spPayment) {
         uint256 total = STORAGE_PRICE_PER_TIB_PER_MONTH;
 
-        serviceFee = (total * serviceCommissionBps) / COMMISSION_MAX_BPS;
+        serviceFee = (total * SERVICE_COMMISSION_BPS) / COMMISSION_MAX_BPS;
         spPayment = total - serviceFee;
 
         return (serviceFee, spPayment);

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -19,7 +19,8 @@ import {ServiceProviderRegistry} from "./ServiceProviderRegistry.sol";
 
 import {Extsload} from "./Extsload.sol";
 
-import {CDNPaymentRailsToppedUp, DEFAULT_LOCKUP_PERIOD, Rails} from "./lib/Rails.sol";
+import {DEFAULT_LOCKUP_PERIOD} from "./lib/PriceListUSDFC.sol";
+import {CDNPaymentRailsToppedUp, Rails} from "./lib/Rails.sol";
 import {SignatureVerificationLib} from "./lib/SignatureVerificationLib.sol";
 
 uint256 constant NO_PROVING_DEADLINE = 0;

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -1209,10 +1209,8 @@ contract FilecoinWarmStorageService is
     /// Ideally we would catch only specific error types, but contract size constraint prevents
     /// us from implementing error handling.
     function _terminateCDNRails(uint256 dataSetId, DataSetInfo storage info, FilecoinPayV1 payments) internal {
-        try payments.terminateRail(info.cacheMissRailId) {} catch {}
-        try payments.terminateRail(info.cdnRailId) {} catch {}
+        payments.terminateCDNRails(dataSetId, info.cacheMissRailId, info.cdnRailId);
         delete dataSetMetadata[dataSetId][METADATA_KEY_WITH_CDN];
-        emit CDNServiceTerminated(msg.sender, dataSetId, info.cacheMissRailId, info.cdnRailId);
     }
 
     /// @notice Validates that the payer has sufficient funds and operator approvals for minimum pricing

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -19,7 +19,14 @@ import {ServiceProviderRegistry} from "./ServiceProviderRegistry.sol";
 
 import {Extsload} from "./Extsload.sol";
 
-import {DEFAULT_LOCKUP_PERIOD} from "./lib/PriceListUSDFC.sol";
+import {
+    DEFAULT_LOCKUP_PERIOD,
+    EPOCHS_PER_MONTH,
+    MINIMUM_STORAGE_RATE_PER_MONTH,
+    STORAGE_PRICE_PER_TIB_PER_MONTH,
+    calculateStorageSizeBasedRatePerEpoch,
+    calculateStorageRate
+} from "./lib/PriceListUSDFC.sol";
 import {CDNPaymentRailsToppedUp, Rails} from "./lib/Rails.sol";
 import {SignatureVerificationLib} from "./lib/SignatureVerificationLib.sol";
 
@@ -106,8 +113,6 @@ contract FilecoinWarmStorageService is
     event ProviderApproved(uint256 indexed providerId);
     event ProviderUnapproved(uint256 indexed providerId);
 
-    event PricingUpdated(uint256 storagePrice, uint256 minimumRate);
-
     // =========================================================================
     // Structs
 
@@ -183,10 +188,6 @@ contract FilecoinWarmStorageService is
     // Constants
 
     uint256 private constant NO_CHALLENGE_SCHEDULED = 0;
-    uint256 private constant MIB_IN_BYTES = 1024 * 1024; // 1 MiB in bytes
-    uint256 private constant GIB_IN_BYTES = MIB_IN_BYTES * 1024; // 1 GiB in bytes
-    uint256 private constant TIB_IN_BYTES = GIB_IN_BYTES * 1024; // 1 TiB in bytes
-    uint256 private constant EPOCHS_PER_MONTH = 2880 * 30;
 
     // Metadata size and count limits
     uint256 private constant MAX_KEY_LENGTH = 32;
@@ -287,8 +288,8 @@ contract FilecoinWarmStorageService is
     PlannedUpgrade private nextUpgrade;
 
     // Pricing rates (mutable for future adjustments)
-    uint256 private storagePricePerTibPerMonth;
-    uint256 private minimumStorageRatePerMonth;
+    uint256 private storagePricePerTibPerMonth; // deprecated
+    uint256 private minimumStorageRatePerMonth; // deprecated
 
     // Piece IDs awaiting metadata cleanup; cleared each nextProvingPeriod call
     mapping(uint256 dataSetId => uint256[] pieceIds) internal scheduledPieceMetadataRemovals;
@@ -410,8 +411,6 @@ contract FilecoinWarmStorageService is
         serviceCommissionBps = 0; // 0%
 
         // Initialize mutable pricing variables
-        storagePricePerTibPerMonth = (5 * 10 ** TOKEN_DECIMALS) / 2; // 2.5 USDFC
-        minimumStorageRatePerMonth = (6 * 10 ** TOKEN_DECIMALS) / 100; // 0.06 USDFC
     }
 
     function announcePlannedUpgrade(PlannedUpgrade calldata plannedUpgrade) external onlyOwner {
@@ -494,40 +493,6 @@ contract FilecoinWarmStorageService is
             Errors.CommissionExceedsMaximum(Errors.CommissionType.Service, COMMISSION_MAX_BPS, newCommissionBps)
         );
         serviceCommissionBps = newCommissionBps;
-    }
-
-    /**
-     * @notice Updates the pricing rates for storage services
-     * @dev Only callable by the contract owner. Pass 0 to keep existing value unchanged.
-     *      Price updates apply immediately to existing payment rails when they're recalculated
-     *      (e.g., during piece additions/deletions or proving period updates).
-     *      Maximum allowed values: 10 USDFC for storage, 0.24 USDFC for minimum rate.
-     * @param newStoragePrice New storage price per TiB per month (0 = no change, max 10 USDFC)
-     * @param newMinimumRate New minimum monthly storage rate (0 = no change, max 0.24 USDFC)
-     */
-    function updatePricing(uint256 newStoragePrice, uint256 newMinimumRate) external onlyOwner {
-        require(newStoragePrice > 0 || newMinimumRate > 0, Errors.AtLeastOnePriceMustBeNonZero());
-
-        if (newStoragePrice > 0) {
-            require(
-                newStoragePrice <= MAX_STORAGE_PRICE_PER_TIB_PER_MONTH,
-                Errors.PriceExceedsMaximum(
-                    Errors.PriceType.Storage, MAX_STORAGE_PRICE_PER_TIB_PER_MONTH, newStoragePrice
-                )
-            );
-            storagePricePerTibPerMonth = newStoragePrice;
-        }
-        if (newMinimumRate > 0) {
-            require(
-                newMinimumRate <= MAX_MINIMUM_STORAGE_RATE_PER_MONTH,
-                Errors.PriceExceedsMaximum(
-                    Errors.PriceType.MinimumRate, MAX_MINIMUM_STORAGE_RATE_PER_MONTH, newMinimumRate
-                )
-            );
-            minimumStorageRatePerMonth = newMinimumRate;
-        }
-
-        emit PricingUpdated(storagePricePerTibPerMonth, minimumStorageRatePerMonth);
     }
 
     /**
@@ -1184,7 +1149,7 @@ contract FilecoinWarmStorageService is
         // from precision loss). This is slightly more conservative than the actual rail lockup (which
         // uses the truncated per-epoch rate), but the difference is under 0.0001% and always in the
         // user's favor - they are never required to have less than what the rail will actually lock.
-        uint256 minimumLockupRequired = (minimumStorageRatePerMonth * DEFAULT_LOCKUP_PERIOD) / EPOCHS_PER_MONTH;
+        uint256 minimumLockupRequired = (MINIMUM_STORAGE_RATE_PER_MONTH * DEFAULT_LOCKUP_PERIOD) / EPOCHS_PER_MONTH;
 
         // If CDN is enabled, include the fixed cache-miss and CDN lockup amounts
         if (includeCDN) {
@@ -1215,7 +1180,7 @@ contract FilecoinWarmStorageService is
         require(isApproved, Errors.OperatorNotApproved(payer, address(this)));
 
         // Calculate minimum rate per epoch
-        uint256 minimumRatePerEpoch = minimumStorageRatePerMonth / EPOCHS_PER_MONTH;
+        uint256 minimumRatePerEpoch = MINIMUM_STORAGE_RATE_PER_MONTH / EPOCHS_PER_MONTH;
 
         // Verify rate allowance is sufficient
         require(
@@ -1242,12 +1207,11 @@ contract FilecoinWarmStorageService is
         // Revert if no payment rail is configured for this data set
         require(dataSetInfo[dataSetId].pdpRailId != 0, Errors.NoPDPPaymentRail(dataSetId));
 
-        uint256 totalBytes = Cids.leafCountToRawSize(leafCount);
         FilecoinPayV1 payments = FilecoinPayV1(paymentsContractAddress);
 
         // Update the PDP rail payment rate with the new rate and no one-time payment
         uint256 pdpRailId = dataSetInfo[dataSetId].pdpRailId;
-        uint256 newStorageRatePerEpoch = _calculateStorageRate(totalBytes);
+        uint256 newStorageRatePerEpoch = calculateStorageRate(leafCount);
         payments.modifyRailPayment(
             pdpRailId,
             newStorageRatePerEpoch,
@@ -1330,64 +1294,8 @@ contract FilecoinWarmStorageService is
         return a < b ? a : b;
     }
 
-    /**
-     * @notice Calculate a per-epoch rate based on total storage size
-     * @param totalBytes Total size of the stored data in bytes
-     * @param ratePerTiBPerMonth The rate per TiB per month in the token's smallest unit
-     * @return ratePerEpoch The calculated rate per epoch in the token's smallest unit
-     */
-    function calculateStorageSizeBasedRatePerEpoch(uint256 totalBytes, uint256 ratePerTiBPerMonth)
-        internal
-        view
-        returns (uint256)
-    {
-        uint256 numerator = totalBytes * ratePerTiBPerMonth;
-        uint256 denominator = TIB_IN_BYTES * EPOCHS_PER_MONTH;
-
-        // Ensure denominator is not zero (shouldn't happen with constants)
-        require(denominator > 0, Errors.DivisionByZero());
-
-        uint256 ratePerEpoch = numerator / denominator;
-
-        // Ensure minimum rate is 0.00001 USDFC if calculation results in 0 due to rounding.
-        // This prevents charging 0 for very small sizes due to integer division.
-        if (ratePerEpoch == 0 && totalBytes > 0) {
-            uint256 minRate = (1 * 10 ** uint256(TOKEN_DECIMALS)) / 100000;
-            return minRate;
-        }
-
-        return ratePerEpoch;
-    }
-
-    /**
-     * @notice Calculate storage rate per epoch based on total storage size
-     * @dev Returns storage rate per TiB per month with minimum pricing floor applied
-     * @param totalBytes Total size of the stored data in bytes
-     * @return storageRate The PDP storage rate per epoch
-     */
-    function calculateRatePerEpoch(uint256 totalBytes) external view returns (uint256 storageRate) {
-        storageRate = _calculateStorageRate(totalBytes);
-    }
-
-    /**
-     * @notice Calculate the storage rate per epoch (internal use)
-     * @dev Implements minimum pricing floor and returns the higher of the natural size-based rate or the minimum rate.
-     * @param totalBytes Total size of the stored data in bytes
-     * @return The storage rate per epoch
-     */
-    function _calculateStorageRate(uint256 totalBytes) internal view returns (uint256) {
-        // Calculate natural size-based rate
-        uint256 naturalRate = calculateStorageSizeBasedRatePerEpoch(totalBytes, storagePricePerTibPerMonth);
-
-        // Calculate minimum rate (floor price converted to per-epoch).
-        // Integer division truncates, so (minimumRate × EPOCHS_PER_MONTH) yields slightly less than
-        // minimumStorageRatePerMonth. For typical floor prices this precision loss is under 0.0001%.
-        // The pre-flight lockup check in validatePayerOperatorApprovalAndFunds uses a multiply-first
-        // formula that preserves the full monthly value, ensuring users always have sufficient funds.
-        uint256 minimumRate = minimumStorageRatePerMonth / EPOCHS_PER_MONTH;
-
-        // Return whichever is higher: natural rate or minimum rate
-        return naturalRate > minimumRate ? naturalRate : minimumRate;
+    function calculateRatePerEpoch(uint256 totalBytes) external pure returns (uint256 storageRate) {
+        return calculateStorageSizeBasedRatePerEpoch(totalBytes);
     }
 
     /**
@@ -1481,12 +1389,12 @@ contract FilecoinWarmStorageService is
      */
     function getServicePrice() external view returns (ServicePricing memory pricing) {
         pricing = ServicePricing({
-            pricePerTiBPerMonthNoCDN: storagePricePerTibPerMonth,
+            pricePerTiBPerMonthNoCDN: STORAGE_PRICE_PER_TIB_PER_MONTH,
             pricePerTiBCdnEgress: CDN_EGRESS_PRICE_PER_TIB,
             pricePerTiBCacheMissEgress: CACHE_MISS_EGRESS_PRICE_PER_TIB,
             tokenAddress: usdfcTokenAddress,
             epochsPerMonth: EPOCHS_PER_MONTH,
-            minimumPricePerMonth: minimumStorageRatePerMonth
+            minimumPricePerMonth: MINIMUM_STORAGE_RATE_PER_MONTH
         });
     }
 
@@ -1496,7 +1404,7 @@ contract FilecoinWarmStorageService is
      * @return spPayment SP payment (per TiB per month)
      */
     function getEffectiveRates() external view returns (uint256 serviceFee, uint256 spPayment) {
-        uint256 total = storagePricePerTibPerMonth;
+        uint256 total = STORAGE_PRICE_PER_TIB_PER_MONTH;
 
         serviceFee = (total * serviceCommissionBps) / COMMISSION_MAX_BPS;
         spPayment = total - serviceFee;

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -19,6 +19,7 @@ import {ServiceProviderRegistry} from "./ServiceProviderRegistry.sol";
 
 import {Extsload} from "./Extsload.sol";
 
+import {Rails} from "./lib/Rails.sol";
 import {SignatureVerificationLib} from "./lib/SignatureVerificationLib.sol";
 
 uint256 constant NO_PROVING_DEADLINE = 0;
@@ -61,7 +62,8 @@ contract FilecoinWarmStorageService is
     // Version tracking
     string public constant VERSION = "1.2.0";
 
-    // =========================================================================
+    using Rails for FilecoinPayV1;
+
     // Events
 
     event ContractUpgraded(string version, address implementation);
@@ -692,21 +694,7 @@ contract FilecoinWarmStorageService is
         payments.modifyRailLockup(pdpRailId, DEFAULT_LOCKUP_PERIOD, 0);
 
         // --- Burn rail: extract USDFC sybil fee from client into payments auction pool ---
-        {
-            uint256 sybilFee = IPDPVerifier(pdpVerifierAddress).USDFC_SYBIL_FEE();
-            uint256 burnRailId = payments.createRail(
-                usdfcTokenAddress,
-                createData.payer, // from: client
-                address(payments), // to: payments contract (auction pool)
-                address(0), // no validator
-                0, // no commission
-                address(0) // service fee recipient (unused, commission=0)
-            );
-            payments.modifyRailLockup(burnRailId, 0, sybilFee);
-            payments.modifyRailPayment(burnRailId, 0, sybilFee);
-            payments.terminateRail(burnRailId);
-            payments.settleRail(burnRailId, block.number);
-        }
+        payments.burnSybil(usdfcTokenAddress, createData.payer);
 
         uint256 cacheMissRailId = 0;
         uint256 cdnRailId = 0;

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -1091,20 +1091,13 @@ contract FilecoinWarmStorageService is
         onlyFilBeamController
     {
         DataSetInfo storage info = dataSetInfo[dataSetId];
-        require(info.pdpRailId != 0, Errors.InvalidDataSetId(dataSetId));
 
         // Check if CDN rails are configured (presence of rails indicates CDN was set up)
         require(info.cdnRailId != 0 && info.cacheMissRailId != 0, Errors.InvalidDataSetId(dataSetId));
 
-        FilecoinPayV1 payments = FilecoinPayV1(paymentsContractAddress);
-
-        if (cdnAmount > 0) {
-            payments.modifyRailPayment(info.cdnRailId, 0, cdnAmount);
-        }
-
-        if (cacheMissAmount > 0) {
-            payments.modifyRailPayment(info.cacheMissRailId, 0, cacheMissAmount);
-        }
+        FilecoinPayV1(paymentsContractAddress).settleCDNRails(
+            info.cdnRailId, info.cacheMissRailId, cdnAmount, cacheMissAmount
+        );
     }
 
     /**

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -19,7 +19,7 @@ import {ServiceProviderRegistry} from "./ServiceProviderRegistry.sol";
 
 import {Extsload} from "./Extsload.sol";
 
-import {Rails} from "./lib/Rails.sol";
+import {CDNPaymentRailsToppedUp, DEFAULT_LOCKUP_PERIOD, Rails} from "./lib/Rails.sol";
 import {SignatureVerificationLib} from "./lib/SignatureVerificationLib.sol";
 
 uint256 constant NO_PROVING_DEADLINE = 0;
@@ -93,10 +93,6 @@ contract FilecoinWarmStorageService is
         address indexed caller, uint256 indexed dataSetId, uint256 pdpRailId, uint256 cacheMissRailId, uint256 cdnRailId
     );
 
-    event CDNServiceTerminated(
-        address indexed caller, uint256 indexed dataSetId, uint256 cacheMissRailId, uint256 cdnRailId
-    );
-
     event PDPPaymentTerminated(uint256 indexed dataSetId, uint256 endEpoch, uint256 pdpRailId);
 
     event CDNPaymentTerminated(uint256 indexed dataSetId, uint256 endEpoch, uint256 cacheMissRailId, uint256 cdnRailId);
@@ -104,14 +100,6 @@ contract FilecoinWarmStorageService is
     event FilBeamControllerChanged(address oldController, address newController);
 
     event ViewContractSet(address indexed viewContract);
-
-    event CDNPaymentRailsToppedUp(
-        uint256 indexed dataSetId,
-        uint256 cdnAmountAdded,
-        uint256 totalCdnLockup,
-        uint256 cacheMissAmountAdded,
-        uint256 totalCacheMissLockup
-    );
 
     // Events for provider management
     event ProviderApproved(uint256 indexed providerId);
@@ -191,12 +179,10 @@ contract FilecoinWarmStorageService is
         uint96 afterEpoch;
     }
 
-    // =========================================================================
     // Constants
 
     uint256 private constant NO_CHALLENGE_SCHEDULED = 0;
     uint256 private constant MIB_IN_BYTES = 1024 * 1024; // 1 MiB in bytes
-    uint256 private constant DEFAULT_LOCKUP_PERIOD = 2880 * 30; // 1 month (30 days) in epochs
     uint256 private constant GIB_IN_BYTES = MIB_IN_BYTES * 1024; // 1 GiB in bytes
     uint256 private constant TIB_IN_BYTES = GIB_IN_BYTES * 1024; // 1 TiB in bytes
     uint256 private constant EPOCHS_PER_MONTH = 2880 * 30;
@@ -1139,30 +1125,8 @@ contract FilecoinWarmStorageService is
         // Check if cache miss and CDN rails are configured
         require(info.cacheMissRailId != 0 && info.cdnRailId != 0, Errors.InvalidDataSetId(dataSetId));
 
-        FilecoinPayV1 payments = FilecoinPayV1(paymentsContractAddress);
-
-        // Both rails must be active for any top-up operation
-        FilecoinPayV1.RailView memory cdnRail = payments.getRail(info.cdnRailId);
-        FilecoinPayV1.RailView memory cacheMissRail = payments.getRail(info.cacheMissRailId);
-
-        require(cdnRail.endEpoch == 0, Errors.CDNPaymentAlreadyTerminated(dataSetId));
-        require(cacheMissRail.endEpoch == 0, Errors.CacheMissPaymentAlreadyTerminated(dataSetId));
-
-        // Require at least one amount to be non-zero
-        if (cdnAmountToAdd == 0 && cacheMissAmountToAdd == 0) {
-            revert Errors.InvalidTopUpAmount(dataSetId);
-        }
-
-        // Calculate total lockup amounts
-        uint256 totalCdnLockup = cdnRail.lockupFixed + cdnAmountToAdd;
-        uint256 totalCacheMissLockup = cacheMissRail.lockupFixed + cacheMissAmountToAdd;
-
-        // Only modify rails if amounts are being added
-        payments.modifyRailLockup(info.cdnRailId, DEFAULT_LOCKUP_PERIOD, totalCdnLockup);
-        payments.modifyRailLockup(info.cacheMissRailId, DEFAULT_LOCKUP_PERIOD, totalCacheMissLockup);
-
-        emit CDNPaymentRailsToppedUp(
-            dataSetId, cdnAmountToAdd, totalCdnLockup, cacheMissAmountToAdd, totalCacheMissLockup
+        FilecoinPayV1(paymentsContractAddress).topUpCDNRails(
+            dataSetId, info.cacheMissRailId, info.cdnRailId, cacheMissAmountToAdd, cdnAmountToAdd
         );
     }
 

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -20,12 +20,15 @@ import {ServiceProviderRegistry} from "./ServiceProviderRegistry.sol";
 import {Extsload} from "./Extsload.sol";
 
 import {
+    CACHE_MISS_EGRESS_PRICE_PER_TIB,
+    CDN_EGRESS_PRICE_PER_TIB,
+    DEFAULT_CACHE_MISS_LOCKUP_AMOUNT,
+    DEFAULT_CDN_LOCKUP_AMOUNT,
     DEFAULT_LOCKUP_PERIOD,
     EPOCHS_PER_MONTH,
     MINIMUM_STORAGE_RATE_PER_MONTH,
     STORAGE_PRICE_PER_TIB_PER_MONTH,
-    calculateStorageSizeBasedRatePerEpoch,
-    calculateStorageRate
+    TOKEN_DECIMALS
 } from "./lib/PriceListUSDFC.sol";
 import {CDNPaymentRailsToppedUp, Rails} from "./lib/Rails.sol";
 import {SignatureVerificationLib} from "./lib/SignatureVerificationLib.sol";
@@ -92,7 +95,6 @@ contract FilecoinWarmStorageService is
         string[] metadataKeys,
         string[] metadataValues
     );
-    event RailRateUpdated(uint256 indexed dataSetId, uint256 railId, uint256 newRate);
     event PieceAdded(
         uint256 indexed dataSetId, uint256 indexed pieceId, Cids.Cid pieceCid, string[] keys, string[] values
     );
@@ -205,21 +207,6 @@ contract FilecoinWarmStorageService is
 
     // Upgrade sequence number, used by Initializable.reinitializer
     uint64 private immutable REINITIALIZER_VERSION;
-
-    // Pricing constants (CDN egress pricing is immutable)
-    uint256 private immutable CDN_EGRESS_PRICE_PER_TIB; // 7 USDFC per TiB of CDN egress
-    uint256 private immutable CACHE_MISS_EGRESS_PRICE_PER_TIB; // 7 USDFC per TiB of cache miss egress
-
-    // Fixed lockup amounts for CDN rails
-    uint256 private immutable DEFAULT_CDN_LOCKUP_AMOUNT; // 0.7 USDFC
-    uint256 private immutable DEFAULT_CACHE_MISS_LOCKUP_AMOUNT; // 0.3 USDFC
-
-    // Maximum pricing bounds (4x initial values)
-    uint256 private immutable MAX_STORAGE_PRICE_PER_TIB_PER_MONTH; // 10 USDFC (4x 2.5)
-    uint256 private immutable MAX_MINIMUM_STORAGE_RATE_PER_MONTH; // 0.24 USDFC (4x 0.06)
-
-    // Token decimals
-    uint8 private immutable TOKEN_DECIMALS;
 
     // External contract addresses
     address public immutable pdpVerifierAddress;
@@ -349,20 +336,8 @@ contract FilecoinWarmStorageService is
         );
         sessionKeyRegistry = _sessionKeyRegistry;
 
-        // Read token decimals from the USDFC token contract
-        TOKEN_DECIMALS = _usdfc.decimals();
-
-        // Initialize the immutable pricing constants based on the actual token decimals
-        CDN_EGRESS_PRICE_PER_TIB = 7 * 10 ** TOKEN_DECIMALS; // 7 USDFC per TiB
-        CACHE_MISS_EGRESS_PRICE_PER_TIB = 7 * 10 ** TOKEN_DECIMALS; // 7 USDFC per TiB
-
-        // Initialize maximum pricing bounds (4x initial values)
-        MAX_STORAGE_PRICE_PER_TIB_PER_MONTH = 10 * 10 ** TOKEN_DECIMALS; // 10 USDFC (4x 2.5)
-        MAX_MINIMUM_STORAGE_RATE_PER_MONTH = (24 * 10 ** TOKEN_DECIMALS) / 100; // 0.24 USDFC (4x 0.06)
-
-        // Initialize the lockup constants based on the actual token decimals
-        DEFAULT_CDN_LOCKUP_AMOUNT = (7 * 10 ** TOKEN_DECIMALS) / 10; // 0.7 USDFC
-        DEFAULT_CACHE_MISS_LOCKUP_AMOUNT = (3 * 10 ** TOKEN_DECIMALS) / 10; // 0.3 USDFC
+        // Verify token decimals from the USDFC token contract
+        require(TOKEN_DECIMALS == _usdfc.decimals());
     }
 
     /**
@@ -1204,20 +1179,13 @@ contract FilecoinWarmStorageService is
     }
 
     function updatePaymentRates(uint256 dataSetId, uint256 leafCount) internal {
+        uint256 pdpRailId = dataSetInfo[dataSetId].pdpRailId;
         // Revert if no payment rail is configured for this data set
-        require(dataSetInfo[dataSetId].pdpRailId != 0, Errors.NoPDPPaymentRail(dataSetId));
-
-        FilecoinPayV1 payments = FilecoinPayV1(paymentsContractAddress);
+        require(pdpRailId != 0, Errors.NoPDPPaymentRail(dataSetId));
 
         // Update the PDP rail payment rate with the new rate and no one-time payment
-        uint256 pdpRailId = dataSetInfo[dataSetId].pdpRailId;
-        uint256 newStorageRatePerEpoch = calculateStorageRate(leafCount);
-        payments.modifyRailPayment(
-            pdpRailId,
-            newStorageRatePerEpoch,
-            0 // No one-time payment during rate update
-        );
-        emit RailRateUpdated(dataSetId, pdpRailId, newStorageRatePerEpoch);
+
+        FilecoinPayV1(paymentsContractAddress).updateStorageRates(dataSetId, pdpRailId, leafCount);
     }
 
     function processScheduledPieceMetadataRemovals(uint256 dataSetId) internal returns (bool hadRemovals) {
@@ -1292,10 +1260,6 @@ contract FilecoinWarmStorageService is
 
     function min(uint256 a, uint256 b) internal pure returns (uint256) {
         return a < b ? a : b;
-    }
-
-    function calculateRatePerEpoch(uint256 totalBytes) external pure returns (uint256 storageRate) {
-        return calculateStorageSizeBasedRatePerEpoch(totalBytes);
     }
 
     /**

--- a/service_contracts/src/FilecoinWarmStorageServiceStateView.sol
+++ b/service_contracts/src/FilecoinWarmStorageServiceStateView.sol
@@ -18,6 +18,10 @@ contract FilecoinWarmStorageServiceStateView is IPDPProvingSchedule {
         service = _service;
     }
 
+    function calculateRatePerEpoch(uint256 totalBytes) external pure returns (uint256 storageRate) {
+        return FilecoinWarmStorageServiceStateInternalLibrary.calculateRatePerEpoch(totalBytes);
+    }
+
     function clientDataSets(address payer) external view returns (uint256[] memory dataSetIds) {
         return service.clientDataSets(payer);
     }

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceLayout.json
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceLayout.json
@@ -22,7 +22,7 @@
     }
   },
   {
-    "label": "serviceCommissionBps",
+    "label": "deprecatedServiceCommissionBps",
     "slot": "2",
     "offset": 0,
     "type": "uint256",
@@ -554,7 +554,7 @@
     }
   },
   {
-    "label": "storagePricePerTibPerMonth",
+    "label": "deprecatedStoragePricePerTibPerMonth",
     "slot": "20",
     "offset": 0,
     "type": "uint256",
@@ -565,7 +565,7 @@
     }
   },
   {
-    "label": "minimumStorageRatePerMonth",
+    "label": "deprecatedMinimumStorageRatePerMonth",
     "slot": "21",
     "offset": 0,
     "type": "uint256",

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceLayout.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceLayout.sol
@@ -7,7 +7,7 @@ pragma solidity ^0.8.20;
 
 bytes32 constant MAX_PROVING_PERIOD_SLOT = bytes32(uint256(0));
 bytes32 constant CHALLENGE_WINDOW_SIZE_SLOT = bytes32(uint256(1));
-bytes32 constant SERVICE_COMMISSION_BPS_SLOT = bytes32(uint256(2));
+bytes32 constant DEPRECATED_SERVICE_COMMISSION_BPS_SLOT = bytes32(uint256(2));
 bytes32 constant PROVEN_PERIODS_SLOT = bytes32(uint256(3));
 bytes32 constant PROVING_ACTIVATION_EPOCH_SLOT = bytes32(uint256(4));
 bytes32 constant PROVING_DEADLINES_SLOT = bytes32(uint256(5));
@@ -25,6 +25,6 @@ bytes32 constant APPROVED_PROVIDER_IDS_SLOT = bytes32(uint256(16));
 bytes32 constant VIEW_CONTRACT_ADDRESS_SLOT = bytes32(uint256(17));
 bytes32 constant FIL_BEAM_CONTROLLER_ADDRESS_SLOT = bytes32(uint256(18));
 bytes32 constant NEXT_UPGRADE_SLOT = bytes32(uint256(19));
-bytes32 constant STORAGE_PRICE_PER_TIB_PER_MONTH_SLOT = bytes32(uint256(20));
-bytes32 constant MINIMUM_STORAGE_RATE_PER_MONTH_SLOT = bytes32(uint256(21));
+bytes32 constant DEPRECATED_STORAGE_PRICE_PER_TIB_PER_MONTH_SLOT = bytes32(uint256(20));
+bytes32 constant DEPRECATED_MINIMUM_STORAGE_RATE_PER_MONTH_SLOT = bytes32(uint256(21));
 bytes32 constant SCHEDULED_PIECE_METADATA_REMOVALS_SLOT = bytes32(uint256(22));

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
@@ -10,7 +10,12 @@ import {Errors} from "../Errors.sol";
 import {
     CHALLENGES_PER_PROOF, NO_PROVING_DEADLINE, FilecoinWarmStorageService
 } from "../FilecoinWarmStorageService.sol";
-import {calculateStorageSizeBasedRatePerEpoch} from "./PriceListUSDFC.sol";
+import {
+    calculateStorageSizeBasedRatePerEpoch,
+    MINIMUM_STORAGE_RATE_PER_MONTH,
+    SERVICE_COMMISSION_BPS,
+    STORAGE_PRICE_PER_TIB_PER_MONTH
+} from "./PriceListUSDFC.sol";
 import "./FilecoinWarmStorageServiceLayout.sol" as StorageLayout;
 
 // bytes32(bytes4(keccak256(abi.encodePacked("extsloadStruct(bytes32,uint256)"))));
@@ -276,8 +281,8 @@ library FilecoinWarmStorageServiceStateInternalLibrary {
         initChallengeWindowStart = block.number + maxProvingPeriod - challengeWindowSize;
     }
 
-    function serviceCommissionBps(FilecoinWarmStorageService service) internal view returns (uint256) {
-        return uint256(service.extsload(StorageLayout.SERVICE_COMMISSION_BPS_SLOT));
+    function serviceCommissionBps(FilecoinWarmStorageService) internal pure returns (uint256) {
+        return SERVICE_COMMISSION_BPS;
     }
 
     /**
@@ -611,15 +616,12 @@ library FilecoinWarmStorageServiceStateInternalLibrary {
      * @return storagePrice Current storage price per TiB per month
      * @return minimumRate Current minimum monthly storage rate
      */
-    function getCurrentPricingRates(FilecoinWarmStorageService service)
+    function getCurrentPricingRates(FilecoinWarmStorageService)
         internal
-        view
+        pure
         returns (uint256 storagePrice, uint256 minimumRate)
     {
-        return (
-            uint256(service.extsload(StorageLayout.STORAGE_PRICE_PER_TIB_PER_MONTH_SLOT)),
-            uint256(service.extsload(StorageLayout.MINIMUM_STORAGE_RATE_PER_MONTH_SLOT))
-        );
+        return (STORAGE_PRICE_PER_TIB_PER_MONTH, MINIMUM_STORAGE_RATE_PER_MONTH);
     }
 
     function calculateRatePerEpoch(uint256 totalBytes) internal pure returns (uint256 storageRate) {

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
@@ -10,6 +10,7 @@ import {Errors} from "../Errors.sol";
 import {
     CHALLENGES_PER_PROOF, NO_PROVING_DEADLINE, FilecoinWarmStorageService
 } from "../FilecoinWarmStorageService.sol";
+import {calculateStorageSizeBasedRatePerEpoch} from "./PriceListUSDFC.sol";
 import "./FilecoinWarmStorageServiceLayout.sol" as StorageLayout;
 
 // bytes32(bytes4(keccak256(abi.encodePacked("extsloadStruct(bytes32,uint256)"))));
@@ -619,5 +620,9 @@ library FilecoinWarmStorageServiceStateInternalLibrary {
             uint256(service.extsload(StorageLayout.STORAGE_PRICE_PER_TIB_PER_MONTH_SLOT)),
             uint256(service.extsload(StorageLayout.MINIMUM_STORAGE_RATE_PER_MONTH_SLOT))
         );
+    }
+
+    function calculateRatePerEpoch(uint256 totalBytes) internal pure returns (uint256 storageRate) {
+        return calculateStorageSizeBasedRatePerEpoch(totalBytes);
     }
 }

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceStateLibrary.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceStateLibrary.sol
@@ -6,7 +6,12 @@ import {Errors} from "../Errors.sol";
 import {
     CHALLENGES_PER_PROOF, NO_PROVING_DEADLINE, FilecoinWarmStorageService
 } from "../FilecoinWarmStorageService.sol";
-import {calculateStorageSizeBasedRatePerEpoch} from "./PriceListUSDFC.sol";
+import {
+    calculateStorageSizeBasedRatePerEpoch,
+    MINIMUM_STORAGE_RATE_PER_MONTH,
+    SERVICE_COMMISSION_BPS,
+    STORAGE_PRICE_PER_TIB_PER_MONTH
+} from "./PriceListUSDFC.sol";
 import "./FilecoinWarmStorageServiceLayout.sol" as StorageLayout;
 
 // bytes32(bytes4(keccak256(abi.encodePacked("extsloadStruct(bytes32,uint256)"))));
@@ -268,8 +273,8 @@ library FilecoinWarmStorageServiceStateLibrary {
         initChallengeWindowStart = block.number + maxProvingPeriod - challengeWindowSize;
     }
 
-    function serviceCommissionBps(FilecoinWarmStorageService service) public view returns (uint256) {
-        return uint256(service.extsload(StorageLayout.SERVICE_COMMISSION_BPS_SLOT));
+    function serviceCommissionBps(FilecoinWarmStorageService) public pure returns (uint256) {
+        return SERVICE_COMMISSION_BPS;
     }
 
     /**
@@ -603,15 +608,12 @@ library FilecoinWarmStorageServiceStateLibrary {
      * @return storagePrice Current storage price per TiB per month
      * @return minimumRate Current minimum monthly storage rate
      */
-    function getCurrentPricingRates(FilecoinWarmStorageService service)
+    function getCurrentPricingRates(FilecoinWarmStorageService)
         public
-        view
+        pure
         returns (uint256 storagePrice, uint256 minimumRate)
     {
-        return (
-            uint256(service.extsload(StorageLayout.STORAGE_PRICE_PER_TIB_PER_MONTH_SLOT)),
-            uint256(service.extsload(StorageLayout.MINIMUM_STORAGE_RATE_PER_MONTH_SLOT))
-        );
+        return (STORAGE_PRICE_PER_TIB_PER_MONTH, MINIMUM_STORAGE_RATE_PER_MONTH);
     }
 
     function calculateRatePerEpoch(uint256 totalBytes) public pure returns (uint256 storageRate) {

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceStateLibrary.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceStateLibrary.sol
@@ -6,6 +6,7 @@ import {Errors} from "../Errors.sol";
 import {
     CHALLENGES_PER_PROOF, NO_PROVING_DEADLINE, FilecoinWarmStorageService
 } from "../FilecoinWarmStorageService.sol";
+import {calculateStorageSizeBasedRatePerEpoch} from "./PriceListUSDFC.sol";
 import "./FilecoinWarmStorageServiceLayout.sol" as StorageLayout;
 
 // bytes32(bytes4(keccak256(abi.encodePacked("extsloadStruct(bytes32,uint256)"))));
@@ -611,5 +612,9 @@ library FilecoinWarmStorageServiceStateLibrary {
             uint256(service.extsload(StorageLayout.STORAGE_PRICE_PER_TIB_PER_MONTH_SLOT)),
             uint256(service.extsload(StorageLayout.MINIMUM_STORAGE_RATE_PER_MONTH_SLOT))
         );
+    }
+
+    function calculateRatePerEpoch(uint256 totalBytes) public pure returns (uint256 storageRate) {
+        return calculateStorageSizeBasedRatePerEpoch(totalBytes);
     }
 }

--- a/service_contracts/src/lib/PriceListUSDFC.sol
+++ b/service_contracts/src/lib/PriceListUSDFC.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+pragma solidity ^0.8.20;
+
+// USDFC has 18 decimals, so $1 = 10**18 (a.k.a. ether)
+uint256 constant SYBIL_FEE = 0.1 ether;

--- a/service_contracts/src/lib/PriceListUSDFC.sol
+++ b/service_contracts/src/lib/PriceListUSDFC.sol
@@ -1,7 +1,43 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 pragma solidity ^0.8.20;
 
+import {Cids} from "@pdp/Cids.sol";
+
+uint256 constant MIB_IN_BYTES = 1024 * 1024; // 1 MiB in bytes
+uint256 constant GIB_IN_BYTES = MIB_IN_BYTES * 1024; // 1 GiB in bytes
+uint256 constant TIB_IN_BYTES = GIB_IN_BYTES * 1024; // 1 TiB in bytes
+
+uint256 constant TOKEN_DECIMALS = 18;
 uint256 constant DEFAULT_LOCKUP_PERIOD = 2880 * 30; // 1 month (30 days) in epochs
+uint256 constant EPOCHS_PER_MONTH = 2880 * 30;
 
 // USDFC has 18 decimals, so $1 = 10**18 (a.k.a. ether)
 uint256 constant SYBIL_FEE = 0.1 ether;
+uint256 constant STORAGE_PRICE_PER_TIB_PER_MONTH = (5 * 10 ** TOKEN_DECIMALS) / 2; // 2.5 USDFC
+uint256 constant MINIMUM_STORAGE_RATE_PER_MONTH = (6 * 10 ** TOKEN_DECIMALS) / 100; // 0.06 USDFC
+uint256 constant MINIMUM_STORAGE_RATE_PER_EPOCH = MINIMUM_STORAGE_RATE_PER_MONTH / EPOCHS_PER_MONTH;
+
+/**
+ * @notice Calculate a per-epoch rate based on total storage size
+ * @param totalBytes Total size of the stored data in bytes
+ * @return ratePerEpoch The calculated rate per epoch in the token's smallest unit
+ */
+function calculateStorageSizeBasedRatePerEpoch(uint256 totalBytes) pure returns (uint256 ratePerEpoch) {
+    uint256 numerator = totalBytes * STORAGE_PRICE_PER_TIB_PER_MONTH;
+    uint256 denominator = TIB_IN_BYTES * EPOCHS_PER_MONTH;
+
+    ratePerEpoch = numerator / denominator;
+
+    // Return whichever is higher: natural rate or minimum rate
+    return ratePerEpoch > MINIMUM_STORAGE_RATE_PER_EPOCH ? ratePerEpoch : MINIMUM_STORAGE_RATE_PER_EPOCH;
+}
+
+/**
+ * @notice Calculate the storage rate per epoch (internal use)
+ * @dev Implements minimum pricing floor and returns the higher of the natural size-based rate or the minimum rate.
+ * @param leafCount the count of the 32b leaves in the FRC-0069 tree
+ * @return storageRatePerEpoch The storage rate per epoch
+ */
+function calculateStorageRate(uint256 leafCount) pure returns (uint256 storageRatePerEpoch) {
+    return calculateStorageSizeBasedRatePerEpoch(Cids.leafCountToRawSize(leafCount));
+}

--- a/service_contracts/src/lib/PriceListUSDFC.sol
+++ b/service_contracts/src/lib/PriceListUSDFC.sol
@@ -23,6 +23,8 @@ uint256 constant CACHE_MISS_EGRESS_PRICE_PER_TIB = 7 * 10 ** TOKEN_DECIMALS; // 
 uint256 constant DEFAULT_CDN_LOCKUP_AMOUNT = (7 * 10 ** TOKEN_DECIMALS) / 10; // 0.7 USDFC
 uint256 constant DEFAULT_CACHE_MISS_LOCKUP_AMOUNT = (3 * 10 ** TOKEN_DECIMALS) / 10; // 0.3 USDFC
 
+uint256 constant SERVICE_COMMISSION_BPS = 0;
+
 /**
  * @notice Calculate a per-epoch rate based on total storage size
  * @param totalBytes Total size of the stored data in bytes

--- a/service_contracts/src/lib/PriceListUSDFC.sol
+++ b/service_contracts/src/lib/PriceListUSDFC.sol
@@ -17,6 +17,12 @@ uint256 constant STORAGE_PRICE_PER_TIB_PER_MONTH = (5 * 10 ** TOKEN_DECIMALS) / 
 uint256 constant MINIMUM_STORAGE_RATE_PER_MONTH = (6 * 10 ** TOKEN_DECIMALS) / 100; // 0.06 USDFC
 uint256 constant MINIMUM_STORAGE_RATE_PER_EPOCH = MINIMUM_STORAGE_RATE_PER_MONTH / EPOCHS_PER_MONTH;
 
+uint256 constant CDN_EGRESS_PRICE_PER_TIB = 7 * 10 ** TOKEN_DECIMALS; // 7 USDFC per TiB
+uint256 constant CACHE_MISS_EGRESS_PRICE_PER_TIB = 7 * 10 ** TOKEN_DECIMALS; // 7 USDFC per TiB
+
+uint256 constant DEFAULT_CDN_LOCKUP_AMOUNT = (7 * 10 ** TOKEN_DECIMALS) / 10; // 0.7 USDFC
+uint256 constant DEFAULT_CACHE_MISS_LOCKUP_AMOUNT = (3 * 10 ** TOKEN_DECIMALS) / 10; // 0.3 USDFC
+
 /**
  * @notice Calculate a per-epoch rate based on total storage size
  * @param totalBytes Total size of the stored data in bytes

--- a/service_contracts/src/lib/PriceListUSDFC.sol
+++ b/service_contracts/src/lib/PriceListUSDFC.sol
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 pragma solidity ^0.8.20;
 
+uint256 constant DEFAULT_LOCKUP_PERIOD = 2880 * 30; // 1 month (30 days) in epochs
+
 // USDFC has 18 decimals, so $1 = 10**18 (a.k.a. ether)
 uint256 constant SYBIL_FEE = 0.1 ether;

--- a/service_contracts/src/lib/Rails.sol
+++ b/service_contracts/src/lib/Rails.sol
@@ -73,4 +73,20 @@ library Rails {
             dataSetId, cdnAmountToAdd, totalCdnLockup, cacheMissAmountToAdd, totalCacheMissLockup
         );
     }
+
+    function settleCDNRails(
+        FilecoinPayV1 payments,
+        uint256 cdnRailId,
+        uint256 cacheMissRailId,
+        uint256 cdnAmount,
+        uint256 cacheMissAmount
+    ) public {
+        if (cdnAmount > 0) {
+            payments.modifyRailPayment(cdnRailId, 0, cdnAmount);
+        }
+
+        if (cacheMissAmount > 0) {
+            payments.modifyRailPayment(cacheMissRailId, 0, cacheMissAmount);
+        }
+    }
 }

--- a/service_contracts/src/lib/Rails.sol
+++ b/service_contracts/src/lib/Rails.sol
@@ -5,6 +5,10 @@ import {FilecoinPayV1} from "@fws-payments/FilecoinPayV1.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SYBIL_FEE} from "./PriceListUSDFC.sol";
 
+event CDNServiceTerminated(
+    address indexed caller, uint256 indexed dataSetId, uint256 cacheMissRailId, uint256 cdnRailId
+);
+
 library Rails {
     function burnSybil(FilecoinPayV1 payments, IERC20 token, address payer) public {
         uint256 burnRailId = payments.createRail(
@@ -19,5 +23,13 @@ library Rails {
         payments.modifyRailPayment(burnRailId, 0, SYBIL_FEE);
         payments.terminateRail(burnRailId);
         payments.settleRail(burnRailId, block.number);
+    }
+
+    function terminateCDNRails(FilecoinPayV1 payments, uint256 dataSetId, uint256 cacheMissRailId, uint256 cdnRailId)
+        public
+    {
+        try payments.terminateRail(cacheMissRailId) {} catch {}
+        try payments.terminateRail(cdnRailId) {} catch {}
+        emit CDNServiceTerminated(msg.sender, dataSetId, cacheMissRailId, cdnRailId);
     }
 }

--- a/service_contracts/src/lib/Rails.sol
+++ b/service_contracts/src/lib/Rails.sol
@@ -4,7 +4,17 @@ pragma solidity ^0.8.20;
 import {Errors} from "../Errors.sol";
 import {FilecoinPayV1} from "@fws-payments/FilecoinPayV1.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {DEFAULT_LOCKUP_PERIOD, SYBIL_FEE, calculateStorageRate} from "./PriceListUSDFC.sol";
+import {
+    DEFAULT_LOCKUP_PERIOD,
+    DEFAULT_CACHE_MISS_LOCKUP_AMOUNT,
+    DEFAULT_CDN_LOCKUP_AMOUNT,
+    DEFAULT_LOCKUP_PERIOD,
+    EPOCHS_PER_MONTH,
+    MINIMUM_STORAGE_RATE_PER_MONTH,
+    SERVICE_COMMISSION_BPS,
+    SYBIL_FEE,
+    calculateStorageRate
+} from "./PriceListUSDFC.sol";
 
 event CDNPaymentRailsToppedUp(
     uint256 indexed dataSetId,
@@ -21,7 +31,7 @@ event CDNServiceTerminated(
 event RailRateUpdated(uint256 indexed dataSetId, uint256 railId, uint256 newRate);
 
 library Rails {
-    function burnSybil(FilecoinPayV1 payments, IERC20 token, address payer) public {
+    function burnSybil(FilecoinPayV1 payments, IERC20 token, address payer) internal {
         uint256 burnRailId = payments.createRail(
             token,
             payer, // from: client
@@ -34,6 +44,137 @@ library Rails {
         payments.modifyRailPayment(burnRailId, 0, SYBIL_FEE);
         payments.terminateRail(burnRailId);
         payments.settleRail(burnRailId, block.number);
+    }
+
+    /// @notice Validates that the payer has sufficient funds and operator approvals for minimum pricing
+    /// @param payments The FilecoinPayV1 contract instance
+    /// @param payer The address of the payer
+    function validatePayerOperatorApprovalAndFunds(
+        FilecoinPayV1 payments,
+        IERC20 usdfcTokenAddress,
+        address payer,
+        bool includeCDN
+    ) internal view {
+        // Calculate required lockup for minimum pricing.
+        // We use multiply-first here to preserve the exact monthly value for cleaner error messages
+        // (a round number like the configured floor price, rather than a value with many trailing digits
+        // from precision loss). This is slightly more conservative than the actual rail lockup (which
+        // uses the truncated per-epoch rate), but the difference is under 0.0001% and always in the
+        // user's favor - they are never required to have less than what the rail will actually lock.
+        uint256 minimumLockupRequired = (MINIMUM_STORAGE_RATE_PER_MONTH * DEFAULT_LOCKUP_PERIOD) / EPOCHS_PER_MONTH;
+
+        // If CDN is enabled, include the fixed cache-miss and CDN lockup amounts
+        if (includeCDN) {
+            minimumLockupRequired += DEFAULT_CACHE_MISS_LOCKUP_AMOUNT + DEFAULT_CDN_LOCKUP_AMOUNT;
+        }
+
+        // Include sybil fee (burn rail lockup consumes funds and lockup allowance)
+        minimumLockupRequired += SYBIL_FEE;
+
+        // Check that payer has sufficient available funds
+        (,, uint256 availableFunds,) = payments.getAccountInfoIfSettled(usdfcTokenAddress, payer);
+        require(
+            availableFunds >= minimumLockupRequired,
+            Errors.InsufficientLockupFunds(payer, minimumLockupRequired, availableFunds)
+        );
+
+        // Check operator approval settings
+        (
+            bool isApproved,
+            uint256 rateAllowance,
+            uint256 lockupAllowance,
+            uint256 rateUsage,
+            uint256 lockupUsage,
+            uint256 maxLockupPeriod
+        ) = payments.operatorApprovals(usdfcTokenAddress, payer, address(this));
+
+        // Verify operator is approved
+        require(isApproved, Errors.OperatorNotApproved(payer, address(this)));
+
+        // Calculate minimum rate per epoch
+        uint256 minimumRatePerEpoch = MINIMUM_STORAGE_RATE_PER_MONTH / EPOCHS_PER_MONTH;
+
+        // Verify rate allowance is sufficient
+        require(
+            rateAllowance >= rateUsage + minimumRatePerEpoch,
+            Errors.InsufficientRateAllowance(payer, address(this), rateAllowance, rateUsage, minimumRatePerEpoch)
+        );
+
+        // Verify lockup allowance is sufficient
+        require(
+            lockupAllowance >= lockupUsage + minimumLockupRequired,
+            Errors.InsufficientLockupAllowance(
+                payer, address(this), lockupAllowance, lockupUsage, minimumLockupRequired
+            )
+        );
+
+        // Verify max lockup period is sufficient
+        require(
+            maxLockupPeriod >= DEFAULT_LOCKUP_PERIOD,
+            Errors.InsufficientMaxLockupPeriod(payer, address(this), maxLockupPeriod, DEFAULT_LOCKUP_PERIOD)
+        );
+    }
+
+    function createRails(
+        FilecoinPayV1 payments,
+        uint256 dataSetId,
+        IERC20 usdfcTokenAddress,
+        address payer,
+        address payee,
+        address filBeamBeneficiaryAddress
+    ) public returns (uint256 pdpRailId, uint256 cacheMissRailId, uint256 cdnRailId) {
+        bool hasCDN = filBeamBeneficiaryAddress != address(0);
+        // Validate payer has sufficient funds and operator approvals for minimum pricing
+        // If CDN is enabled, validation must account for the additional fixed lockup amounts
+        validatePayerOperatorApprovalAndFunds(payments, usdfcTokenAddress, payer, hasCDN);
+
+        pdpRailId = payments.createRail(
+            usdfcTokenAddress, // token address
+            payer, // from (payer)
+            payee, // payee address from registry
+            address(this), // this contract acts as the validator
+            SERVICE_COMMISSION_BPS, // commission rate based on CDN usage
+            address(this)
+        );
+
+        // Set lockup period for the rail
+        payments.modifyRailLockup(pdpRailId, DEFAULT_LOCKUP_PERIOD, 0);
+
+        // --- Burn rail: extract USDFC sybil fee from client into payments auction pool ---
+        burnSybil(payments, usdfcTokenAddress, payer);
+
+        cacheMissRailId = 0;
+        cdnRailId = 0;
+
+        if (hasCDN) {
+            cacheMissRailId = payments.createRail(
+                usdfcTokenAddress, // token address
+                payer, // from (payer)
+                payee, // payee address from registry
+                address(0), // no validator
+                0, // no service commission
+                address(this) // controller
+            );
+            payments.modifyRailLockup(cacheMissRailId, DEFAULT_LOCKUP_PERIOD, DEFAULT_CACHE_MISS_LOCKUP_AMOUNT);
+
+            cdnRailId = payments.createRail(
+                usdfcTokenAddress, // token address
+                payer, // from (payer)
+                filBeamBeneficiaryAddress, // to FilBeam beneficiary
+                address(0), // no validator
+                0, // no service commission
+                address(this) // controller
+            );
+            payments.modifyRailLockup(cdnRailId, DEFAULT_LOCKUP_PERIOD, DEFAULT_CDN_LOCKUP_AMOUNT);
+
+            emit CDNPaymentRailsToppedUp(
+                dataSetId,
+                DEFAULT_CDN_LOCKUP_AMOUNT,
+                DEFAULT_CDN_LOCKUP_AMOUNT,
+                DEFAULT_CACHE_MISS_LOCKUP_AMOUNT,
+                DEFAULT_CACHE_MISS_LOCKUP_AMOUNT
+            );
+        }
     }
 
     function terminateCDNRails(FilecoinPayV1 payments, uint256 dataSetId, uint256 cacheMissRailId, uint256 cdnRailId)

--- a/service_contracts/src/lib/Rails.sol
+++ b/service_contracts/src/lib/Rails.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+pragma solidity ^0.8.20;
+
+import {FilecoinPayV1} from "@fws-payments/FilecoinPayV1.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SYBIL_FEE} from "./PriceListUSDFC.sol";
+
+library Rails {
+    function burnSybil(FilecoinPayV1 payments, IERC20 token, address payer) public {
+        uint256 burnRailId = payments.createRail(
+            token,
+            payer, // from: client
+            address(payments), // to: payments contract (auction pool)
+            address(0), // no validator
+            0, // no commission
+            address(0) // service fee recipient (unused, commission=0)
+        );
+        payments.modifyRailLockup(burnRailId, 0, SYBIL_FEE);
+        payments.modifyRailPayment(burnRailId, 0, SYBIL_FEE);
+        payments.terminateRail(burnRailId);
+        payments.settleRail(burnRailId, block.number);
+    }
+}

--- a/service_contracts/src/lib/Rails.sol
+++ b/service_contracts/src/lib/Rails.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 import {Errors} from "../Errors.sol";
 import {FilecoinPayV1} from "@fws-payments/FilecoinPayV1.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {DEFAULT_LOCKUP_PERIOD, SYBIL_FEE} from "./PriceListUSDFC.sol";
+import {DEFAULT_LOCKUP_PERIOD, SYBIL_FEE, calculateStorageRate} from "./PriceListUSDFC.sol";
 
 event CDNPaymentRailsToppedUp(
     uint256 indexed dataSetId,
@@ -17,6 +17,8 @@ event CDNPaymentRailsToppedUp(
 event CDNServiceTerminated(
     address indexed caller, uint256 indexed dataSetId, uint256 cacheMissRailId, uint256 cdnRailId
 );
+
+event RailRateUpdated(uint256 indexed dataSetId, uint256 railId, uint256 newRate);
 
 library Rails {
     function burnSybil(FilecoinPayV1 payments, IERC20 token, address payer) public {
@@ -88,5 +90,13 @@ library Rails {
         if (cacheMissAmount > 0) {
             payments.modifyRailPayment(cacheMissRailId, 0, cacheMissAmount);
         }
+    }
+
+    function updateStorageRates(FilecoinPayV1 payments, uint256 dataSetId, uint256 pdpRailId, uint256 leafCount)
+        public
+    {
+        uint256 newStorageRatePerEpoch = calculateStorageRate(leafCount);
+        payments.modifyRailPayment(pdpRailId, newStorageRatePerEpoch, 0);
+        emit RailRateUpdated(dataSetId, pdpRailId, newStorageRatePerEpoch);
     }
 }

--- a/service_contracts/src/lib/Rails.sol
+++ b/service_contracts/src/lib/Rails.sol
@@ -5,7 +5,6 @@ import {Errors} from "../Errors.sol";
 import {FilecoinPayV1} from "@fws-payments/FilecoinPayV1.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {
-    DEFAULT_LOCKUP_PERIOD,
     DEFAULT_CACHE_MISS_LOCKUP_AMOUNT,
     DEFAULT_CDN_LOCKUP_AMOUNT,
     DEFAULT_LOCKUP_PERIOD,

--- a/service_contracts/src/lib/Rails.sol
+++ b/service_contracts/src/lib/Rails.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 import {Errors} from "../Errors.sol";
 import {FilecoinPayV1} from "@fws-payments/FilecoinPayV1.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {SYBIL_FEE} from "./PriceListUSDFC.sol";
+import {DEFAULT_LOCKUP_PERIOD, SYBIL_FEE} from "./PriceListUSDFC.sol";
 
 event CDNPaymentRailsToppedUp(
     uint256 indexed dataSetId,
@@ -17,8 +17,6 @@ event CDNPaymentRailsToppedUp(
 event CDNServiceTerminated(
     address indexed caller, uint256 indexed dataSetId, uint256 cacheMissRailId, uint256 cdnRailId
 );
-
-uint256 constant DEFAULT_LOCKUP_PERIOD = 2880 * 30; // 1 month (30 days) in epochs
 
 library Rails {
     function burnSybil(FilecoinPayV1 payments, IERC20 token, address payer) public {

--- a/service_contracts/src/lib/Rails.sol
+++ b/service_contracts/src/lib/Rails.sol
@@ -1,13 +1,24 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 pragma solidity ^0.8.20;
 
+import {Errors} from "../Errors.sol";
 import {FilecoinPayV1} from "@fws-payments/FilecoinPayV1.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SYBIL_FEE} from "./PriceListUSDFC.sol";
 
+event CDNPaymentRailsToppedUp(
+    uint256 indexed dataSetId,
+    uint256 cdnAmountAdded,
+    uint256 totalCdnLockup,
+    uint256 cacheMissAmountAdded,
+    uint256 totalCacheMissLockup
+);
+
 event CDNServiceTerminated(
     address indexed caller, uint256 indexed dataSetId, uint256 cacheMissRailId, uint256 cdnRailId
 );
+
+uint256 constant DEFAULT_LOCKUP_PERIOD = 2880 * 30; // 1 month (30 days) in epochs
 
 library Rails {
     function burnSybil(FilecoinPayV1 payments, IERC20 token, address payer) public {
@@ -31,5 +42,37 @@ library Rails {
         try payments.terminateRail(cacheMissRailId) {} catch {}
         try payments.terminateRail(cdnRailId) {} catch {}
         emit CDNServiceTerminated(msg.sender, dataSetId, cacheMissRailId, cdnRailId);
+    }
+
+    function topUpCDNRails(
+        FilecoinPayV1 payments,
+        uint256 dataSetId,
+        uint256 cacheMissRailId,
+        uint256 cdnRailId,
+        uint256 cacheMissAmountToAdd,
+        uint256 cdnAmountToAdd
+    ) public {
+        // Both rails must be active for any top-up operation
+        FilecoinPayV1.RailView memory cdnRail = payments.getRail(cdnRailId);
+        FilecoinPayV1.RailView memory cacheMissRail = payments.getRail(cacheMissRailId);
+
+        require(cdnRail.endEpoch == 0, Errors.CDNPaymentAlreadyTerminated(dataSetId));
+        require(cacheMissRail.endEpoch == 0, Errors.CacheMissPaymentAlreadyTerminated(dataSetId));
+
+        // Require at least one amount to be non-zero
+        if (cdnAmountToAdd == 0 && cacheMissAmountToAdd == 0) {
+            revert Errors.InvalidTopUpAmount(dataSetId);
+        }
+
+        // Calculate total lockup amounts
+        uint256 totalCdnLockup = cdnRail.lockupFixed + cdnAmountToAdd;
+        uint256 totalCacheMissLockup = cacheMissRail.lockupFixed + cacheMissAmountToAdd;
+
+        // Only modify rails if amounts are being added
+        payments.modifyRailLockup(cdnRailId, DEFAULT_LOCKUP_PERIOD, totalCdnLockup);
+        payments.modifyRailLockup(cacheMissRailId, DEFAULT_LOCKUP_PERIOD, totalCacheMissLockup);
+        emit CDNPaymentRailsToppedUp(
+            dataSetId, cdnAmountToAdd, totalCdnLockup, cacheMissAmountToAdd, totalCacheMissLockup
+        );
     }
 }

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -18,7 +18,7 @@ import {
 import {FilecoinWarmStorageServiceStateView} from "../src/FilecoinWarmStorageServiceStateView.sol";
 import {SignatureVerificationLib} from "../src/lib/SignatureVerificationLib.sol";
 import {FilecoinWarmStorageServiceStateLibrary} from "../src/lib/FilecoinWarmStorageServiceStateLibrary.sol";
-import {CDNServiceTerminated} from "../src/lib/Rails.sol";
+import {CDNServiceTerminated, CDNPaymentRailsToppedUp} from "../src/lib/Rails.sol";
 import {FilecoinPayV1, IValidator} from "@fws-payments/FilecoinPayV1.sol";
 import {MockERC20, MockPDPVerifier} from "./mocks/SharedMocks.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -564,7 +564,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
 
         // Expect CDNPaymentRailsToppedUp event when creating the data set with CDN enabled
         vm.expectEmit(true, false, false, true);
-        emit FilecoinWarmStorageService.CDNPaymentRailsToppedUp(
+        emit CDNPaymentRailsToppedUp(
             1, defaultCDNLockup, defaultCDNLockup, defaultCacheMissLockup, defaultCacheMissLockup
         );
 
@@ -3867,7 +3867,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
 
         // Expect CDNPaymentRailsToppedUp event when creating the data set with CDN enabled
         vm.expectEmit(true, false, false, true);
-        emit FilecoinWarmStorageService.CDNPaymentRailsToppedUp(
+        emit CDNPaymentRailsToppedUp(
             1, defaultCDNLockup, defaultCDNLockup, defaultCacheMissLockup, defaultCacheMissLockup
         );
 
@@ -3921,7 +3921,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         // Expect the CDNPaymentRailsToppedUp event with correct parameters
         // Event signature: CDNPaymentRailsToppedUp(uint256 indexed dataSetId, uint256 cdnAmountAdded, uint256 totalCdnLockup, uint256 cacheMissAmountAdded, uint256 totalCacheMissLockup)
         vm.expectEmit(true, false, false, true);
-        emit FilecoinWarmStorageService.CDNPaymentRailsToppedUp(
+        emit CDNPaymentRailsToppedUp(
             1, // dataSetId will be 1 (first dataset created)
             defaultCDNLockup, // CDN amount added (0.7 USDFC)
             defaultCDNLockup, // Total CDN lockup (0.7 USDFC)
@@ -4004,7 +4004,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
 
         // Top up the rails first to allow for settlement
         vm.expectEmit(true, false, false, true);
-        emit FilecoinWarmStorageService.CDNPaymentRailsToppedUp(
+        emit CDNPaymentRailsToppedUp(
             dataSetId,
             cdnAmount,
             defaultCDNLockup + cdnAmount,
@@ -4044,7 +4044,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
 
         // Top up only the CDN rail
         vm.expectEmit(true, false, false, true);
-        emit FilecoinWarmStorageService.CDNPaymentRailsToppedUp(
+        emit CDNPaymentRailsToppedUp(
             dataSetId,
             cdnAmount,
             defaultCDNLockup + cdnAmount,
@@ -4077,7 +4077,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
 
         // Top up only the cache miss rail
         vm.expectEmit(true, false, false, true);
-        emit FilecoinWarmStorageService.CDNPaymentRailsToppedUp(
+        emit CDNPaymentRailsToppedUp(
             dataSetId,
             cdnAmount,
             defaultCDNLockup + cdnAmount,
@@ -4162,7 +4162,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
 
         // Top up the rails first
         vm.expectEmit(true, false, false, true);
-        emit FilecoinWarmStorageService.CDNPaymentRailsToppedUp(
+        emit CDNPaymentRailsToppedUp(
             dataSetId,
             cdnAmount,
             defaultCDNLockup + cdnAmount,
@@ -4187,7 +4187,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
 
         // Top up the rails first
         vm.expectEmit(true, false, false, true);
-        emit FilecoinWarmStorageService.CDNPaymentRailsToppedUp(
+        emit CDNPaymentRailsToppedUp(
             dataSetId,
             cdnAmount,
             defaultCDNLockup + cdnAmount,
@@ -4244,7 +4244,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
 
         // Top up the rails first
         vm.expectEmit(true, false, false, true);
-        emit FilecoinWarmStorageService.CDNPaymentRailsToppedUp(
+        emit CDNPaymentRailsToppedUp(
             dataSetId,
             cdnAmount,
             defaultCDNLockup + cdnAmount,
@@ -4414,7 +4414,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
 
         // Top up the rails
         vm.expectEmit(true, false, false, true);
-        emit FilecoinWarmStorageService.CDNPaymentRailsToppedUp(
+        emit CDNPaymentRailsToppedUp(
             dataSetId, cdnTopUp, defaultCDNLockup + cdnTopUp, cacheMissTopUp, defaultCacheMissLockup + cacheMissTopUp
         );
         vm.prank(client);
@@ -4449,9 +4449,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
 
         // Should work as payer
         vm.expectEmit(true, false, false, true);
-        emit FilecoinWarmStorageService.CDNPaymentRailsToppedUp(
-            dataSetId, 1000, defaultCDNLockup + 1000, 1000, defaultCacheMissLockup + 1000
-        );
+        emit CDNPaymentRailsToppedUp(dataSetId, 1000, defaultCDNLockup + 1000, 1000, defaultCacheMissLockup + 1000);
         vm.prank(client);
         pdpServiceWithPayments.topUpCDNPaymentRails(dataSetId, 1000, 1000);
     }
@@ -4475,9 +4473,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
 
         // First top-up
         vm.expectEmit(true, false, false, true);
-        emit FilecoinWarmStorageService.CDNPaymentRailsToppedUp(
-            dataSetId, 1000, defaultCDNLockup + 1000, 500, defaultCacheMissLockup + 500
-        );
+        emit CDNPaymentRailsToppedUp(dataSetId, 1000, defaultCDNLockup + 1000, 500, defaultCacheMissLockup + 500);
         vm.prank(client);
         pdpServiceWithPayments.topUpCDNPaymentRails(dataSetId, 1000, 500);
 
@@ -4488,9 +4484,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
 
         // Second top-up (should be additive)
         vm.expectEmit(true, false, false, true);
-        emit FilecoinWarmStorageService.CDNPaymentRailsToppedUp(
-            dataSetId, 2000, defaultCDNLockup + 3000, 1500, defaultCacheMissLockup + 2000
-        );
+        emit CDNPaymentRailsToppedUp(dataSetId, 2000, defaultCDNLockup + 3000, 1500, defaultCacheMissLockup + 2000);
         vm.prank(client);
         pdpServiceWithPayments.topUpCDNPaymentRails(dataSetId, 2000, 1500);
 
@@ -4541,7 +4535,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         uint256 cacheMissTopUp = 50000;
 
         vm.expectEmit(true, false, false, true);
-        emit FilecoinWarmStorageService.CDNPaymentRailsToppedUp(
+        emit CDNPaymentRailsToppedUp(
             dataSetId, cdnTopUp, defaultCDNLockup + cdnTopUp, cacheMissTopUp, defaultCacheMissLockup + cacheMissTopUp
         );
         vm.prank(client);
@@ -4567,7 +4561,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         uint256 cacheMissTopUp = 50000;
 
         vm.expectEmit(true, false, false, true);
-        emit FilecoinWarmStorageService.CDNPaymentRailsToppedUp(
+        emit CDNPaymentRailsToppedUp(
             dataSetId, cdnTopUp, defaultCDNLockup + cdnTopUp, cacheMissTopUp, defaultCacheMissLockup + cacheMissTopUp
         );
         vm.prank(client);
@@ -4594,7 +4588,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         uint256 cacheMissTopUp = 50000;
 
         vm.expectEmit(true, false, false, true);
-        emit FilecoinWarmStorageService.CDNPaymentRailsToppedUp(
+        emit CDNPaymentRailsToppedUp(
             dataSetId, cdnTopUp, defaultCDNLockup + cdnTopUp, cacheMissTopUp, defaultCacheMissLockup + cacheMissTopUp
         );
         vm.prank(client);
@@ -4639,14 +4633,14 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
 
         // First top-up
         vm.expectEmit(true, false, false, true);
-        emit FilecoinWarmStorageService.CDNPaymentRailsToppedUp(
+        emit CDNPaymentRailsToppedUp(
             dataSetId, cdnTopUp, defaultCDNLockup + cdnTopUp, cacheMissTopUp, defaultCacheMissLockup + cacheMissTopUp
         );
         pdpServiceWithPayments.topUpCDNPaymentRails(dataSetId, cdnTopUp, cacheMissTopUp);
 
         // Second top-up
         vm.expectEmit(true, false, false, true);
-        emit FilecoinWarmStorageService.CDNPaymentRailsToppedUp(
+        emit CDNPaymentRailsToppedUp(
             dataSetId,
             cdnTopUp * 2,
             defaultCDNLockup + cdnTopUp * 3,
@@ -4657,14 +4651,14 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
 
         // Third top-up (only CDN)
         vm.expectEmit(true, false, false, true);
-        emit FilecoinWarmStorageService.CDNPaymentRailsToppedUp(
+        emit CDNPaymentRailsToppedUp(
             dataSetId, cdnTopUp, defaultCDNLockup + cdnTopUp * 4, 0, defaultCacheMissLockup + cacheMissTopUp * 3
         );
         pdpServiceWithPayments.topUpCDNPaymentRails(dataSetId, cdnTopUp, 0);
 
         // Fourth top-up (only cache miss)
         vm.expectEmit(true, false, false, true);
-        emit FilecoinWarmStorageService.CDNPaymentRailsToppedUp(
+        emit CDNPaymentRailsToppedUp(
             dataSetId, 0, defaultCDNLockup + cdnTopUp * 4, cacheMissTopUp, defaultCacheMissLockup + cacheMissTopUp * 4
         );
         pdpServiceWithPayments.topUpCDNPaymentRails(dataSetId, 0, cacheMissTopUp);

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -963,19 +963,19 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         uint256 expectedMinPerEpoch = expectedMinPerMonth / 86400; // Convert to per-epoch
 
         // Test 0 bytes
-        uint256 rateZero = pdpServiceWithPayments.calculateRatePerEpoch(0);
+        uint256 rateZero = viewContract.calculateRatePerEpoch(0);
         assertEq(rateZero, expectedMinPerEpoch, "0 bytes should return 0.06 USDFC/month minimum");
 
         // Test 1 GiB
-        uint256 rateOneGiB = pdpServiceWithPayments.calculateRatePerEpoch(oneGiB);
+        uint256 rateOneGiB = viewContract.calculateRatePerEpoch(oneGiB);
         assertEq(rateOneGiB, expectedMinPerEpoch, "1 GiB should return minimum rate");
 
         // Test 10 GiB
-        uint256 rateTenGiB = pdpServiceWithPayments.calculateRatePerEpoch(10 * oneGiB);
+        uint256 rateTenGiB = viewContract.calculateRatePerEpoch(10 * oneGiB);
         assertEq(rateTenGiB, expectedMinPerEpoch, "10 GiB should return minimum rate");
 
         // Test 24 GiB (below crossover)
-        uint256 rateTwentyFourGiB = pdpServiceWithPayments.calculateRatePerEpoch(24 * oneGiB);
+        uint256 rateTwentyFourGiB = viewContract.calculateRatePerEpoch(24 * oneGiB);
         assertEq(rateTwentyFourGiB, expectedMinPerEpoch, "24 GiB should return minimum rate");
     }
 
@@ -988,11 +988,11 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         uint256 expectedMinPerEpoch = expectedMinPerMonth / 86400;
 
         // 24 GiB: natural rate (0.0586) < minimum (0.06), so returns minimum
-        uint256 rate24GiB = pdpServiceWithPayments.calculateRatePerEpoch(24 * oneGiB);
+        uint256 rate24GiB = viewContract.calculateRatePerEpoch(24 * oneGiB);
         assertEq(rate24GiB, expectedMinPerEpoch, "24 GiB should use minimum floor");
 
         // 25 GiB: natural rate (0.0610) > minimum (0.06), so returns natural rate
-        uint256 rate25GiB = pdpServiceWithPayments.calculateRatePerEpoch(25 * oneGiB);
+        uint256 rate25GiB = viewContract.calculateRatePerEpoch(25 * oneGiB);
         assert(rate25GiB > expectedMinPerEpoch);
 
         // Verify it's actually proportional (not minimum)
@@ -1010,16 +1010,16 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         uint256 expectedMinPerEpoch = expectedMinPerMonth / 86400;
 
         // Test 48 GiB
-        uint256 rate48GiB = pdpServiceWithPayments.calculateRatePerEpoch(48 * oneGiB);
+        uint256 rate48GiB = viewContract.calculateRatePerEpoch(48 * oneGiB);
         assert(rate48GiB > expectedMinPerEpoch);
 
         // Test 100 GiB
-        uint256 rate100GiB = pdpServiceWithPayments.calculateRatePerEpoch(100 * oneGiB);
+        uint256 rate100GiB = viewContract.calculateRatePerEpoch(100 * oneGiB);
         assert(rate100GiB > rate48GiB);
 
         // Test 1 TiB
         uint256 oneTiB = oneGiB * 1024;
-        uint256 rateOneTiB = pdpServiceWithPayments.calculateRatePerEpoch(oneTiB);
+        uint256 rateOneTiB = viewContract.calculateRatePerEpoch(oneTiB);
         assert(rateOneTiB > rate100GiB);
 
         // Verify proportional scaling
@@ -1032,7 +1032,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         uint256 oneGiB = 1024 * 1024 * 1024;
 
         // Get rate per epoch for dataset below crossover point
-        uint256 ratePerEpoch = pdpServiceWithPayments.calculateRatePerEpoch(oneGiB);
+        uint256 ratePerEpoch = viewContract.calculateRatePerEpoch(oneGiB);
 
         // Convert to rate per month (86400 epochs per month)
         uint256 ratePerMonth = ratePerEpoch * 86400;
@@ -1320,8 +1320,8 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         );
 
         uint256 actualRate = payments.getRail(viewContract.getDataSet(dataSetId).pdpRailId).paymentRate;
-        uint256 expectedRate = pdpServiceWithPayments.calculateRatePerEpoch(Cids.leafCountToRawSize(leafCount));
-        uint256 buggyRate = pdpServiceWithPayments.calculateRatePerEpoch(leafCount * 32);
+        uint256 expectedRate = viewContract.calculateRatePerEpoch(Cids.leafCountToRawSize(leafCount));
+        uint256 buggyRate = viewContract.calculateRatePerEpoch(leafCount * 32);
 
         assertEq(actualRate, expectedRate, "rail rate should price on raw bytes");
         assertLt(actualRate, buggyRate, "raw-size rate must be lower than the Fr32-size rate");
@@ -1374,8 +1374,8 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         pdpServiceWithPayments.nextProvingPeriod(dataSetId, firstDeadline + provingPeriod, perPieceLeaves, "");
 
         uint256 actualRate = payments.getRail(viewContract.getDataSet(dataSetId).pdpRailId).paymentRate;
-        uint256 expectedRate = pdpServiceWithPayments.calculateRatePerEpoch(Cids.leafCountToRawSize(perPieceLeaves));
-        uint256 buggyRate = pdpServiceWithPayments.calculateRatePerEpoch(perPieceLeaves * 32);
+        uint256 expectedRate = viewContract.calculateRatePerEpoch(Cids.leafCountToRawSize(perPieceLeaves));
+        uint256 buggyRate = viewContract.calculateRatePerEpoch(perPieceLeaves * 32);
         assertEq(actualRate, expectedRate, "post-removal rate should price on raw bytes");
         assertApproxEqAbs(
             actualRate, (buggyRate * 127) / 128, 1, "post-removal ratio between raw and Fr32 rates is 127/128"

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -18,6 +18,7 @@ import {
 import {FilecoinWarmStorageServiceStateView} from "../src/FilecoinWarmStorageServiceStateView.sol";
 import {SignatureVerificationLib} from "../src/lib/SignatureVerificationLib.sol";
 import {FilecoinWarmStorageServiceStateLibrary} from "../src/lib/FilecoinWarmStorageServiceStateLibrary.sol";
+import {CDNServiceTerminated} from "../src/lib/Rails.sol";
 import {FilecoinPayV1, IValidator} from "@fws-payments/FilecoinPayV1.sol";
 import {MockERC20, MockPDPVerifier} from "./mocks/SharedMocks.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -2286,9 +2287,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
         vm.prank(viewContract.filBeamControllerAddress()); // FilBeam terminates
         vm.expectEmit(true, true, true, true);
-        emit FilecoinWarmStorageService.CDNServiceTerminated(
-            filBeamController, dataSetId, info.cacheMissRailId, info.cdnRailId
-        );
+        emit CDNServiceTerminated(filBeamController, dataSetId, info.cacheMissRailId, info.cdnRailId);
         pdpServiceWithPayments.terminateCDNService(dataSetId);
 
         // 5. Assertions
@@ -2398,9 +2397,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         console.log("Current block:", block.number);
         vm.prank(viewContract.filBeamControllerAddress()); // FilBeam terminates
         vm.expectEmit(true, true, true, true);
-        emit FilecoinWarmStorageService.CDNServiceTerminated(
-            filBeamController, dataSetId, info.cacheMissRailId, info.cdnRailId
-        );
+        emit CDNServiceTerminated(filBeamController, dataSetId, info.cacheMissRailId, info.cdnRailId);
         pdpServiceWithPayments.terminateCDNService(dataSetId);
 
         // 4. Start new proving period and submit new proof

--- a/service_contracts/tools/check_storage_layout.sh
+++ b/service_contracts/tools/check_storage_layout.sh
@@ -92,6 +92,20 @@ compare_layouts() {
         new_entry=$(jq -c --arg l "$label" '.[] | select(.label == $l)' "$new_file")
 
         if [ -z "$new_entry" ]; then
+            # Allow rename where only change is adding the "deprecated" prefix
+            local deprecated_label="deprecated${label^}"
+            local deprecated_entry
+            deprecated_entry=$(jq -c --arg l "$deprecated_label" '.[] | select(.label == $l)' "$new_file")
+            if [ -n "$deprecated_entry" ]; then
+                local dep_slot dep_offset dep_type
+                dep_slot=$(echo "$deprecated_entry" | jq -r '.slot')
+                dep_offset=$(echo "$deprecated_entry" | jq -r '.offset')
+                dep_type=$(echo "$deprecated_entry" | jq -r '.type')
+                if [ "$dep_slot" = "$slot" ] && [ "$dep_offset" = "$offset" ] && [ "$dep_type" = "$type" ]; then
+                    echo "  Renamed: '$label' → '$deprecated_label' (slot $slot, deprecated)"
+                    continue
+                fi
+            fi
             echo "  DESTRUCTIVE: Variable '$label' (slot $slot, offset $offset, type $type) was removed" >&2
             errors=$((errors + 1))
             continue
@@ -142,7 +156,29 @@ compare_layouts() {
         base_match=$(jq -c --arg l "$label" '.[] | select(.label == $l)' "$base_file")
 
         if [ -z "$base_match" ]; then
-            if [ "$slot" -le "$max_base_slot" ]; then
+            # Check if this is a permitted deprecated rename (already reported in Check 1)
+            local is_deprecated_rename=false
+            if [[ "$label" == deprecated* ]]; then
+                local original_label="${label#deprecated}"
+                original_label="${original_label,}"
+                local base_original
+                base_original=$(jq -c --arg l "$original_label" '.[] | select(.label == $l)' "$base_file")
+                if [ -n "$base_original" ]; then
+                    local orig_slot orig_offset orig_type entry_offset entry_type
+                    orig_slot=$(echo "$base_original" | jq -r '.slot')
+                    orig_offset=$(echo "$base_original" | jq -r '.offset')
+                    orig_type=$(echo "$base_original" | jq -r '.type')
+                    entry_offset=$(echo "$entry" | jq -r '.offset')
+                    entry_type=$(echo "$entry" | jq -r '.type')
+                    if [ "$orig_slot" = "$slot" ] && [ "$orig_offset" = "$entry_offset" ] && [ "$orig_type" = "$entry_type" ]; then
+                        is_deprecated_rename=true
+                    fi
+                fi
+            fi
+
+            if $is_deprecated_rename; then
+                : # already reported in Check 1
+            elif [ "$slot" -le "$max_base_slot" ]; then
                 echo "  DESTRUCTIVE: New variable '$label' inserted at slot $slot (must be > $max_base_slot)" >&2
                 errors=$((errors + 1))
             else

--- a/service_contracts/tools/generate_view_contract.sh
+++ b/service_contracts/tools/generate_view_contract.sh
@@ -43,7 +43,7 @@ jq -rM 'reduce .abi.[] as {$type,$name,$inputs,$outputs,$stateMutability} (
                     ]
                 end
             ) | join(", ") ) +
-        ") external " +  $stateMutability + " returns (" +
+        ") external " + (if $inputs.[0].type == "FilecoinWarmStorageService" and $stateMutability == "pure" then "view" else $stateMutability end) + " returns (" +
             ( reduce $outputs.[] as {$type,$name,$internalType} (
                 []; 
                 . += [

--- a/service_contracts/tools/warm-storage-deploy-all.sh
+++ b/service_contracts/tools/warm-storage-deploy-all.sh
@@ -202,7 +202,10 @@ deploy_implementation_if_needed() {
         local forge_cmd=(forge create --password "$PASSWORD" $BROADCAST_FLAG --nonce "$NONCE")
 
         if [ -n "$LIBRARIES" ]; then
-            forge_cmd+=(--libraries "$LIBRARIES")
+            IFS=',' read -ra lib_arr <<< "$LIBRARIES"
+            for lib in "${lib_arr[@]}"; do
+                forge_cmd+=(--libraries "$lib")
+            done
         fi
 
         forge_cmd+=("$contract")
@@ -461,14 +464,20 @@ deploy_implementation_if_needed \
     "src/lib/SignatureVerificationLib.sol:SignatureVerificationLib" \
     "SignatureVerificationLib"
 
-# Step 7: Deploy or use existing FilecoinWarmStorageService implementation
-# Set LIBRARIES variable for the deployment helper (format: path:name:address)
+# Step 7: Deploy or use existing Rails
+deploy_implementation_if_needed \
+    "RAILS_LIB_ADDRESS" \
+    "src/lib/Rails.sol:Rails" \
+    "Rails"
+
+# Step 8: Deploy or use existing FilecoinWarmStorageService implementation
+# Set LIBRARIES variable for the deployment helper (comma-separated path:name:address)
 if [ -n "$FWSS_PROXY_ADDRESS" ]; then
     FWSS_INIT_COUNTER=$(expr $($SCRIPT_DIR/get-initialized-counter.sh $FWSS_PROXY_ADDRESS) + "1")
 else
     FWSS_INIT_COUNTER=1
 fi
-LIBRARIES="src/lib/SignatureVerificationLib.sol:SignatureVerificationLib:$SIGNATURE_VERIFICATION_LIB_ADDRESS"
+LIBRARIES="src/lib/SignatureVerificationLib.sol:SignatureVerificationLib:$SIGNATURE_VERIFICATION_LIB_ADDRESS,src/lib/Rails.sol:Rails:$RAILS_LIB_ADDRESS"
 deploy_implementation_if_needed \
     "FWSS_IMPLEMENTATION_ADDRESS" \
     "src/FilecoinWarmStorageService.sol:FilecoinWarmStorageService" \
@@ -482,7 +491,7 @@ deploy_implementation_if_needed \
     "$FWSS_INIT_COUNTER"
 unset LIBRARIES
 
-# Step 8: Deploy or use existing FilecoinWarmStorageService proxy
+# Step 9: Deploy or use existing FilecoinWarmStorageService proxy
 # Initialize with max proving period, challenge window size, FilBeam controller address, name, and description
 INIT_DATA=$(cast calldata "initialize(uint64,uint256,address,string,string)" $MAX_PROVING_PERIOD $CHALLENGE_WINDOW_SIZE $FILBEAM_CONTROLLER_ADDRESS "$SERVICE_NAME" "$SERVICE_DESCRIPTION")
 deploy_proxy_if_needed \
@@ -491,7 +500,7 @@ deploy_proxy_if_needed \
     "$INIT_DATA" \
     "FilecoinWarmStorageService proxy"
 
-# Step 9: Deploy FilecoinWarmStorageServiceStateView
+# Step 10: Deploy FilecoinWarmStorageServiceStateView
 echo -e "${BOLD}FilecoinWarmStorageServiceStateView${RESET}"
 if [ "$DRY_RUN" = "true" ]; then
     echo "  🔍 Would deploy (skipping in dry-run)"
@@ -510,7 +519,7 @@ else
 fi
 echo
 
-# Step 10: Set the view contract address on the main contract
+# Step 11: Set the view contract address on the main contract
 echo -e "${BOLD}Setting view contract address${RESET}"
 if [ "$DRY_RUN" = "true" ]; then
     echo "  🔍 Would set view contract address on main contract (skipping in dry-run)"
@@ -522,7 +531,7 @@ else
 fi
 echo
 
-# Step 11: Deploy Endorsements ProviderIdSet
+# Step 12: Deploy Endorsements ProviderIdSet
 deploy_endorsements_if_needed
 
 if [ "$DRY_RUN" = "true" ]; then
@@ -545,6 +554,8 @@ echo "PDPVerifier Proxy: $PDP_VERIFIER_PROXY_ADDRESS"
 echo "FilecoinPayV1 Contract: $FILECOIN_PAY_ADDRESS"
 echo "ServiceProviderRegistry Implementation: $SERVICE_PROVIDER_REGISTRY_IMPLEMENTATION_ADDRESS"
 echo "ServiceProviderRegistry Proxy: $SERVICE_PROVIDER_REGISTRY_PROXY_ADDRESS"
+echo "SignatureVerificationLib: $SIGNATURE_VERIFICATION_LIB_ADDRESS"
+echo "Rails: $RAILS_LIB_ADDRESS"
 echo "FilecoinWarmStorageService Implementation: $FWSS_IMPLEMENTATION_ADDRESS"
 echo "FilecoinWarmStorageService Proxy: $FWSS_PROXY_ADDRESS"
 echo "FilecoinWarmStorageServiceStateView: $FWSS_VIEW_ADDRESS"
@@ -575,6 +586,8 @@ if [ "$DRY_RUN" = "false" ] && [ "${AUTO_VERIFY:-true}" = "true" ]; then
         "$FILECOIN_PAY_ADDRESS,lib/fws-payments/src/FilecoinPayV1.sol:FilecoinPayV1" \
         "$SERVICE_PROVIDER_REGISTRY_IMPLEMENTATION_ADDRESS,src/ServiceProviderRegistry.sol:ServiceProviderRegistry" \
         "$SERVICE_PROVIDER_REGISTRY_PROXY_ADDRESS,lib/openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol:ERC1967Proxy" \
+        "$SIGNATURE_VERIFICATION_LIB_ADDRESS,src/lib/SignatureVerificationLib.sol:SignatureVerificationLib" \
+        "$RAILS_LIB_ADDRESS,src/lib/Rails.sol:Rails" \
         "$FWSS_IMPLEMENTATION_ADDRESS,src/FilecoinWarmStorageService.sol:FilecoinWarmStorageService" \
         "$FWSS_PROXY_ADDRESS,lib/openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol:ERC1967Proxy" \
         "$FWSS_VIEW_ADDRESS,src/FilecoinWarmStorageServiceStateView.sol:FilecoinWarmStorageServiceStateView"

--- a/service_contracts/tools/warm-storage-deploy-implementation.sh
+++ b/service_contracts/tools/warm-storage-deploy-implementation.sh
@@ -108,10 +108,25 @@ if [ -z "$SIGNATURE_VERIFICATION_LIB_ADDRESS" ]; then
   fi
   echo "SignatureVerificationLib deployed at: $SIGNATURE_VERIFICATION_LIB_ADDRESS"
   SIGNATURE_LIB_DEPLOYED=true
-  # Increment nonce for the next deployment
   NONCE=$((NONCE + 1))
 else
   echo "Using SignatureVerificationLib at: $SIGNATURE_VERIFICATION_LIB_ADDRESS"
+fi
+
+RAILS_LIB_DEPLOYED=false
+if [ -z "$RAILS_LIB_ADDRESS" ]; then
+  echo "Deploying Rails..."
+  export RAILS_LIB_ADDRESS=$(forge create --password "$PASSWORD" --broadcast --nonce $NONCE src/lib/Rails.sol:Rails | grep "Deployed to" | awk '{print $3}')
+
+  if [ -z "$RAILS_LIB_ADDRESS" ]; then
+    echo "Error: Failed to deploy Rails"
+    exit 1
+  fi
+  echo "Rails deployed at: $RAILS_LIB_ADDRESS"
+  RAILS_LIB_DEPLOYED=true
+  NONCE=$((NONCE + 1))
+else
+  echo "Using Rails at: $RAILS_LIB_ADDRESS"
 fi
 
 echo ""
@@ -130,7 +145,11 @@ else
     FWSS_INIT_COUNTER=1
 fi
 
-FWSS_IMPLEMENTATION_ADDRESS=$(forge create --password "$PASSWORD" --broadcast --nonce $NONCE --libraries "src/lib/SignatureVerificationLib.sol:SignatureVerificationLib:$SIGNATURE_VERIFICATION_LIB_ADDRESS" src/FilecoinWarmStorageService.sol:FilecoinWarmStorageService --constructor-args $PDP_VERIFIER_PROXY_ADDRESS $FILECOIN_PAY_ADDRESS $USDFC_TOKEN_ADDRESS $FILBEAM_BENEFICIARY_ADDRESS $SERVICE_PROVIDER_REGISTRY_PROXY_ADDRESS $SESSION_KEY_REGISTRY_ADDRESS $FWSS_INIT_COUNTER | grep "Deployed to" | awk '{print $3}')
+FWSS_IMPLEMENTATION_ADDRESS=$(forge create --password "$PASSWORD" --broadcast --nonce $NONCE \
+  --libraries "src/lib/SignatureVerificationLib.sol:SignatureVerificationLib:$SIGNATURE_VERIFICATION_LIB_ADDRESS" \
+  --libraries "src/lib/Rails.sol:Rails:$RAILS_LIB_ADDRESS" \
+  src/FilecoinWarmStorageService.sol:FilecoinWarmStorageService \
+  --constructor-args $PDP_VERIFIER_PROXY_ADDRESS $FILECOIN_PAY_ADDRESS $USDFC_TOKEN_ADDRESS $FILBEAM_BENEFICIARY_ADDRESS $SERVICE_PROVIDER_REGISTRY_PROXY_ADDRESS $SESSION_KEY_REGISTRY_ADDRESS $FWSS_INIT_COUNTER | grep "Deployed to" | awk '{print $3}')
 
 if [ -z "$FWSS_IMPLEMENTATION_ADDRESS" ]; then
   echo "Error: Failed to deploy FilecoinWarmStorageService implementation"
@@ -140,6 +159,7 @@ fi
 echo ""
 echo "# DEPLOYMENT COMPLETE"
 echo "SignatureVerificationLib deployed at: $SIGNATURE_VERIFICATION_LIB_ADDRESS"
+echo "Rails deployed at: $RAILS_LIB_ADDRESS"
 echo "FilecoinWarmStorageService Implementation deployed at: $FWSS_IMPLEMENTATION_ADDRESS"
 echo ""
 
@@ -147,6 +167,9 @@ echo ""
 update_deployment_address "$CHAIN" "FWSS_IMPLEMENTATION_ADDRESS" "$FWSS_IMPLEMENTATION_ADDRESS"
 if [ "$SIGNATURE_LIB_DEPLOYED" = "true" ]; then
   update_deployment_address "$CHAIN" "SIGNATURE_VERIFICATION_LIB_ADDRESS" "$SIGNATURE_VERIFICATION_LIB_ADDRESS"
+fi
+if [ "$RAILS_LIB_DEPLOYED" = "true" ]; then
+  update_deployment_address "$CHAIN" "RAILS_LIB_ADDRESS" "$RAILS_LIB_ADDRESS"
 fi
 update_deployment_metadata "$CHAIN"
 
@@ -157,7 +180,10 @@ if [ "${AUTO_VERIFY:-true}" = "true" ]; then
 
   pushd "$(dirname $0)/.." >/dev/null
   source $SCRIPT_DIR/verify-contracts.sh
-  verify_contracts_batch "$FWSS_IMPLEMENTATION_ADDRESS,src/FilecoinWarmStorageService.sol:FilecoinWarmStorageService"
+  verify_contracts_batch \
+    "$SIGNATURE_VERIFICATION_LIB_ADDRESS,src/lib/SignatureVerificationLib.sol:SignatureVerificationLib" \
+    "$RAILS_LIB_ADDRESS,src/lib/Rails.sol:Rails" \
+    "$FWSS_IMPLEMENTATION_ADDRESS,src/FilecoinWarmStorageService.sol:FilecoinWarmStorageService"
   popd >/dev/null
 else
   echo


### PR DESCRIPTION

Reviewer @rvagg
Toward #469
I am cutting a PR here in order to help keep the code review digestible.
I think reviewing the changes commit-by-commit might also be helpful.
This reduces contract size from `23939` to `19857`
#### Changes
* move pricing constants and functions to lib/PriceListUSDFC.sol
* move rails logic to lib/Rails.sol 
* move `calculateRatePerEpoch` to the View contract, update gen to allow pure methods in the view contract.
* remove methods `updateServiceCommission` and `updatePricing`; these parameters will now be managed by the upgrade path
* update deployment scripts to deploy the rails lib