### PR TITLE
refactor!: rm calculateRatePerEpoch

### DIFF
--- a/service_contracts/abi/FilecoinWarmStorageServiceStateLibrary.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageServiceStateLibrary.abi.json
@@ -1,25 +1,6 @@
 [
   {
     "type": "function",
-    "name": "calculateRatePerEpoch",
-    "inputs": [
-      {
-        "name": "totalBytes",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "storageRate",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "pure"
-  },
-  {
-    "type": "function",
     "name": "clientDataSets",
     "inputs": [
       {

--- a/service_contracts/abi/FilecoinWarmStorageServiceStateView.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageServiceStateView.abi.json
@@ -12,25 +12,6 @@
   },
   {
     "type": "function",
-    "name": "calculateRatePerEpoch",
-    "inputs": [
-      {
-        "name": "totalBytes",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "storageRate",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "pure"
-  },
-  {
-    "type": "function",
     "name": "clientDataSets",
     "inputs": [
       {

--- a/service_contracts/src/FilecoinWarmStorageServiceStateView.sol
+++ b/service_contracts/src/FilecoinWarmStorageServiceStateView.sol
@@ -18,10 +18,6 @@ contract FilecoinWarmStorageServiceStateView is IPDPProvingSchedule {
         service = _service;
     }
 
-    function calculateRatePerEpoch(uint256 totalBytes) external pure returns (uint256 storageRate) {
-        return FilecoinWarmStorageServiceStateInternalLibrary.calculateRatePerEpoch(totalBytes);
-    }
-
     function clientDataSets(address payer) external view returns (uint256[] memory dataSetIds) {
         return service.clientDataSets(payer);
     }

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
@@ -11,7 +11,6 @@ import {
     CHALLENGES_PER_PROOF, NO_PROVING_DEADLINE, FilecoinWarmStorageService
 } from "../FilecoinWarmStorageService.sol";
 import {
-    calculateStorageSizeBasedRatePerEpoch,
     MINIMUM_STORAGE_RATE_PER_MONTH,
     SERVICE_COMMISSION_BPS,
     STORAGE_PRICE_PER_TIB_PER_MONTH
@@ -622,9 +621,5 @@ library FilecoinWarmStorageServiceStateInternalLibrary {
         returns (uint256 storagePrice, uint256 minimumRate)
     {
         return (STORAGE_PRICE_PER_TIB_PER_MONTH, MINIMUM_STORAGE_RATE_PER_MONTH);
-    }
-
-    function calculateRatePerEpoch(uint256 totalBytes) internal pure returns (uint256 storageRate) {
-        return calculateStorageSizeBasedRatePerEpoch(totalBytes);
     }
 }

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceStateLibrary.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceStateLibrary.sol
@@ -7,7 +7,6 @@ import {
     CHALLENGES_PER_PROOF, NO_PROVING_DEADLINE, FilecoinWarmStorageService
 } from "../FilecoinWarmStorageService.sol";
 import {
-    calculateStorageSizeBasedRatePerEpoch,
     MINIMUM_STORAGE_RATE_PER_MONTH,
     SERVICE_COMMISSION_BPS,
     STORAGE_PRICE_PER_TIB_PER_MONTH
@@ -614,9 +613,5 @@ library FilecoinWarmStorageServiceStateLibrary {
         returns (uint256 storagePrice, uint256 minimumRate)
     {
         return (STORAGE_PRICE_PER_TIB_PER_MONTH, MINIMUM_STORAGE_RATE_PER_MONTH);
-    }
-
-    function calculateRatePerEpoch(uint256 totalBytes) public pure returns (uint256 storageRate) {
-        return calculateStorageSizeBasedRatePerEpoch(totalBytes);
     }
 }

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -24,6 +24,7 @@ import {MockERC20, MockPDPVerifier} from "./mocks/SharedMocks.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {Errors} from "../src/Errors.sol";
 import {Errors as PayErrors} from "@fws-payments/Errors.sol";
+import {calculateStorageSizeBasedRatePerEpoch} from "../src/lib/PriceListUSDFC.sol";
 
 import {PDPOffering} from "./PDPOffering.sol";
 import {ServiceProviderRegistryStorage} from "../src/ServiceProviderRegistryStorage.sol";
@@ -953,7 +954,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
     }
 
     // Minimum Pricing Tests
-    function testMinimumPricing_SmallDataSetsPayFloorRate() public view {
+    function testMinimumPricing_SmallDataSetsPayFloorRate() public pure {
         // Small datasets should all pay the minimum floor rate of 0.06 USDFC/month
         uint256 decimals = 18;
         uint256 oneGiB = 1024 * 1024 * 1024;
@@ -963,23 +964,23 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         uint256 expectedMinPerEpoch = expectedMinPerMonth / 86400; // Convert to per-epoch
 
         // Test 0 bytes
-        uint256 rateZero = viewContract.calculateRatePerEpoch(0);
+        uint256 rateZero = calculateStorageSizeBasedRatePerEpoch(0);
         assertEq(rateZero, expectedMinPerEpoch, "0 bytes should return 0.06 USDFC/month minimum");
 
         // Test 1 GiB
-        uint256 rateOneGiB = viewContract.calculateRatePerEpoch(oneGiB);
+        uint256 rateOneGiB = calculateStorageSizeBasedRatePerEpoch(oneGiB);
         assertEq(rateOneGiB, expectedMinPerEpoch, "1 GiB should return minimum rate");
 
         // Test 10 GiB
-        uint256 rateTenGiB = viewContract.calculateRatePerEpoch(10 * oneGiB);
+        uint256 rateTenGiB = calculateStorageSizeBasedRatePerEpoch(10 * oneGiB);
         assertEq(rateTenGiB, expectedMinPerEpoch, "10 GiB should return minimum rate");
 
         // Test 24 GiB (below crossover)
-        uint256 rateTwentyFourGiB = viewContract.calculateRatePerEpoch(24 * oneGiB);
+        uint256 rateTwentyFourGiB = calculateStorageSizeBasedRatePerEpoch(24 * oneGiB);
         assertEq(rateTwentyFourGiB, expectedMinPerEpoch, "24 GiB should return minimum rate");
     }
 
-    function testMinimumPricing_CrossoverPoint() public view {
+    function testMinimumPricing_CrossoverPoint() public pure {
         // Test the crossover where natural pricing exceeds minimum
         // At 2.5 USDFC/TiB: 0.06/2.5*1024 = 24.576 GiB is the crossover
         uint256 oneGiB = 1024 * 1024 * 1024;
@@ -988,11 +989,11 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         uint256 expectedMinPerEpoch = expectedMinPerMonth / 86400;
 
         // 24 GiB: natural rate (0.0586) < minimum (0.06), so returns minimum
-        uint256 rate24GiB = viewContract.calculateRatePerEpoch(24 * oneGiB);
+        uint256 rate24GiB = calculateStorageSizeBasedRatePerEpoch(24 * oneGiB);
         assertEq(rate24GiB, expectedMinPerEpoch, "24 GiB should use minimum floor");
 
         // 25 GiB: natural rate (0.0610) > minimum (0.06), so returns natural rate
-        uint256 rate25GiB = viewContract.calculateRatePerEpoch(25 * oneGiB);
+        uint256 rate25GiB = calculateStorageSizeBasedRatePerEpoch(25 * oneGiB);
         assert(rate25GiB > expectedMinPerEpoch);
 
         // Verify it's actually proportional (not minimum)
@@ -1002,7 +1003,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         assertApproxEqAbs(expectedNatural25, expected25Monthly, 100000, "25 GiB should use natural rate");
     }
 
-    function testMinimumPricing_LargeDataSetsUseProportionalPricing() public view {
+    function testMinimumPricing_LargeDataSetsUseProportionalPricing() public pure {
         // Large datasets should use proportional pricing (natural rate > minimum)
         uint256 oneGiB = 1024 * 1024 * 1024;
         uint256 decimals = 18;
@@ -1010,29 +1011,29 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         uint256 expectedMinPerEpoch = expectedMinPerMonth / 86400;
 
         // Test 48 GiB
-        uint256 rate48GiB = viewContract.calculateRatePerEpoch(48 * oneGiB);
+        uint256 rate48GiB = calculateStorageSizeBasedRatePerEpoch(48 * oneGiB);
         assert(rate48GiB > expectedMinPerEpoch);
 
         // Test 100 GiB
-        uint256 rate100GiB = viewContract.calculateRatePerEpoch(100 * oneGiB);
+        uint256 rate100GiB = calculateStorageSizeBasedRatePerEpoch(100 * oneGiB);
         assert(rate100GiB > rate48GiB);
 
         // Test 1 TiB
         uint256 oneTiB = oneGiB * 1024;
-        uint256 rateOneTiB = viewContract.calculateRatePerEpoch(oneTiB);
+        uint256 rateOneTiB = calculateStorageSizeBasedRatePerEpoch(oneTiB);
         assert(rateOneTiB > rate100GiB);
 
         // Verify proportional scaling
         assertApproxEqRel(rate100GiB, rate48GiB * 100 / 48, 0.01e18, "Rates should scale proportionally");
     }
 
-    function testMinimumPricing_ExactlyPoint06USDFC() public view {
+    function testMinimumPricing_ExactlyPoint06USDFC() public pure {
         // Verify that minimum pricing is exactly 0.06 USDFC/month for small datasets
         uint256 decimals = 18; // MockUSDFC uses 18 decimals in tests
         uint256 oneGiB = 1024 * 1024 * 1024;
 
         // Get rate per epoch for dataset below crossover point
-        uint256 ratePerEpoch = viewContract.calculateRatePerEpoch(oneGiB);
+        uint256 ratePerEpoch = calculateStorageSizeBasedRatePerEpoch(oneGiB);
 
         // Convert to rate per month (86400 epochs per month)
         uint256 ratePerMonth = ratePerEpoch * 86400;
@@ -1320,8 +1321,8 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         );
 
         uint256 actualRate = payments.getRail(viewContract.getDataSet(dataSetId).pdpRailId).paymentRate;
-        uint256 expectedRate = viewContract.calculateRatePerEpoch(Cids.leafCountToRawSize(leafCount));
-        uint256 buggyRate = viewContract.calculateRatePerEpoch(leafCount * 32);
+        uint256 expectedRate = calculateStorageSizeBasedRatePerEpoch(Cids.leafCountToRawSize(leafCount));
+        uint256 buggyRate = calculateStorageSizeBasedRatePerEpoch(leafCount * 32);
 
         assertEq(actualRate, expectedRate, "rail rate should price on raw bytes");
         assertLt(actualRate, buggyRate, "raw-size rate must be lower than the Fr32-size rate");
@@ -1374,8 +1375,8 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         pdpServiceWithPayments.nextProvingPeriod(dataSetId, firstDeadline + provingPeriod, perPieceLeaves, "");
 
         uint256 actualRate = payments.getRail(viewContract.getDataSet(dataSetId).pdpRailId).paymentRate;
-        uint256 expectedRate = viewContract.calculateRatePerEpoch(Cids.leafCountToRawSize(perPieceLeaves));
-        uint256 buggyRate = viewContract.calculateRatePerEpoch(perPieceLeaves * 32);
+        uint256 expectedRate = calculateStorageSizeBasedRatePerEpoch(Cids.leafCountToRawSize(perPieceLeaves));
+        uint256 buggyRate = calculateStorageSizeBasedRatePerEpoch(perPieceLeaves * 32);
         assertEq(actualRate, expectedRate, "post-removal rate should price on raw bytes");
         assertApproxEqAbs(
             actualRate, (buggyRate * 127) / 128, 1, "post-removal ratio between raw and Fr32 rates is 127/128"


### PR DESCRIPTION

Reviewer @rvagg
#### [Context](https://github.com/FilOzone/filecoin-services/pull/476#issuecomment-4449640815)
This method was moved from the main contract to the view contract because the logic it uses was factored out into the Rails library. 
This change goes further and also removes it from the view contract.
#### Changes
* rm `calculateRatePerEpoch`
* change tests to use `calculateStorageSizeBasedRatePerEpoch`