### PR TITLE
feat: termination extra data param

### DIFF
--- a/service_contracts/abi/FilecoinWarmStorageService.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageService.abi.json
@@ -1240,16 +1240,16 @@
     "name": "ServiceTerminated",
     "inputs": [
       {
+        "name": "approver",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
         "name": "dataSetId",
         "type": "uint256",
         "indexed": true,
         "internalType": "uint256"
-      },
-      {
-        "name": "signer",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
       },
       {
         "name": "pdpRailId",

--- a/service_contracts/abi/FilecoinWarmStorageService.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageService.abi.json
@@ -732,6 +732,24 @@
   },
   {
     "type": "function",
+    "name": "terminateService",
+    "inputs": [
+      {
+        "name": "dataSetId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "topUpCDNPaymentRails",
     "inputs": [
       {

--- a/service_contracts/abi/FilecoinWarmStorageService.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageService.abi.json
@@ -1240,16 +1240,16 @@
     "name": "ServiceTerminated",
     "inputs": [
       {
-        "name": "approver",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
         "name": "dataSetId",
         "type": "uint256",
         "indexed": true,
         "internalType": "uint256"
+      },
+      {
+        "name": "signer",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
       },
       {
         "name": "pdpRailId",

--- a/service_contracts/abi/FilecoinWarmStorageService.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageService.abi.json
@@ -740,7 +740,7 @@
         "internalType": "uint256"
       },
       {
-        "name": "",
+        "name": "extraData",
         "type": "bytes",
         "internalType": "bytes"
       }
@@ -1240,7 +1240,7 @@
     "name": "ServiceTerminated",
     "inputs": [
       {
-        "name": "caller",
+        "name": "approver",
         "type": "address",
         "indexed": true,
         "internalType": "address"

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -103,6 +103,13 @@ contract FilecoinWarmStorageService is
         uint256 indexed dataSetId, uint256 indexed pieceId, Cids.Cid pieceCid, string[] keys, string[] values
     );
 
+    /// @notice Emitted when a service is terminated.
+    /// @param approver The address that authorized termination: the payer, one of the payer's
+    ///   session keys (SessionKeyRegistry), or the service provider. Cross-reference with
+    ///   `DataSetCreated` to classify: `approver == serviceProvider` is provider-initiated;
+    ///   otherwise the payer (or their session key) authorized it. Mutual termination — payer
+    ///   signed off-chain while the provider submitted the tx — is indistinguishable from
+    ///   payer-initiated using this event alone; inspect the call trace to detect it.
     event ServiceTerminated(
         address indexed approver,
         uint256 indexed dataSetId,

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -53,6 +53,12 @@ uint256 constant MAX_ADD_PIECES_EXTRA_DATA_SIZE = 8192; // 8 KiB
 */
 uint256 constant MAX_SCHEDULE_PIECE_REMOVALS_EXTRA_DATA_SIZE = 256; // 256 bytes
 
+/*
+* Maximum extraData for terminateService
+* Supports: signature (160 bytes needed)
+*/
+uint256 constant MAX_TERMINATE_SERVICE_EXTRA_DATA_SIZE = 256; // 256 bytes
+
 /// @title FilecoinWarmStorageService
 /// @notice An implementation of PDP Listener with payment integration.
 /// @dev This contract extends SimplePDPService by adding payment functionality
@@ -98,7 +104,11 @@ contract FilecoinWarmStorageService is
     );
 
     event ServiceTerminated(
-        address indexed caller, uint256 indexed dataSetId, uint256 pdpRailId, uint256 cacheMissRailId, uint256 cdnRailId
+        address indexed approver,
+        uint256 indexed dataSetId,
+        uint256 pdpRailId,
+        uint256 cacheMissRailId,
+        uint256 cdnRailId
     );
 
     event PDPPaymentTerminated(uint256 indexed dataSetId, uint256 endEpoch, uint256 pdpRailId);
@@ -925,33 +935,46 @@ contract FilecoinWarmStorageService is
         revert Errors.StorageProviderChangesNotSupported();
     }
 
-    function terminateService(uint256 dataSetId, bytes memory /*extraData*/ ) external {
-        terminateService(dataSetId);
+    function terminateService(uint256 dataSetId, bytes calldata extraData) external {
+        _terminateService(dataSetId, extraData);
     }
 
     /// @custom:deprecated Use terminateService(uint256,bytes) instead
     function terminateService(uint256 dataSetId) public {
+        _terminateService(dataSetId, "");
+    }
+
+    function _terminateService(uint256 dataSetId, bytes memory extraData) private {
         DataSetInfo storage info = dataSetInfo[dataSetId];
         require(info.pdpRailId != 0, Errors.InvalidDataSetId(dataSetId));
-
-        // Check if already terminated
         require(info.pdpEndEpoch == 0, Errors.DataSetPaymentAlreadyTerminated(dataSetId));
 
-        // Check authorization
-        require(
-            msg.sender == info.payer || msg.sender == info.serviceProvider,
-            Errors.CallerNotPayerOrPayee(dataSetId, info.payer, info.serviceProvider, msg.sender)
-        );
+        address approver;
+        if (extraData.length > 0) {
+            require(
+                extraData.length <= MAX_TERMINATE_SERVICE_EXTRA_DATA_SIZE,
+                Errors.ExtraDataTooLarge(extraData.length, MAX_TERMINATE_SERVICE_EXTRA_DATA_SIZE)
+            );
+            bytes memory signature = abi.decode(extraData, (bytes));
+            _verifyTerminateServiceSignature(info.payer, dataSetId, signature);
+            approver = info.payer;
+            // TODO if msg.sender is info.serviceProvider, termination is immediate
+        } else {
+            require(
+                msg.sender == info.payer || msg.sender == info.serviceProvider,
+                Errors.CallerNotPayerOrPayee(dataSetId, info.payer, info.serviceProvider, msg.sender)
+            );
+            approver = msg.sender;
+        }
 
         FilecoinPayV1 payments = FilecoinPayV1(paymentsContractAddress);
-
         payments.terminateRail(info.pdpRailId);
 
         if (deleteCDNMetadataKey(dataSetMetadataKeys[dataSetId])) {
             _terminateCDNRails(dataSetId, info, payments);
         }
 
-        emit ServiceTerminated(msg.sender, dataSetId, info.pdpRailId, info.cacheMissRailId, info.cdnRailId);
+        emit ServiceTerminated(approver, dataSetId, info.pdpRailId, info.cacheMissRailId, info.cdnRailId);
     }
 
     /**
@@ -1319,6 +1342,12 @@ contract FilecoinWarmStorageService is
 
         // Delegate to library for verification
         SignatureVerificationLib.verifySchedulePieceRemovalsSignature(payer, signature, digest, sessionKeyRegistry);
+    }
+
+    function _verifyTerminateServiceSignature(address payer, uint256 dataSetId, bytes memory signature) internal view {
+        bytes32 structHash = keccak256(abi.encode(SignatureVerificationLib.TERMINATE_SERVICE_TYPEHASH, dataSetId));
+        bytes32 digest = _hashTypedDataV4(structHash);
+        SignatureVerificationLib.verifyTerminateServiceSignature(payer, signature, digest, sessionKeyRegistry);
     }
 
     /**

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -929,6 +929,7 @@ contract FilecoinWarmStorageService is
         terminateService(dataSetId);
     }
 
+    /// @custom:deprecated Use terminateService(uint256,bytes) instead
     function terminateService(uint256 dataSetId) public {
         DataSetInfo storage info = dataSetInfo[dataSetId];
         require(info.pdpRailId != 0, Errors.InvalidDataSetId(dataSetId));

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -925,7 +925,11 @@ contract FilecoinWarmStorageService is
         revert Errors.StorageProviderChangesNotSupported();
     }
 
-    function terminateService(uint256 dataSetId) external {
+    function terminateService(uint256 dataSetId, bytes memory /*extraData*/ ) external {
+        terminateService(dataSetId);
+    }
+
+    function terminateService(uint256 dataSetId) public {
         DataSetInfo storage info = dataSetInfo[dataSetId];
         require(info.pdpRailId != 0, Errors.InvalidDataSetId(dataSetId));
 

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -104,11 +104,7 @@ contract FilecoinWarmStorageService is
     );
 
     event ServiceTerminated(
-        address indexed approver,
-        uint256 indexed dataSetId,
-        uint256 pdpRailId,
-        uint256 cacheMissRailId,
-        uint256 cdnRailId
+        uint256 indexed dataSetId, address signer, uint256 pdpRailId, uint256 cacheMissRailId, uint256 cdnRailId
     );
 
     event PDPPaymentTerminated(uint256 indexed dataSetId, uint256 endEpoch, uint256 pdpRailId);
@@ -949,22 +945,21 @@ contract FilecoinWarmStorageService is
         require(info.pdpRailId != 0, Errors.InvalidDataSetId(dataSetId));
         require(info.pdpEndEpoch == 0, Errors.DataSetPaymentAlreadyTerminated(dataSetId));
 
-        address approver;
+        address signer;
         if (extraData.length > 0) {
             require(
                 extraData.length <= MAX_TERMINATE_SERVICE_EXTRA_DATA_SIZE,
                 Errors.ExtraDataTooLarge(extraData.length, MAX_TERMINATE_SERVICE_EXTRA_DATA_SIZE)
             );
             bytes memory signature = abi.decode(extraData, (bytes));
-            _verifyTerminateServiceSignature(info.payer, dataSetId, signature);
-            approver = info.payer;
+            signer = _verifyTerminateServiceSignature(info.payer, dataSetId, signature);
             // TODO if msg.sender is info.serviceProvider, termination is immediate
         } else {
             require(
                 msg.sender == info.payer || msg.sender == info.serviceProvider,
                 Errors.CallerNotPayerOrPayee(dataSetId, info.payer, info.serviceProvider, msg.sender)
             );
-            approver = msg.sender;
+            signer = address(0);
         }
 
         FilecoinPayV1 payments = FilecoinPayV1(paymentsContractAddress);
@@ -974,7 +969,7 @@ contract FilecoinWarmStorageService is
             _terminateCDNRails(dataSetId, info, payments);
         }
 
-        emit ServiceTerminated(approver, dataSetId, info.pdpRailId, info.cacheMissRailId, info.cdnRailId);
+        emit ServiceTerminated(dataSetId, signer, info.pdpRailId, info.cacheMissRailId, info.cdnRailId);
     }
 
     /**
@@ -1344,10 +1339,14 @@ contract FilecoinWarmStorageService is
         SignatureVerificationLib.verifySchedulePieceRemovalsSignature(payer, signature, digest, sessionKeyRegistry);
     }
 
-    function _verifyTerminateServiceSignature(address payer, uint256 dataSetId, bytes memory signature) internal view {
+    function _verifyTerminateServiceSignature(address payer, uint256 dataSetId, bytes memory signature)
+        internal
+        view
+        returns (address signer)
+    {
         bytes32 structHash = keccak256(abi.encode(SignatureVerificationLib.TERMINATE_SERVICE_TYPEHASH, dataSetId));
         bytes32 digest = _hashTypedDataV4(structHash);
-        SignatureVerificationLib.verifyTerminateServiceSignature(payer, signature, digest, sessionKeyRegistry);
+        return SignatureVerificationLib.verifyTerminateServiceSignature(payer, signature, digest, sessionKeyRegistry);
     }
 
     /**

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -104,7 +104,11 @@ contract FilecoinWarmStorageService is
     );
 
     event ServiceTerminated(
-        uint256 indexed dataSetId, address signer, uint256 pdpRailId, uint256 cacheMissRailId, uint256 cdnRailId
+        address indexed approver,
+        uint256 indexed dataSetId,
+        uint256 pdpRailId,
+        uint256 cacheMissRailId,
+        uint256 cdnRailId
     );
 
     event PDPPaymentTerminated(uint256 indexed dataSetId, uint256 endEpoch, uint256 pdpRailId);
@@ -945,21 +949,21 @@ contract FilecoinWarmStorageService is
         require(info.pdpRailId != 0, Errors.InvalidDataSetId(dataSetId));
         require(info.pdpEndEpoch == 0, Errors.DataSetPaymentAlreadyTerminated(dataSetId));
 
-        address signer;
+        address approver;
         if (extraData.length > 0) {
             require(
                 extraData.length <= MAX_TERMINATE_SERVICE_EXTRA_DATA_SIZE,
                 Errors.ExtraDataTooLarge(extraData.length, MAX_TERMINATE_SERVICE_EXTRA_DATA_SIZE)
             );
             bytes memory signature = abi.decode(extraData, (bytes));
-            signer = _verifyTerminateServiceSignature(info.payer, dataSetId, signature);
+            approver = _verifyTerminateServiceSignature(info.payer, dataSetId, signature);
             // TODO if msg.sender is info.serviceProvider, termination is immediate
         } else {
             require(
                 msg.sender == info.payer || msg.sender == info.serviceProvider,
                 Errors.CallerNotPayerOrPayee(dataSetId, info.payer, info.serviceProvider, msg.sender)
             );
-            signer = address(0);
+            approver = msg.sender;
         }
 
         FilecoinPayV1 payments = FilecoinPayV1(paymentsContractAddress);
@@ -969,7 +973,7 @@ contract FilecoinWarmStorageService is
             _terminateCDNRails(dataSetId, info, payments);
         }
 
-        emit ServiceTerminated(dataSetId, signer, info.pdpRailId, info.cacheMissRailId, info.cdnRailId);
+        emit ServiceTerminated(approver, dataSetId, info.pdpRailId, info.cacheMissRailId, info.cdnRailId);
     }
 
     /**

--- a/service_contracts/src/lib/SignatureVerificationLib.sol
+++ b/service_contracts/src/lib/SignatureVerificationLib.sol
@@ -279,16 +279,15 @@ library SignatureVerificationLib {
         bytes calldata signature,
         bytes32 digest,
         SessionKeyRegistry sessionKeyRegistry
-    ) public view {
-        address recoveredSigner = recoverSigner(digest, signature);
+    ) public view returns (address recoveredSigner) {
+        recoveredSigner = recoverSigner(digest, signature);
 
-        if (payer == recoveredSigner) {
-            return;
+        if (payer != recoveredSigner) {
+            require(
+                sessionKeyRegistry.authorizationExpiry(payer, recoveredSigner, TERMINATE_SERVICE_TYPEHASH)
+                    >= block.timestamp,
+                Errors.InvalidSignature(payer, recoveredSigner)
+            );
         }
-        require(
-            sessionKeyRegistry.authorizationExpiry(payer, recoveredSigner, TERMINATE_SERVICE_TYPEHASH)
-                >= block.timestamp,
-            Errors.InvalidSignature(payer, recoveredSigner)
-        );
     }
 }

--- a/service_contracts/src/lib/SignatureVerificationLib.sol
+++ b/service_contracts/src/lib/SignatureVerificationLib.sol
@@ -34,6 +34,8 @@ library SignatureVerificationLib {
     bytes32 internal constant SCHEDULE_PIECE_REMOVALS_TYPEHASH =
         keccak256("SchedulePieceRemovals(uint256 clientDataSetId,uint256[] pieceIds)");
 
+    bytes32 internal constant TERMINATE_SERVICE_TYPEHASH = keccak256("TerminateService(uint256 dataSetId)");
+
     // ============================================================================
     // Metadata Hashing Functions
     // ============================================================================
@@ -259,6 +261,32 @@ library SignatureVerificationLib {
         }
         require(
             sessionKeyRegistry.authorizationExpiry(payer, recoveredSigner, SCHEDULE_PIECE_REMOVALS_TYPEHASH)
+                >= block.timestamp,
+            Errors.InvalidSignature(payer, recoveredSigner)
+        );
+    }
+
+    /**
+     * @notice Verifies a signature for the TerminateService operation
+     * @dev The digest parameter already contains the EIP-712 wrapped struct hash computed by the caller
+     * @param payer The address of the payer who should have signed the message
+     * @param signature The signature bytes (v, r, s)
+     * @param digest The EIP-712 digest to verify
+     * @param sessionKeyRegistry The session key registry contract
+     */
+    function verifyTerminateServiceSignature(
+        address payer,
+        bytes calldata signature,
+        bytes32 digest,
+        SessionKeyRegistry sessionKeyRegistry
+    ) public view {
+        address recoveredSigner = recoverSigner(digest, signature);
+
+        if (payer == recoveredSigner) {
+            return;
+        }
+        require(
+            sessionKeyRegistry.authorizationExpiry(payer, recoveredSigner, TERMINATE_SERVICE_TYPEHASH)
                 >= block.timestamp,
             Errors.InvalidSignature(payer, recoveredSigner)
         );

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -2569,8 +2569,8 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         bytes memory sig = abi.encode(FAKE_SIGNATURE);
         makeSignaturePass(client);
 
-        vm.expectEmit(true, true, false, true);
-        emit FilecoinWarmStorageService.ServiceTerminated(client, dataSetId, info.pdpRailId, 0, 0);
+        vm.expectEmit(true, false, false, true);
+        emit FilecoinWarmStorageService.ServiceTerminated(dataSetId, client, info.pdpRailId, 0, 0);
         vm.prank(serviceProvider);
         pdpServiceWithPayments.terminateService(dataSetId, sig);
 
@@ -2582,8 +2582,8 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         uint256 dataSetId = createDataSetForClient(serviceProvider, client, keys, values);
         FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
 
-        vm.expectEmit(true, true, false, true);
-        emit FilecoinWarmStorageService.ServiceTerminated(client, dataSetId, info.pdpRailId, 0, 0);
+        vm.expectEmit(true, false, false, true);
+        emit FilecoinWarmStorageService.ServiceTerminated(dataSetId, address(0), info.pdpRailId, 0, 0);
         vm.prank(client);
         pdpServiceWithPayments.terminateService(dataSetId);
     }
@@ -2593,8 +2593,8 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         uint256 dataSetId = createDataSetForClient(serviceProvider, client, keys, values);
         FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
 
-        vm.expectEmit(true, true, false, true);
-        emit FilecoinWarmStorageService.ServiceTerminated(serviceProvider, dataSetId, info.pdpRailId, 0, 0);
+        vm.expectEmit(true, false, false, true);
+        emit FilecoinWarmStorageService.ServiceTerminated(dataSetId, address(0), info.pdpRailId, 0, 0);
         vm.prank(serviceProvider);
         pdpServiceWithPayments.terminateService(dataSetId);
     }
@@ -2612,9 +2612,9 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         bytes memory sig = abi.encode(FAKE_SIGNATURE);
         makeSignaturePass(sessionKey1);
 
-        // approver in event is the payer (client), not the session key or SP caller
-        vm.expectEmit(true, true, false, true);
-        emit FilecoinWarmStorageService.ServiceTerminated(client, dataSetId, info.pdpRailId, 0, 0);
+        // signer in event is the session key, not the payer
+        vm.expectEmit(true, false, false, true);
+        emit FilecoinWarmStorageService.ServiceTerminated(dataSetId, sessionKey1, info.pdpRailId, 0, 0);
         vm.prank(serviceProvider);
         pdpServiceWithPayments.terminateService(dataSetId, sig);
 

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -96,6 +96,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
     );
     bytes32 private constant SCHEDULE_PIECE_REMOVALS_TYPEHASH =
         keccak256("SchedulePieceRemovals(uint256 clientDataSetId,uint256[] pieceIds)");
+    bytes32 private constant TERMINATE_SERVICE_TYPEHASH = keccak256("TerminateService(uint256 dataSetId)");
 
     // Expected lockup amounts for CDN rails
     uint256 defaultCDNLockup;
@@ -2554,6 +2555,116 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         assertFalse(exists, "withCDN flag should be deleted");
 
         console.log("=== Test completed successfully! ===");
+    }
+
+    // ============================================================
+    // terminateService extraData / session-key tests
+    // ============================================================
+
+    function testTerminateService_signatureApprover() public {
+        (string[] memory keys, string[] memory values) = _getSingleMetadataKV("label", "sig test");
+        uint256 dataSetId = createDataSetForClient(serviceProvider, client, keys, values);
+        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
+
+        bytes memory sig = abi.encode(FAKE_SIGNATURE);
+        makeSignaturePass(client);
+
+        vm.expectEmit(true, true, false, true);
+        emit FilecoinWarmStorageService.ServiceTerminated(client, dataSetId, info.pdpRailId, 0, 0);
+        vm.prank(serviceProvider);
+        pdpServiceWithPayments.terminateService(dataSetId, sig);
+
+        assertTrue(viewContract.getDataSet(dataSetId).pdpEndEpoch > 0, "dataset should be terminated");
+    }
+
+    function testTerminateService_directPayer_emitsApprover() public {
+        (string[] memory keys, string[] memory values) = _getSingleMetadataKV("label", "test");
+        uint256 dataSetId = createDataSetForClient(serviceProvider, client, keys, values);
+        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
+
+        vm.expectEmit(true, true, false, true);
+        emit FilecoinWarmStorageService.ServiceTerminated(client, dataSetId, info.pdpRailId, 0, 0);
+        vm.prank(client);
+        pdpServiceWithPayments.terminateService(dataSetId);
+    }
+
+    function testTerminateService_directSP_emitsApprover() public {
+        (string[] memory keys, string[] memory values) = _getSingleMetadataKV("label", "test");
+        uint256 dataSetId = createDataSetForClient(serviceProvider, client, keys, values);
+        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
+
+        vm.expectEmit(true, true, false, true);
+        emit FilecoinWarmStorageService.ServiceTerminated(serviceProvider, dataSetId, info.pdpRailId, 0, 0);
+        vm.prank(serviceProvider);
+        pdpServiceWithPayments.terminateService(dataSetId);
+    }
+
+    function testTerminateService_sessionKey() public {
+        (string[] memory keys, string[] memory values) = _getSingleMetadataKV("label", "session key test");
+        uint256 dataSetId = createDataSetForClient(serviceProvider, client, keys, values);
+        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
+
+        bytes32[] memory permissions = new bytes32[](1);
+        permissions[0] = TERMINATE_SERVICE_TYPEHASH;
+        vm.prank(client);
+        sessionKeyRegistry.login(sessionKey1, block.timestamp, permissions, "test");
+
+        bytes memory sig = abi.encode(FAKE_SIGNATURE);
+        makeSignaturePass(sessionKey1);
+
+        // approver in event is the payer (client), not the session key or SP caller
+        vm.expectEmit(true, true, false, true);
+        emit FilecoinWarmStorageService.ServiceTerminated(client, dataSetId, info.pdpRailId, 0, 0);
+        vm.prank(serviceProvider);
+        pdpServiceWithPayments.terminateService(dataSetId, sig);
+
+        assertTrue(viewContract.getDataSet(dataSetId).pdpEndEpoch > 0, "dataset should be terminated");
+    }
+
+    function testTerminateService_sessionKey_unauthorizedKey() public {
+        (string[] memory keys, string[] memory values) = _getSingleMetadataKV("label", "test");
+        uint256 dataSetId = createDataSetForClient(serviceProvider, client, keys, values);
+
+        // sessionKey2 is not registered at all
+        bytes memory sig = abi.encode(FAKE_SIGNATURE);
+        makeSignaturePass(sessionKey2);
+        vm.prank(serviceProvider);
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidSignature.selector, client, sessionKey2));
+        pdpServiceWithPayments.terminateService(dataSetId, sig);
+    }
+
+    function testTerminateService_sessionKey_expiredKey() public {
+        (string[] memory keys, string[] memory values) = _getSingleMetadataKV("label", "test");
+        uint256 dataSetId = createDataSetForClient(serviceProvider, client, keys, values);
+
+        bytes32[] memory permissions = new bytes32[](1);
+        permissions[0] = TERMINATE_SERVICE_TYPEHASH;
+        vm.prank(client);
+        sessionKeyRegistry.login(sessionKey1, block.timestamp, permissions, "test");
+
+        vm.warp(block.timestamp + 1); // one second past expiry
+
+        bytes memory sig = abi.encode(FAKE_SIGNATURE);
+        makeSignaturePass(sessionKey1);
+        vm.prank(serviceProvider);
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidSignature.selector, client, sessionKey1));
+        pdpServiceWithPayments.terminateService(dataSetId, sig);
+    }
+
+    function testTerminateService_sessionKey_wrongPermission() public {
+        (string[] memory keys, string[] memory values) = _getSingleMetadataKV("label", "test");
+        uint256 dataSetId = createDataSetForClient(serviceProvider, client, keys, values);
+
+        bytes32[] memory permissions = new bytes32[](1);
+        permissions[0] = CREATE_DATA_SET_TYPEHASH; // not TERMINATE_SERVICE_TYPEHASH
+        vm.prank(client);
+        sessionKeyRegistry.login(sessionKey1, block.timestamp, permissions, "test");
+
+        bytes memory sig = abi.encode(FAKE_SIGNATURE);
+        makeSignaturePass(sessionKey1);
+        vm.prank(serviceProvider);
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidSignature.selector, client, sessionKey1));
+        pdpServiceWithPayments.terminateService(dataSetId, sig);
     }
 
     function testTransferCDNController() public {

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -2569,8 +2569,8 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         bytes memory sig = abi.encode(FAKE_SIGNATURE);
         makeSignaturePass(client);
 
-        vm.expectEmit(true, false, false, true);
-        emit FilecoinWarmStorageService.ServiceTerminated(dataSetId, client, info.pdpRailId, 0, 0);
+        vm.expectEmit(true, true, false, true);
+        emit FilecoinWarmStorageService.ServiceTerminated(client, dataSetId, info.pdpRailId, 0, 0);
         vm.prank(serviceProvider);
         pdpServiceWithPayments.terminateService(dataSetId, sig);
 
@@ -2582,8 +2582,8 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         uint256 dataSetId = createDataSetForClient(serviceProvider, client, keys, values);
         FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
 
-        vm.expectEmit(true, false, false, true);
-        emit FilecoinWarmStorageService.ServiceTerminated(dataSetId, address(0), info.pdpRailId, 0, 0);
+        vm.expectEmit(true, true, false, true);
+        emit FilecoinWarmStorageService.ServiceTerminated(client, dataSetId, info.pdpRailId, 0, 0);
         vm.prank(client);
         pdpServiceWithPayments.terminateService(dataSetId);
     }
@@ -2593,8 +2593,8 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         uint256 dataSetId = createDataSetForClient(serviceProvider, client, keys, values);
         FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
 
-        vm.expectEmit(true, false, false, true);
-        emit FilecoinWarmStorageService.ServiceTerminated(dataSetId, address(0), info.pdpRailId, 0, 0);
+        vm.expectEmit(true, true, false, true);
+        emit FilecoinWarmStorageService.ServiceTerminated(serviceProvider, dataSetId, info.pdpRailId, 0, 0);
         vm.prank(serviceProvider);
         pdpServiceWithPayments.terminateService(dataSetId);
     }
@@ -2612,9 +2612,9 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         bytes memory sig = abi.encode(FAKE_SIGNATURE);
         makeSignaturePass(sessionKey1);
 
-        // signer in event is the session key, not the payer
-        vm.expectEmit(true, false, false, true);
-        emit FilecoinWarmStorageService.ServiceTerminated(dataSetId, sessionKey1, info.pdpRailId, 0, 0);
+        // approver in event is the session key, not the payer
+        vm.expectEmit(true, true, false, true);
+        emit FilecoinWarmStorageService.ServiceTerminated(sessionKey1, dataSetId, info.pdpRailId, 0, 0);
         vm.prank(serviceProvider);
         pdpServiceWithPayments.terminateService(dataSetId, sig);
 

--- a/service_contracts/test/SignatureFixtureTest.t.sol
+++ b/service_contracts/test/SignatureFixtureTest.t.sol
@@ -37,18 +37,13 @@ import {SignatureVerificationLib} from "../src/lib/SignatureVerificationLib.sol"
  * (chainId, verifyingContract) pair so we can mirror an arbitrary deployed
  * domain (e.g. calibration FWSS) without redeploying at that address.
  *
- * Typehashes for operations the FWSS contract implements come from
- * SignatureVerificationLib so any rename in the library will surface here as
- * a fixture mismatch (caught by external_signatures.json + the SDK fixtures).
- * TERMINATE_SERVICE_TYPEHASH is declared locally because the FWSS contract
- * doesn't currently implement TerminateService auth; move it into the library
- * when the impl lands.
+ * Typehashes for all FWSS operations come from SignatureVerificationLib so any
+ * rename in the library will surface here as a fixture mismatch (caught by
+ * external_signatures.json + the SDK fixtures).
  */
 contract MetadataSignatureTestContract {
     bytes32 private constant EIP712_DOMAIN_TYPEHASH =
         keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
-
-    bytes32 private constant TERMINATE_SERVICE_TYPEHASH = keccak256("TerminateService(uint256 dataSetId)");
 
     bytes32 private immutable _domainSeparator;
 
@@ -165,7 +160,7 @@ contract MetadataSignatureTestContract {
     }
 
     function getTerminateServiceDigest(uint256 dataSetId) public view returns (bytes32) {
-        bytes32 structHash = keccak256(abi.encode(TERMINATE_SERVICE_TYPEHASH, dataSetId));
+        bytes32 structHash = keccak256(abi.encode(SignatureVerificationLib.TERMINATE_SERVICE_TYPEHASH, dataSetId));
         return _hashTypedData(structHash);
     }
 }


### PR DESCRIPTION

Reviewer @rvagg
CC @LexLuthr
Toward https://github.com/FilOzone/filecoin-services/issues/469
Replaces https://github.com/FilOzone/filecoin-services/pull/474
This adds the next signature for terminateService which will allow optional extra data.
Cutting this separately while I work on the more complicated operation pricing change in order to unblock curio and synapse
#### Changes
* add terminateService method with extra data
* deprecate terminateService without extra data
* use extradata for client auth signature