### PR TITLE
feat: operational pricing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,6 @@ This release improves data set creation and data set query behavior in FWSS, whi
 
 See [`service_contracts/deployments.json`](https://github.com/FilOzone/filecoin-services/blob/v1.2.0/service_contracts/deployments.json) for the latest Mainnet (chain 314) and Calibnet (chain 314159) contract addresses. The FWSS proxy addresses remain unchanged in this release; the upgrade only changes the implementation behind the existing proxies.
 
-### Changed
-- Data set creation now charges the PDPVerifier USDFC sybil fee via a client-funded burn rail ([#437](https://github.com/FilOzone/filecoin-services/pull/437))
-
 ### Fixed
 - Corrected FWSS proving-period boundary handling to use exclusive-inclusive ranges ([#419](https://github.com/FilOzone/filecoin-services/pull/419))
 - Simplified and optimized validator-path settlement calculations in `_findProvenEpochs` ([#423](https://github.com/FilOzone/filecoin-services/pull/423), [#424](https://github.com/FilOzone/filecoin-services/pull/424))
@@ -21,9 +18,6 @@ See [`service_contracts/deployments.json`](https://github.com/FilOzone/filecoin-
 ### Upgrade Notes
 - Existing FWSS proxy integrations continue using the same proxy addresses.
 - No migration is required for existing data sets or existing integrations.
-- Clients creating new data sets should ensure they have enough available USDFC funds and lockup allowance to cover both the existing minimum lockup and the PDPVerifier sybil fee.
-  - The USDFC sybil fee is `0.1 USDFC`.
-  - The configured amount can be read on-chain by calling `USDFC_SYBIL_FEE()` on the PDPVerifier proxy for each network. See [`service_contracts/deployments.json`](https://github.com/FilOzone/filecoin-services/blob/main/service_contracts/deployments.json) for the PDP proxy addresses.
 - No user action is required unless your integration depends on the exact pre-upgrade dataset-creation funding assumptions.
 
 ## [1.1.0] - 2026-01-30 - FWSS Upgrade

--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ This repository contains smart contracts and services for the Filecoin ecosystem
 ## Pricing
 
 The service uses static global pricing set by the contract owner (currently 2.5 USDFC per TiB/month).
-Rail payment rates are calculated as a size-proportional component plus a flat per-dataset fee of 0.024 USDFC/month. See [SPEC.md](SPEC.md) for details on rate calculation, pricing updates, and top-up/renewal behavior.
+Rail payment rates are calculated as a size-proportional component plus a flat per-dataset fee of 0.024 USDFC/month.
+
+Storage providers submit on-chain transactions on behalf of clients (piece additions, removal scheduling, proving). To reimburse SPs for these gas costs, FWSS charges small one-time operation fees: $0.0025 on dataset creation, $0.0005 + $0.0003/piece per add-pieces call, $0.002 per removal-scheduling call, and $0.00112 when an SP terminates service with payer consent. Fees are drawn from a $0.10 lifecycle reserve maintained as fixed lockup on the PDP rail.
+
+See [SPEC.md](SPEC.md) for details on rate calculation, operation fees, pricing updates, and top-up/renewal behavior.
 
 ## 🚀 Quick Start
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -63,7 +63,7 @@ pendingOneTimePayments   = 0
 
 This keeps the hot path at one external call per event.
 
-**Replenishment**: Before each flush, if `lifecycleReserveBalance - pending < REPLENISH_THRESHOLD`, the reserve is automatically topped back up to `LIFECYCLE_RESERVE_TARGET` via an additional `modifyRailLockup` call. Replenishment fires roughly once every 50 operations.
+**Replenishment**: When `lifecycleReserveBalance < pending + REPLENISH_THRESHOLD`, the reserve is topped back up via `modifyRailLockup`, setting `lockupFixed` to `LIFECYCLE_RESERVE_TARGET + pending`. After the next flush deducts the pending fees, the net balance returns to `LIFECYCLE_RESERVE_TARGET`. For `piecesAdded` and `nextProvingPeriod`, replenishment and flush happen together inside `updateStorageRates`. For `piecesScheduledRemove`, replenishment fires immediately at scheduling time—before the fee is deferred to the next flush—so the reserve covers accumulating debt even when piece removals precede the next proving period by a long interval.
 
 **Post-termination**: Once the PDP rail is terminated, `modifyRailLockup` can no longer raise `lockupFixed`. The reserve balance at termination time is the maximum available for wind-down fees. Clients anticipating many post-termination piece removals should pre-fund the reserve before terminating.
 
@@ -189,7 +189,7 @@ Service is terminated by calling `terminateService(dataSetId)` on FWSS. Only the
 
 `terminateService` calls `FilecoinPay.terminateRail(pdpRailId)`. That call sets the rail's `endEpoch` and starts the lockup-period countdown to finalization. FilecoinPay then calls `railTerminated()` back into FWSS, since FWSS is the PDP rail's validator. The callback sets `info.pdpEndEpoch`, emits `PDPPaymentTerminated`, and verifies that the terminator is FWSS itself. The effect of that last check is that the PDP rail can only be terminated through `terminateService`. A direct `FilecoinPay.terminateRail` call from a client or SP is rejected inside the callback.
 
-If the dataset has CDN rails (`withCDN` metadata set), `terminateService` also terminates the cache-miss and CDN rails in the same transaction as a best-effort step. Errors from those calls are suppressed so PDP service termination always succeeds regardless of CDN rail state.
+CDN rails are not touched by `terminateService`. They remain active through the PDP rail's 30-day lockup window, allowing FilBeam to continue settling CDN usage during that period. When the dataset is subsequently deleted (`dataSetDeleted` callback), FWSS performs best-effort termination of CDN rails, giving FilBeam a 5-day settle window from that point. Any unsettled fixed lockup returns to the payer after the window closes.
 
 Client-initiated termination of a zero-rate rail (a CDN rail called directly on FilecoinPay) is permitted because `isAccountLockupFullySettled` is trivially true when the payment rate is zero. For a non-zero-rate rail like the PDP rail, a client whose account has fallen behind on lockup settlement cannot call `FilecoinPay.terminateRail` directly. However, `terminateService` on FWSS still works for the payer, because FWSS is the caller of `terminateRail` in that path.
 
@@ -217,7 +217,7 @@ require(settledUpTo >= endEpoch, RailNotFullySettled)
 
 **State cleared**: The `dataSetDeleted` callback removes `dataSetInfo`, `provingDeadlines`, `provenThisPeriod`, `provingActivationEpoch`, `railToDataSet[pdpRailId]`, the dataset's entry in `clientDataSets[payer]`, and all `dataSetMetadata` entries. `clientNonces[payer][nonce]` is **not** cleared. It is retained to prevent replay of authorization signatures.
 
-**CDN rails are not checked**: The settled-up-to requirement above and the `pdpEndEpoch` checks in the timing list both apply to the PDP rail only. FWSS does not verify CDN rail termination or settlement before allowing dataset deletion, because it does not track the CDN rails' `endEpoch` (there is no validator callback to set it). In the normal flow this is safe: CDN rails are terminated in the same `terminateService` call that initiates PDP rail termination.
+**CDN rails are not checked**: The settled-up-to requirement above and the `pdpEndEpoch` checks in the timing list both apply to the PDP rail only. FWSS does not verify CDN rail termination or settlement before allowing dataset deletion, because it does not track the CDN rails' `endEpoch` (there is no validator callback to set it). In the normal flow this is safe: CDN rails are terminated as part of the `dataSetDeleted` callback itself.
 
 ## CDN Payment Rails
 
@@ -226,7 +226,7 @@ Datasets with CDN support have three payment rails: a **PDP rail** for storage p
 - **Cache-miss rail** (`cacheMissRailId`): Pays to the storage provider (SP) for origin fetches
 - **Bandwidth rail** (`cdnRailId`): Pays to the FilBeam beneficiary address (immutably set at deployment)
 
-Both CDN rails have `paymentRate = 0` and use fixed lockup for one-time payments based on usage.
+Both CDN rails have `paymentRate = 0` and use fixed lockup for one-time payments based on usage. At dataset creation the cache-miss rail is seeded with **0.3 USDFC** and the CDN rail with **0.7 USDFC**. Both CDN rails use a **5-day lockup period**, which sets the settle window FilBeam has after dataset deletion to claim any remaining fixed lockup.
 
 ### Payment Models
 
@@ -254,11 +254,11 @@ FWSS tracks CDN-enabled datasets using a `withCDN` metadata key. This metadata i
 
 If CDN rails are terminated directly via FilecoinPay (bypassing FWSS), the `withCDN` metadata remains set because FWSS receives no callback. This creates an out-of-sync state where FWSS believes CDN is active but the underlying rails are terminated or finalized. Subsequent CDN operations (`topUpCDNPaymentRails`, `settleFilBeamPaymentRails`) will fail when they attempt to interact with the inactive rails.
 
-**Note**: There is currently no mechanism to clean up orphaned `withCDN` metadata. The practical impact is limited since `terminateService()` uses best-effort CDN termination (ignoring errors), so full service termination still succeeds.
+**Note**: There is currently no mechanism to clean up orphaned `withCDN` metadata. The practical impact is limited: `terminateService()` does not interact with CDN rails at all, so storage termination always succeeds; and CDN rail termination in `dataSetDeleted` is best-effort, so dataset deletion also succeeds.
 
 ### Service Termination
 
-When terminating a dataset's service, FWSS terminates the PDP rail (which it validates) and performs best-effort termination of CDN rails, ignoring any errors. This ensures service termination succeeds regardless of CDN rail state—whether rails are active, already terminated, or fully settled and finalized.
+`terminateService` only terminates the PDP rail. CDN rails remain active through the PDP rail's 30-day lockup window, allowing FilBeam to continue settling CDN usage during that period. When the dataset is subsequently deleted (`dataSetDeleted` callback), FWSS terminates the CDN rails with best-effort error suppression. The CDN rails then enter their 5-day settle window; any remaining fixed lockup not claimed by FilBeam returns to the payer once the window closes.
 
 ## Contract Architecture
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -31,6 +31,44 @@ Every dataset with stored data pays a flat 0.024 USDFC/month fee on top of the s
 
 **Precision note**: Integer division when computing `DATASET_FEE_PER_EPOCH` causes minor precision loss. The actual monthly payment (`DATASET_FEE_PER_EPOCH × EPOCHS_PER_MONTH`) is slightly less than `DATASET_FEE_PER_MONTH`—under 0.0001%. This is acceptable; see the lockup section below for how pre-flight checks handle this.
 
+### Operation Fees
+
+In addition to the ongoing storage rate, FWSS charges one-time fees for specific lifecycle operations. These fees are deducted from a **lifecycle reserve** maintained as fixed lockup on the PDP rail.
+
+| Operation | Fee | Trigger | Recipient |
+|---|---|---|---|
+| Create dataset | $0.0025 | `dataSetCreated` callback | SP |
+| Add pieces | $0.0005 + $0.0003 × n | `piecesAdded` callback (n = piece count) | SP |
+| Schedule piece removals | $0.002 | `piecesScheduledRemove` callback | SP |
+| Terminate service (consent) | $0.00112 | SP-initiated termination with payer EIP-712 signature | SP |
+
+The terminate fee applies only in the **consent case**: when the SP calls `terminateService` with a valid payer signature in `extraData`. Direct termination by the payer or unilateral SP termination does not incur this fee.
+
+#### Lifecycle Reserve
+
+The lifecycle reserve is seeded at **$0.10** when the dataset is created, stored as `lockupFixed` on the PDP rail.
+
+```
+LIFECYCLE_RESERVE_TARGET = $0.10
+REPLENISH_THRESHOLD      = $0.005
+```
+
+**Flush mechanism**: Operation fees are not paid immediately. Each triggering operation increments `pendingOneTimePayments` (a local field in `DataSetInfo`). The accumulated amount is flushed the next time `updateStorageRates` runs—once per `piecesAdded` and once per `nextProvingPeriod`:
+
+```
+modifyRailPayment(pdpRailId, newStorageRate, pendingFees)
+lifecycleReserveBalance -= pendingFees
+pendingOneTimePayments   = 0
+```
+
+This keeps the hot path at one external call per event.
+
+**Replenishment**: Before each flush, if `lifecycleReserveBalance - pending < REPLENISH_THRESHOLD`, the reserve is automatically topped back up to `LIFECYCLE_RESERVE_TARGET` via an additional `modifyRailLockup` call. Replenishment fires roughly once every 50 operations.
+
+**Post-termination**: Once the PDP rail is terminated, `modifyRailLockup` can no longer raise `lockupFixed`. The reserve balance at termination time is the maximum available for wind-down fees. Clients anticipating many post-termination piece removals should pre-fund the reserve before terminating.
+
+**Manual top-up**: The payer can call `topUpLifecycleReserve(dataSetId, amount)` at any time before termination. The payer must have sufficient available funds and `lockupAllowance` to cover the increase; `modifyRailLockup` enforces this via the standard operator approval checks.
+
 ### Pricing Updates
 
 Only the contract owner can update pricing, by upgrading the contract.

--- a/service_contracts/abi/FilecoinWarmStorageService.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageService.abi.json
@@ -773,6 +773,24 @@
   },
   {
     "type": "function",
+    "name": "topUpLifecycleReserve",
+    "inputs": [
+      {
+        "name": "dataSetId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "transferFilBeamController",
     "inputs": [
       {

--- a/service_contracts/abi/FilecoinWarmStorageServiceStateLibrary.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageServiceStateLibrary.abi.json
@@ -298,6 +298,16 @@
             "internalType": "uint256"
           },
           {
+            "name": "pendingOneTimePayments",
+            "type": "uint96",
+            "internalType": "uint96"
+          },
+          {
+            "name": "lifecycleReserveBalance",
+            "type": "uint96",
+            "internalType": "uint96"
+          },
+          {
             "name": "dataSetId",
             "type": "uint256",
             "internalType": "uint256"
@@ -377,6 +387,16 @@
             "name": "providerId",
             "type": "uint256",
             "internalType": "uint256"
+          },
+          {
+            "name": "pendingOneTimePayments",
+            "type": "uint96",
+            "internalType": "uint96"
+          },
+          {
+            "name": "lifecycleReserveBalance",
+            "type": "uint96",
+            "internalType": "uint96"
           },
           {
             "name": "dataSetId",
@@ -506,6 +526,16 @@
             "name": "providerId",
             "type": "uint256",
             "internalType": "uint256"
+          },
+          {
+            "name": "pendingOneTimePayments",
+            "type": "uint96",
+            "internalType": "uint96"
+          },
+          {
+            "name": "lifecycleReserveBalance",
+            "type": "uint96",
+            "internalType": "uint96"
           },
           {
             "name": "dataSetId",

--- a/service_contracts/abi/FilecoinWarmStorageServiceStateView.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageServiceStateView.abi.json
@@ -262,6 +262,16 @@
             "internalType": "uint256"
           },
           {
+            "name": "pendingOneTimePayments",
+            "type": "uint96",
+            "internalType": "uint96"
+          },
+          {
+            "name": "lifecycleReserveBalance",
+            "type": "uint96",
+            "internalType": "uint96"
+          },
+          {
             "name": "dataSetId",
             "type": "uint256",
             "internalType": "uint256"
@@ -336,6 +346,16 @@
             "name": "providerId",
             "type": "uint256",
             "internalType": "uint256"
+          },
+          {
+            "name": "pendingOneTimePayments",
+            "type": "uint96",
+            "internalType": "uint96"
+          },
+          {
+            "name": "lifecycleReserveBalance",
+            "type": "uint96",
+            "internalType": "uint96"
           },
           {
             "name": "dataSetId",
@@ -449,6 +469,16 @@
             "name": "providerId",
             "type": "uint256",
             "internalType": "uint256"
+          },
+          {
+            "name": "pendingOneTimePayments",
+            "type": "uint96",
+            "internalType": "uint96"
+          },
+          {
+            "name": "lifecycleReserveBalance",
+            "type": "uint96",
+            "internalType": "uint96"
           },
           {
             "name": "dataSetId",

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -22,6 +22,7 @@ import {Extsload} from "./Extsload.sol";
 import {
     CACHE_MISS_EGRESS_PRICE_PER_TIB,
     ADD_PIECES_FEE,
+    CREATE_DATA_SET_FEE,
     CDN_EGRESS_PRICE_PER_TIB,
     DATASET_FEE_PER_MONTH,
     DEFAULT_LOCKUP_PERIOD,
@@ -611,6 +612,7 @@ contract FilecoinWarmStorageService is
         railToDataSet[pdpRailId] = dataSetId;
         info.pdpRailId = pdpRailId;
         info.lifecycleReserveBalance = uint96(LIFECYCLE_RESERVE_TARGET);
+        info.pendingOneTimePayments = uint96(CREATE_DATA_SET_FEE);
         if (hasCDN) {
             info.cacheMissRailId = cacheMissRailId;
             info.cdnRailId = cdnRailId;

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -21,7 +21,8 @@ import {Extsload} from "./Extsload.sol";
 
 import {
     CACHE_MISS_EGRESS_PRICE_PER_TIB,
-    ADD_PIECES_FEE,
+    ADD_PIECES_BASE_FEE,
+    ADD_PIECES_PER_PIECE_FEE,
     CREATE_DATA_SET_FEE,
     CDN_EGRESS_PRICE_PER_TIB,
     DATASET_FEE_PER_MONTH,
@@ -747,7 +748,8 @@ contract FilecoinWarmStorageService is
         // Verify the signature
         verifyAddPiecesSignature(payer, info.clientDataSetId, pieceData, nonce, metadataKeys, metadataValues, signature);
 
-        uint96 pending = info.pendingOneTimePayments + uint96(ADD_PIECES_FEE);
+        uint96 pending =
+            info.pendingOneTimePayments + uint96(ADD_PIECES_BASE_FEE + pieceData.length * ADD_PIECES_PER_PIECE_FEE);
         uint96 reserveBalance = info.lifecycleReserveBalance;
 
         // Validate lockup for the new data set size (fail-fast if client has insufficient funds)

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -21,11 +21,16 @@ import {Extsload} from "./Extsload.sol";
 
 import {
     CACHE_MISS_EGRESS_PRICE_PER_TIB,
+    ADD_PIECES_FEE,
     CDN_EGRESS_PRICE_PER_TIB,
     DATASET_FEE_PER_MONTH,
+    DEFAULT_LOCKUP_PERIOD,
     EPOCHS_PER_MONTH,
+    LIFECYCLE_RESERVE_TARGET,
+    SCHEDULE_PIECE_REMOVALS_FEE,
     SERVICE_COMMISSION_BPS,
     STORAGE_PRICE_PER_TIB_PER_MONTH,
+    TERMINATE_FEE,
     TOKEN_DECIMALS
 } from "./lib/PriceListUSDFC.sol";
 import {Rails} from "./lib/Rails.sol";
@@ -145,6 +150,8 @@ contract FilecoinWarmStorageService is
         uint256 clientDataSetId; // ClientDataSetID
         uint256 pdpEndEpoch; // 0 if PDP rail are not terminated
         uint256 providerId; // Provider ID from the ServiceProviderRegistry
+        uint96 pendingOneTimePayments; // fees accumulated since last flush via updateStorageRates
+        uint96 lifecycleReserveBalance; // local mirror of rail's lockupFixed; decremented on flush
     }
 
     // Storage for data set payment information with dataSetId
@@ -159,6 +166,8 @@ contract FilecoinWarmStorageService is
         uint256 clientDataSetId; // ClientDataSetID
         uint256 pdpEndEpoch; // 0 if PDP rail are not terminated
         uint256 providerId; // Provider ID from the ServiceProviderRegistry
+        uint96 pendingOneTimePayments; // fees accumulated since last flush via updateStorageRates
+        uint96 lifecycleReserveBalance; // local mirror of rail's lockupFixed; decremented on flush
         uint256 dataSetId; // DataSet ID
     }
 
@@ -601,6 +610,7 @@ contract FilecoinWarmStorageService is
 
         railToDataSet[pdpRailId] = dataSetId;
         info.pdpRailId = pdpRailId;
+        info.lifecycleReserveBalance = uint96(LIFECYCLE_RESERVE_TARGET);
         if (hasCDN) {
             info.cacheMissRailId = cacheMissRailId;
             info.cdnRailId = cdnRailId;
@@ -735,9 +745,12 @@ contract FilecoinWarmStorageService is
         // Verify the signature
         verifyAddPiecesSignature(payer, info.clientDataSetId, pieceData, nonce, metadataKeys, metadataValues, signature);
 
+        uint96 pending = info.pendingOneTimePayments + uint96(ADD_PIECES_FEE);
+        uint96 reserveBalance = info.lifecycleReserveBalance;
+
         // Validate lockup for the new data set size (fail-fast if client has insufficient funds)
         uint256 currentLeafCount = IPDPVerifier(pdpVerifierAddress).getDataSetLeafCount(dataSetId);
-        updatePaymentRates(dataSetId, currentLeafCount);
+        updatePaymentRates(dataSetId, info, currentLeafCount, pending, reserveBalance);
 
         // Store metadata for each new piece
         for (uint256 i = 0; i < pieceData.length; i++) {
@@ -802,6 +815,8 @@ contract FilecoinWarmStorageService is
         // Verify the signature
         verifySchedulePieceRemovalsSignature(payer, info.clientDataSetId, pieceIds, signature);
 
+        info.pendingOneTimePayments += uint96(SCHEDULE_PIECE_REMOVALS_FEE);
+
         // Queue piece IDs for metadata cleanup at nextProvingPeriod
         uint256[] storage scheduled = scheduledPieceMetadataRemovals[dataSetId];
         for (uint256 i = 0; i < pieceIds.length; i++) {
@@ -858,6 +873,11 @@ contract FilecoinWarmStorageService is
         onlyPDPVerifier
     {
         requirePaymentNotBeyondEndEpoch(dataSetId);
+
+        DataSetInfo storage info = dataSetInfo[dataSetId];
+        uint96 pending = info.pendingOneTimePayments;
+        uint96 reserveBalance = info.lifecycleReserveBalance;
+
         // initialize state for new data set
         if (provingDeadlines[dataSetId] == NO_PROVING_DEADLINE) {
             uint256 firstDeadline = block.number + maxProvingPeriod;
@@ -872,9 +892,9 @@ contract FilecoinWarmStorageService is
             // This marks when the data set became active for proving
             provingActivationEpoch[dataSetId] = block.number;
 
-            // Rate was already set in piecesAdded; only update if pieces were removed
-            if (processScheduledPieceMetadataRemovals(dataSetId)) {
-                updatePaymentRates(dataSetId, leafCount);
+            // Rate was already set in piecesAdded; only update if pieces were removed or fees are pending
+            if (processScheduledPieceMetadataRemovals(dataSetId) || pending > 0) {
+                updatePaymentRates(dataSetId, info, leafCount, pending, reserveBalance);
             }
 
             return;
@@ -921,9 +941,10 @@ contract FilecoinWarmStorageService is
         provingDeadlines[dataSetId] = nextDeadline;
         provenThisPeriod[dataSetId] = false;
 
-        // Additions update rate immediately in piecesAdded; only update here if pieces were removed
-        if (processScheduledPieceMetadataRemovals(dataSetId)) {
-            updatePaymentRates(dataSetId, leafCount);
+        // Additions update rate immediately in piecesAdded; update here if pieces were removed or fees are pending
+        bool hadRemovals = processScheduledPieceMetadataRemovals(dataSetId);
+        if (hadRemovals || pending > 0) {
+            updatePaymentRates(dataSetId, info, leafCount, pending, reserveBalance);
         }
     }
 
@@ -973,6 +994,10 @@ contract FilecoinWarmStorageService is
             approver = msg.sender;
         }
 
+        if (approver == info.payer) {
+            info.pendingOneTimePayments += uint96(TERMINATE_FEE);
+        }
+
         FilecoinPayV1 payments = FilecoinPayV1(paymentsContractAddress);
         payments.terminateRail(info.pdpRailId);
 
@@ -981,6 +1006,23 @@ contract FilecoinWarmStorageService is
         }
 
         emit ServiceTerminated(approver, dataSetId, info.pdpRailId, info.cacheMissRailId, info.cdnRailId);
+    }
+
+    /**
+     * @notice Pre-funds the lifecycle reserve beyond the automatic target
+     * @dev Useful before scheduling many piece removals or before terminating.
+     *      Cannot be called after termination; FilecoinPay forbids raising lockupFixed on a terminated rail.
+     * @param dataSetId The ID of the data set
+     * @param amount Additional amount to add to the lifecycle reserve
+     */
+    function topUpLifecycleReserve(uint256 dataSetId, uint256 amount) external {
+        DataSetInfo storage info = dataSetInfo[dataSetId];
+        require(msg.sender == info.payer, Errors.CallerNotPayer(dataSetId, info.payer, msg.sender));
+
+        uint256 pdpRailId = info.pdpRailId;
+        uint96 newBalance = info.lifecycleReserveBalance + uint96(amount);
+        FilecoinPayV1(paymentsContractAddress).modifyRailLockup(pdpRailId, DEFAULT_LOCKUP_PERIOD, newBalance);
+        info.lifecycleReserveBalance = newBalance;
     }
 
     /**
@@ -1075,14 +1117,20 @@ contract FilecoinWarmStorageService is
         delete dataSetMetadata[dataSetId][METADATA_KEY_WITH_CDN];
     }
 
-    function updatePaymentRates(uint256 dataSetId, uint256 leafCount) internal {
-        uint256 pdpRailId = dataSetInfo[dataSetId].pdpRailId;
-        // Revert if no payment rail is configured for this data set
+    function updatePaymentRates(
+        uint256 dataSetId,
+        DataSetInfo storage info,
+        uint256 leafCount,
+        uint96 pending,
+        uint96 reserveBalance
+    ) internal {
+        uint256 pdpRailId = info.pdpRailId;
         require(pdpRailId != 0, Errors.NoPDPPaymentRail(dataSetId));
 
-        // Update the PDP rail payment rate with the new rate and no one-time payment
-
-        FilecoinPayV1(paymentsContractAddress).updateStorageRates(dataSetId, pdpRailId, leafCount);
+        info.lifecycleReserveBalance = FilecoinPayV1(paymentsContractAddress).updateStorageRates(
+            dataSetId, pdpRailId, leafCount, pending, reserveBalance
+        );
+        info.pendingOneTimePayments = 0;
     }
 
     function processScheduledPieceMetadataRemovals(uint256 dataSetId) internal returns (bool hadRemovals) {

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -1002,6 +1002,13 @@ contract FilecoinWarmStorageService is
         }
 
         FilecoinPayV1 payments = FilecoinPayV1(paymentsContractAddress);
+
+        uint96 pending = info.pendingOneTimePayments;
+        if (pending > 0) {
+            uint256 leafCount = IPDPVerifier(pdpVerifierAddress).getDataSetLeafCount(dataSetId);
+            updatePaymentRates(dataSetId, info, leafCount, pending, info.lifecycleReserveBalance);
+        }
+
         payments.terminateRail(info.pdpRailId);
 
         if (deleteCDNMetadataKey(dataSetMetadataKeys[dataSetId])) {

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -989,7 +989,7 @@ contract FilecoinWarmStorageService is
             );
             bytes memory signature = abi.decode(extraData, (bytes));
             approver = _verifyTerminateServiceSignature(info.payer, dataSetId, signature);
-            if (approver == info.payer && msg.sender == info.serviceProvider) {
+            if (msg.sender == info.serviceProvider) {
                 // TODO termination can be immediate
                 info.pendingOneTimePayments += uint96(TERMINATE_FEE);
             }

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -1141,7 +1141,7 @@ contract FilecoinWarmStorageService is
         require(pdpRailId != 0, Errors.NoPDPPaymentRail(dataSetId));
 
         info.lifecycleReserveBalance = FilecoinPayV1(paymentsContractAddress).updateStorageRates(
-            dataSetId, pdpRailId, leafCount, pending, reserveBalance
+            dataSetId, pdpRailId, leafCount, pending, reserveBalance, info.pdpEndEpoch
         );
         info.pendingOneTimePayments = 0;
     }

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -1027,7 +1027,10 @@ contract FilecoinWarmStorageService is
      */
     function topUpLifecycleReserve(uint256 dataSetId, uint256 amount) external {
         DataSetInfo storage info = dataSetInfo[dataSetId];
-        require(msg.sender == info.payer, Errors.CallerNotPayer(dataSetId, info.payer, msg.sender));
+        address payer = info.payer;
+        require(payer != address(0), Errors.InvalidDataSetId(dataSetId));
+        require(msg.sender == payer, Errors.CallerNotPayer(dataSetId, payer, msg.sender));
+        require(info.pdpEndEpoch == 0, Errors.DataSetPaymentAlreadyTerminated(dataSetId));
 
         uint256 pdpRailId = info.pdpRailId;
         uint96 newBalance = info.lifecycleReserveBalance + uint96(amount);

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -670,6 +670,11 @@ contract FilecoinWarmStorageService is
             // Rail is finalized (zeroed out), meaning it was already fully settled
         }
 
+        // Terminate CDN rails if configured, giving FilBeam a graceful settle window
+        if (info.cdnRailId != 0) {
+            _terminateCDNRails(dataSetId, info, payments);
+        }
+
         // NOTE keep clientNonces[payer][clientDataSetId] to prevent replay
 
         // Remove from client's dataset list
@@ -1015,10 +1020,6 @@ contract FilecoinWarmStorageService is
 
         payments.terminateRail(info.pdpRailId);
 
-        if (deleteCDNMetadataKey(dataSetMetadataKeys[dataSetId])) {
-            _terminateCDNRails(dataSetId, info, payments);
-        }
-
         emit ServiceTerminated(approver, dataSetId, info.pdpRailId, info.cacheMissRailId, info.cdnRailId);
     }
 
@@ -1090,6 +1091,7 @@ contract FilecoinWarmStorageService is
     function terminateCDNService(uint256 dataSetId) external onlyFilBeamController {
         // Check if CDN service is configured
         require(deleteCDNMetadataKey(dataSetMetadataKeys[dataSetId]), Errors.FilBeamServiceNotConfigured(dataSetId));
+        delete dataSetMetadata[dataSetId][METADATA_KEY_WITH_CDN];
 
         // Check if cache miss and CDN rails are configured
         DataSetInfo storage info = dataSetInfo[dataSetId];
@@ -1131,7 +1133,6 @@ contract FilecoinWarmStorageService is
     /// us from implementing error handling.
     function _terminateCDNRails(uint256 dataSetId, DataSetInfo storage info, FilecoinPayV1 payments) internal {
         payments.terminateCDNRails(dataSetId, info.cacheMissRailId, info.cdnRailId);
-        delete dataSetMetadata[dataSetId][METADATA_KEY_WITH_CDN];
     }
 
     function updatePaymentRates(

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -819,7 +819,11 @@ contract FilecoinWarmStorageService is
         // Verify the signature
         verifySchedulePieceRemovalsSignature(payer, info.clientDataSetId, pieceIds, signature);
 
-        info.pendingOneTimePayments += uint96(SCHEDULE_PIECE_REMOVALS_FEE);
+        uint96 newPending = info.pendingOneTimePayments + uint96(SCHEDULE_PIECE_REMOVALS_FEE);
+        info.lifecycleReserveBalance = FilecoinPayV1(paymentsContractAddress).replenishReserveIfNeeded(
+            info.pdpRailId, info.pdpEndEpoch, info.lifecycleReserveBalance, newPending
+        );
+        info.pendingOneTimePayments = newPending;
 
         // Queue piece IDs for metadata cleanup at nextProvingPeriod
         uint256[] storage scheduled = scheduledPieceMetadataRemovals[dataSetId];

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -989,17 +989,16 @@ contract FilecoinWarmStorageService is
             );
             bytes memory signature = abi.decode(extraData, (bytes));
             approver = _verifyTerminateServiceSignature(info.payer, dataSetId, signature);
-            // TODO if msg.sender is info.serviceProvider, termination is immediate
+            if (approver == info.payer && msg.sender == info.serviceProvider) {
+                // TODO termination can be immediate
+                info.pendingOneTimePayments += uint96(TERMINATE_FEE);
+            }
         } else {
             require(
                 msg.sender == info.payer || msg.sender == info.serviceProvider,
                 Errors.CallerNotPayerOrPayee(dataSetId, info.payer, info.serviceProvider, msg.sender)
             );
             approver = msg.sender;
-        }
-
-        if (approver == info.payer) {
-            info.pendingOneTimePayments += uint96(TERMINATE_FEE);
         }
 
         FilecoinPayV1 payments = FilecoinPayV1(paymentsContractAddress);

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceLayout.json
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceLayout.json
@@ -143,7 +143,7 @@
       "value": {
         "label": "struct FilecoinWarmStorageService.DataSetInfo",
         "encoding": "inplace",
-        "numberOfBytes": "320",
+        "numberOfBytes": "352",
         "members": [
           {
             "label": "pdpRailId",
@@ -243,6 +243,26 @@
               "label": "uint256",
               "encoding": "inplace",
               "numberOfBytes": "32"
+            }
+          },
+          {
+            "label": "pendingOneTimePayments",
+            "slot": "10",
+            "offset": 0,
+            "type": {
+              "label": "uint96",
+              "encoding": "inplace",
+              "numberOfBytes": "12"
+            }
+          },
+          {
+            "label": "lifecycleReserveBalance",
+            "slot": "10",
+            "offset": 12,
+            "type": {
+              "label": "uint96",
+              "encoding": "inplace",
+              "numberOfBytes": "12"
             }
           }
         ]

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
@@ -116,6 +116,8 @@ library FilecoinWarmStorageServiceStateInternalLibrary {
         info.clientDataSetId = uint256(info11[7]);
         info.pdpEndEpoch = uint256(info11[8]);
         info.providerId = uint256(info11[9]);
+        info.pendingOneTimePayments = uint96(uint256(info11[10]));
+        info.lifecycleReserveBalance = uint96(uint256(info11[10]) >> 96);
         info.dataSetId = dataSetId;
     }
 

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceStateLibrary.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceStateLibrary.sol
@@ -112,6 +112,8 @@ library FilecoinWarmStorageServiceStateLibrary {
         info.clientDataSetId = uint256(info11[7]);
         info.pdpEndEpoch = uint256(info11[8]);
         info.providerId = uint256(info11[9]);
+        info.pendingOneTimePayments = uint96(uint256(info11[10]));
+        info.lifecycleReserveBalance = uint96(uint256(info11[10]) >> 96);
         info.dataSetId = dataSetId;
     }
 

--- a/service_contracts/src/lib/PriceListUSDFC.sol
+++ b/service_contracts/src/lib/PriceListUSDFC.sol
@@ -29,6 +29,16 @@ uint256 constant DEFAULT_CACHE_MISS_LOCKUP_AMOUNT = (3 * 10 ** TOKEN_DECIMALS) /
 
 uint256 constant SERVICE_COMMISSION_BPS = 0;
 
+// Operation fees (one-time, paid from the lifecycle reserve on the PDP rail)
+uint256 constant ADD_PIECES_FEE = (2 * 10 ** TOKEN_DECIMALS) / 1000; // $0.002 per addPieces call
+uint256 constant SCHEDULE_PIECE_REMOVALS_FEE = (2 * 10 ** TOKEN_DECIMALS) / 1000; // $0.002 per schedulePieceRemovals call
+uint256 constant TERMINATE_FEE = (112 * 10 ** TOKEN_DECIMALS) / 100000; // $0.00112 per user-initiated termination
+
+// Lifecycle reserve: fixed lockup on the PDP rail covering per-op fees during wind-down
+uint256 constant LIFECYCLE_RESERVE_TARGET = (10 * 10 ** TOKEN_DECIMALS) / 100; // $0.10
+// Replenish when reserve drops below this; ~25 ops of headroom before we top up again
+uint256 constant REPLENISH_THRESHOLD = (5 * 10 ** TOKEN_DECIMALS) / 1000; // $0.005
+
 /**
  * @notice Calculate a per-epoch rate based on total storage size
  * @dev Adds a fixed per-dataset fee to the size-proportional rate.

--- a/service_contracts/src/lib/PriceListUSDFC.sol
+++ b/service_contracts/src/lib/PriceListUSDFC.sol
@@ -8,8 +8,10 @@ uint256 constant GIB_IN_BYTES = MIB_IN_BYTES * 1024; // 1 GiB in bytes
 uint256 constant TIB_IN_BYTES = GIB_IN_BYTES * 1024; // 1 TiB in bytes
 
 uint256 constant TOKEN_DECIMALS = 18;
-uint256 constant DEFAULT_LOCKUP_PERIOD = 2880 * 30; // 1 month (30 days) in epochs
-uint256 constant EPOCHS_PER_MONTH = 2880 * 30;
+uint256 constant EPOCHS_PER_DAY = 2880;
+uint256 constant DEFAULT_LOCKUP_PERIOD = EPOCHS_PER_DAY * 30;
+uint256 constant CDN_LOCKUP_PERIOD = EPOCHS_PER_DAY * 5; // shorter settle window for FilBeam
+uint256 constant EPOCHS_PER_MONTH = EPOCHS_PER_DAY * 30;
 
 // USDFC has 18 decimals, so $1 = 10**18 (a.k.a. ether)
 uint256 constant STORAGE_PRICE_PER_TIB_PER_MONTH = (5 * 10 ** TOKEN_DECIMALS) / 2; // 2.5 USDFC

--- a/service_contracts/src/lib/PriceListUSDFC.sol
+++ b/service_contracts/src/lib/PriceListUSDFC.sol
@@ -55,5 +55,6 @@ function calculateStorageSizeBasedRatePerEpoch(uint256 totalBytes) pure returns 
  * @return storageRatePerEpoch The storage rate per epoch
  */
 function calculateStorageRate(uint256 leafCount) pure returns (uint256 storageRatePerEpoch) {
+    if (leafCount == 0) return 0;
     return calculateStorageSizeBasedRatePerEpoch(Cids.leafCountToRawSize(leafCount));
 }

--- a/service_contracts/src/lib/PriceListUSDFC.sol
+++ b/service_contracts/src/lib/PriceListUSDFC.sol
@@ -25,6 +25,7 @@ uint256 constant DEFAULT_CACHE_MISS_LOCKUP_AMOUNT = (3 * 10 ** TOKEN_DECIMALS) /
 uint256 constant SERVICE_COMMISSION_BPS = 0;
 
 // Operation fees (one-time, paid from the lifecycle reserve on the PDP rail)
+uint256 constant CREATE_DATA_SET_FEE = (25 * 10 ** TOKEN_DECIMALS) / 10000; // $0.0025 per dataset created
 uint256 constant ADD_PIECES_FEE = (2 * 10 ** TOKEN_DECIMALS) / 1000; // $0.002 per addPieces call
 uint256 constant SCHEDULE_PIECE_REMOVALS_FEE = (2 * 10 ** TOKEN_DECIMALS) / 1000; // $0.002 per schedulePieceRemovals call
 uint256 constant TERMINATE_FEE = (112 * 10 ** TOKEN_DECIMALS) / 100000; // $0.00112 per user-initiated termination

--- a/service_contracts/src/lib/PriceListUSDFC.sol
+++ b/service_contracts/src/lib/PriceListUSDFC.sol
@@ -26,7 +26,8 @@ uint256 constant SERVICE_COMMISSION_BPS = 0;
 
 // Operation fees (one-time, paid from the lifecycle reserve on the PDP rail)
 uint256 constant CREATE_DATA_SET_FEE = (25 * 10 ** TOKEN_DECIMALS) / 10000; // $0.0025 per dataset created
-uint256 constant ADD_PIECES_FEE = (2 * 10 ** TOKEN_DECIMALS) / 1000; // $0.002 per addPieces call
+uint256 constant ADD_PIECES_BASE_FEE = (5 * 10 ** TOKEN_DECIMALS) / 10000; // $0.0005 base per addPieces call
+uint256 constant ADD_PIECES_PER_PIECE_FEE = (3 * 10 ** TOKEN_DECIMALS) / 10000; // $0.0003 per piece added
 uint256 constant SCHEDULE_PIECE_REMOVALS_FEE = (2 * 10 ** TOKEN_DECIMALS) / 1000; // $0.002 per schedulePieceRemovals call
 uint256 constant TERMINATE_FEE = (112 * 10 ** TOKEN_DECIMALS) / 100000; // $0.00112 per user-initiated termination
 

--- a/service_contracts/src/lib/PriceListUSDFC.sol
+++ b/service_contracts/src/lib/PriceListUSDFC.sol
@@ -11,12 +11,7 @@ uint256 constant TOKEN_DECIMALS = 18;
 uint256 constant DEFAULT_LOCKUP_PERIOD = 2880 * 30; // 1 month (30 days) in epochs
 uint256 constant EPOCHS_PER_MONTH = 2880 * 30;
 
-// Client-paid, burned to the FilecoinPay auction pool on data set creation.
-// PDPVerifier's cleanup deposit is SP-paid and refundable but may be locked up
-// for 30 days by FWSS, so this client-side burn is what keeps a client from
-// cheaply locking up an SP's FIL by spawning data sets.
 // USDFC has 18 decimals, so $1 = 10**18 (a.k.a. ether)
-uint256 constant SYBIL_FEE = 0.1 ether;
 uint256 constant STORAGE_PRICE_PER_TIB_PER_MONTH = (5 * 10 ** TOKEN_DECIMALS) / 2; // 2.5 USDFC
 uint256 constant DATASET_FEE_PER_MONTH = (24 * 10 ** TOKEN_DECIMALS) / 1000; // 0.024 USDFC
 uint256 constant DATASET_FEE_PER_EPOCH = DATASET_FEE_PER_MONTH / EPOCHS_PER_MONTH;

--- a/service_contracts/src/lib/Rails.sol
+++ b/service_contracts/src/lib/Rails.sol
@@ -5,6 +5,7 @@ import {Errors} from "../Errors.sol";
 import {FilecoinPayV1} from "@fws-payments/FilecoinPayV1.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {
+    CDN_LOCKUP_PERIOD,
     DATASET_FEE_PER_EPOCH,
     DATASET_FEE_PER_MONTH,
     DEFAULT_CACHE_MISS_LOCKUP_AMOUNT,
@@ -133,7 +134,7 @@ library Rails {
                 0, // no service commission
                 address(this) // controller
             );
-            payments.modifyRailLockup(cacheMissRailId, DEFAULT_LOCKUP_PERIOD, DEFAULT_CACHE_MISS_LOCKUP_AMOUNT);
+            payments.modifyRailLockup(cacheMissRailId, CDN_LOCKUP_PERIOD, DEFAULT_CACHE_MISS_LOCKUP_AMOUNT);
 
             cdnRailId = payments.createRail(
                 usdfcTokenAddress, // token address
@@ -143,7 +144,7 @@ library Rails {
                 0, // no service commission
                 address(this) // controller
             );
-            payments.modifyRailLockup(cdnRailId, DEFAULT_LOCKUP_PERIOD, DEFAULT_CDN_LOCKUP_AMOUNT);
+            payments.modifyRailLockup(cdnRailId, CDN_LOCKUP_PERIOD, DEFAULT_CDN_LOCKUP_AMOUNT);
 
             emit CDNPaymentRailsToppedUp(
                 dataSetId,
@@ -188,8 +189,8 @@ library Rails {
         uint256 totalCacheMissLockup = cacheMissRail.lockupFixed + cacheMissAmountToAdd;
 
         // Only modify rails if amounts are being added
-        payments.modifyRailLockup(cdnRailId, DEFAULT_LOCKUP_PERIOD, totalCdnLockup);
-        payments.modifyRailLockup(cacheMissRailId, DEFAULT_LOCKUP_PERIOD, totalCacheMissLockup);
+        payments.modifyRailLockup(cdnRailId, CDN_LOCKUP_PERIOD, totalCdnLockup);
+        payments.modifyRailLockup(cacheMissRailId, CDN_LOCKUP_PERIOD, totalCacheMissLockup);
         emit CDNPaymentRailsToppedUp(
             dataSetId, cdnAmountToAdd, totalCdnLockup, cacheMissAmountToAdd, totalCacheMissLockup
         );

--- a/service_contracts/src/lib/Rails.sol
+++ b/service_contracts/src/lib/Rails.sol
@@ -217,11 +217,12 @@ library Rails {
         uint256 pdpRailId,
         uint256 leafCount,
         uint96 pending,
-        uint96 reserveBalance
+        uint96 reserveBalance,
+        uint256 pdpEndEpoch
     ) public returns (uint96 newReserveBalance) {
         uint256 newStorageRatePerEpoch = calculateStorageRate(leafCount);
 
-        if (reserveBalance < pending + uint96(REPLENISH_THRESHOLD)) {
+        if (pdpEndEpoch == 0 && reserveBalance < pending + uint96(REPLENISH_THRESHOLD)) {
             payments.modifyRailLockup(pdpRailId, DEFAULT_LOCKUP_PERIOD, uint96(LIFECYCLE_RESERVE_TARGET) + pending);
             newReserveBalance = uint96(LIFECYCLE_RESERVE_TARGET);
         } else {

--- a/service_contracts/src/lib/Rails.sol
+++ b/service_contracts/src/lib/Rails.sol
@@ -11,6 +11,8 @@ import {
     DEFAULT_CDN_LOCKUP_AMOUNT,
     DEFAULT_LOCKUP_PERIOD,
     EPOCHS_PER_MONTH,
+    LIFECYCLE_RESERVE_TARGET,
+    REPLENISH_THRESHOLD,
     SERVICE_COMMISSION_BPS,
     SYBIL_FEE,
     calculateStorageRate
@@ -59,7 +61,8 @@ library Rails {
         // We use multiply-first here to preserve the exact monthly value for cleaner error messages.
         // This is slightly more conservative than the actual rail lockup (which uses the truncated
         // per-epoch rate), but the difference is under 0.0001% and always in the user's favor.
-        uint256 minimumLockupRequired = (DATASET_FEE_PER_MONTH * DEFAULT_LOCKUP_PERIOD) / EPOCHS_PER_MONTH;
+        uint256 minimumLockupRequired =
+            (DATASET_FEE_PER_MONTH * DEFAULT_LOCKUP_PERIOD) / EPOCHS_PER_MONTH + LIFECYCLE_RESERVE_TARGET;
 
         // If CDN is enabled, include the fixed cache-miss and CDN lockup amounts
         if (includeCDN) {
@@ -134,8 +137,8 @@ library Rails {
             address(this)
         );
 
-        // Set lockup period for the rail
-        payments.modifyRailLockup(pdpRailId, DEFAULT_LOCKUP_PERIOD, 0);
+        // Set lockup period and seed the lifecycle reserve
+        payments.modifyRailLockup(pdpRailId, DEFAULT_LOCKUP_PERIOD, LIFECYCLE_RESERVE_TARGET);
 
         // --- Burn rail: extract USDFC sybil fee from client into payments auction pool ---
         burnSybil(payments, usdfcTokenAddress, payer);
@@ -230,11 +233,25 @@ library Rails {
         }
     }
 
-    function updateStorageRates(FilecoinPayV1 payments, uint256 dataSetId, uint256 pdpRailId, uint256 leafCount)
-        public
-    {
+    function updateStorageRates(
+        FilecoinPayV1 payments,
+        uint256 dataSetId,
+        uint256 pdpRailId,
+        uint256 leafCount,
+        uint96 pending,
+        uint96 reserveBalance
+    ) public returns (uint96 newReserveBalance) {
         uint256 newStorageRatePerEpoch = calculateStorageRate(leafCount);
-        payments.modifyRailPayment(pdpRailId, newStorageRatePerEpoch, 0);
+
+        if (reserveBalance < pending + uint96(REPLENISH_THRESHOLD)) {
+            payments.modifyRailLockup(pdpRailId, DEFAULT_LOCKUP_PERIOD, uint96(LIFECYCLE_RESERVE_TARGET) + pending);
+            newReserveBalance = uint96(LIFECYCLE_RESERVE_TARGET);
+        } else {
+            newReserveBalance = reserveBalance - pending;
+        }
+
+        payments.modifyRailPayment(pdpRailId, newStorageRatePerEpoch, pending);
+
         emit RailRateUpdated(dataSetId, pdpRailId, newStorageRatePerEpoch);
     }
 }

--- a/service_contracts/src/lib/Rails.sol
+++ b/service_contracts/src/lib/Rails.sol
@@ -211,6 +211,24 @@ library Rails {
         }
     }
 
+    // Replenishes the rail's fixed lockup when the reserve would drop below REPLENISH_THRESHOLD
+    // after paying pending. Returns the new lockupFixed value (mirrors lifecycleReserveBalance).
+    // Skipped for terminated rails (pdpEndEpoch != 0): modifyRailLockup forbids increases there.
+    function replenishReserveIfNeeded(
+        FilecoinPayV1 payments,
+        uint256 pdpRailId,
+        uint256 pdpEndEpoch,
+        uint96 reserveBalance,
+        uint96 pending
+    ) internal returns (uint96) {
+        if (pdpEndEpoch == 0 && reserveBalance < pending + uint96(REPLENISH_THRESHOLD)) {
+            uint96 newLockup = uint96(LIFECYCLE_RESERVE_TARGET) + pending;
+            payments.modifyRailLockup(pdpRailId, DEFAULT_LOCKUP_PERIOD, newLockup);
+            return newLockup;
+        }
+        return reserveBalance;
+    }
+
     function updateStorageRates(
         FilecoinPayV1 payments,
         uint256 dataSetId,
@@ -221,16 +239,9 @@ library Rails {
         uint256 pdpEndEpoch
     ) public returns (uint96 newReserveBalance) {
         uint256 newStorageRatePerEpoch = calculateStorageRate(leafCount);
-
-        if (pdpEndEpoch == 0 && reserveBalance < pending + uint96(REPLENISH_THRESHOLD)) {
-            payments.modifyRailLockup(pdpRailId, DEFAULT_LOCKUP_PERIOD, uint96(LIFECYCLE_RESERVE_TARGET) + pending);
-            newReserveBalance = uint96(LIFECYCLE_RESERVE_TARGET);
-        } else {
-            newReserveBalance = reserveBalance - pending;
-        }
-
+        newReserveBalance =
+            replenishReserveIfNeeded(payments, pdpRailId, pdpEndEpoch, reserveBalance, pending) - pending;
         payments.modifyRailPayment(pdpRailId, newStorageRatePerEpoch, pending);
-
         emit RailRateUpdated(dataSetId, pdpRailId, newStorageRatePerEpoch);
     }
 }

--- a/service_contracts/src/lib/Rails.sol
+++ b/service_contracts/src/lib/Rails.sol
@@ -14,7 +14,6 @@ import {
     LIFECYCLE_RESERVE_TARGET,
     REPLENISH_THRESHOLD,
     SERVICE_COMMISSION_BPS,
-    SYBIL_FEE,
     calculateStorageRate
 } from "./PriceListUSDFC.sol";
 
@@ -33,21 +32,6 @@ event CDNServiceTerminated(
 event RailRateUpdated(uint256 indexed dataSetId, uint256 railId, uint256 newRate);
 
 library Rails {
-    function burnSybil(FilecoinPayV1 payments, IERC20 token, address payer) internal {
-        uint256 burnRailId = payments.createRail(
-            token,
-            payer, // from: client
-            address(payments), // to: payments contract (auction pool)
-            address(0), // no validator
-            0, // no commission
-            address(0) // service fee recipient (unused, commission=0)
-        );
-        payments.modifyRailLockup(burnRailId, 0, SYBIL_FEE);
-        payments.modifyRailPayment(burnRailId, 0, SYBIL_FEE);
-        payments.terminateRail(burnRailId);
-        payments.settleRail(burnRailId, block.number);
-    }
-
     /// @notice Validates that the payer has sufficient funds and operator approvals for minimum pricing
     /// @param payments The FilecoinPayV1 contract instance
     /// @param payer The address of the payer
@@ -68,9 +52,6 @@ library Rails {
         if (includeCDN) {
             minimumLockupRequired += DEFAULT_CACHE_MISS_LOCKUP_AMOUNT + DEFAULT_CDN_LOCKUP_AMOUNT;
         }
-
-        // Include sybil fee (burn rail lockup consumes funds and lockup allowance)
-        minimumLockupRequired += SYBIL_FEE;
 
         // Check that payer has sufficient available funds
         (,, uint256 availableFunds,) = payments.getAccountInfoIfSettled(usdfcTokenAddress, payer);
@@ -139,9 +120,6 @@ library Rails {
 
         // Set lockup period and seed the lifecycle reserve
         payments.modifyRailLockup(pdpRailId, DEFAULT_LOCKUP_PERIOD, LIFECYCLE_RESERVE_TARGET);
-
-        // --- Burn rail: extract USDFC sybil fee from client into payments auction pool ---
-        burnSybil(payments, usdfcTokenAddress, payer);
 
         cacheMissRailId = 0;
         cdnRailId = 0;

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -23,7 +23,6 @@ import {FilecoinPayV1, IValidator} from "@fws-payments/FilecoinPayV1.sol";
 import {MockERC20, MockPDPVerifier} from "./mocks/SharedMocks.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {Errors} from "../src/Errors.sol";
-import {Errors as PayErrors} from "@fws-payments/Errors.sol";
 import {
     calculateStorageSizeBasedRatePerEpoch,
     DATASET_FEE_PER_EPOCH,
@@ -31,7 +30,6 @@ import {
     EPOCHS_PER_MONTH,
     DEFAULT_LOCKUP_PERIOD,
     LIFECYCLE_RESERVE_TARGET,
-    SYBIL_FEE,
     STORAGE_PRICE_PER_TIB_PER_MONTH,
     CDN_EGRESS_PRICE_PER_TIB,
     CACHE_MISS_EGRESS_PRICE_PER_TIB
@@ -582,10 +580,10 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         );
 
         // Expect DataSetCreated event when creating the data set (with CDN rails)
-        // Rail IDs: burn rail takes ID 2 (then finalized), so pdp=1, cacheMiss=3, cdn=4
+        // Rail IDs: pdp=1, cacheMiss=2, cdn=3
         vm.expectEmit(true, true, true, true);
         emit FilecoinWarmStorageService.DataSetCreated(
-            1, 1, 1, 3, 4, client, serviceProvider, serviceProvider, createData.metadataKeys, createData.metadataValues
+            1, 1, 1, 2, 3, client, serviceProvider, serviceProvider, createData.metadataKeys, createData.metadataValues
         );
 
         // Create a data set as the service provider
@@ -1000,9 +998,9 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
 
     // Minimum Funds Validation Tests
     function testInsufficientFunds_BelowMinimum() public {
-        // Setup: Client with insufficient funds (below 0.224 USDFC minimum = 0.024 dataset fee + 0.1 sybil fee + 0.1 lifecycle reserve)
+        // Setup: Client with insufficient funds (below 0.124 USDFC minimum = 0.024 dataset fee + 0.1 lifecycle reserve)
         address insufficientClient = makeAddr("insufficientClient");
-        uint256 insufficientAmount = 12e16; // 0.12 USDFC (below 0.224 minimum)
+        uint256 insufficientAmount = 12e16; // 0.12 USDFC (below 0.124 minimum)
 
         // Transfer tokens from test contract to the test client
         mockUSDFC.safeTransfer(insufficientClient, insufficientAmount);
@@ -1031,7 +1029,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
             createData.signature
         );
 
-        uint256 minimumRequired = DATASET_FEE_PER_MONTH + SYBIL_FEE + LIFECYCLE_RESERVE_TARGET;
+        uint256 minimumRequired = DATASET_FEE_PER_MONTH + LIFECYCLE_RESERVE_TARGET;
 
         // Expect revert with InsufficientLockupFunds error
         makeSignaturePass(insufficientClient);
@@ -1045,9 +1043,9 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
     }
 
     function testInsufficientFunds_ExactMinimum() public {
-        // Setup: Client with exactly the minimum funds (0.224 USDFC = 0.024 dataset fee + 0.1 sybil fee + 0.1 lifecycle reserve)
+        // Setup: Client with exactly the minimum funds (0.124 USDFC = 0.024 dataset fee + 0.1 lifecycle reserve)
         address exactClient = makeAddr("exactClient");
-        uint256 exactAmount = DATASET_FEE_PER_MONTH + SYBIL_FEE + LIFECYCLE_RESERVE_TARGET; // Exactly 0.224 USDFC
+        uint256 exactAmount = DATASET_FEE_PER_MONTH + LIFECYCLE_RESERVE_TARGET; // Exactly 0.124 USDFC
 
         // Transfer tokens from test contract to the test client
         mockUSDFC.safeTransfer(exactClient, exactAmount);
@@ -1086,9 +1084,9 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
     }
 
     function testInsufficientFunds_JustAboveMinimum() public {
-        // Setup: Client with slightly more than minimum (0.225 USDFC)
+        // Setup: Client with slightly more than minimum (0.125 USDFC)
         address aboveMinClient = makeAddr("aboveMinClient");
-        uint256 aboveMinAmount = DATASET_FEE_PER_MONTH + SYBIL_FEE + LIFECYCLE_RESERVE_TARGET + 1e15; // 0.225 USDFC (just above 0.224 minimum)
+        uint256 aboveMinAmount = DATASET_FEE_PER_MONTH + LIFECYCLE_RESERVE_TARGET + 1e15; // 0.125 USDFC (just above 0.124 minimum)
 
         // Transfer tokens from test contract to the test client
         mockUSDFC.safeTransfer(aboveMinClient, aboveMinAmount);
@@ -1133,7 +1131,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
 
         // Setup: Client with minimal funds - just enough to create an empty dataset
         address limitedClient = makeAddr("limitedClient");
-        uint256 limitedAmount = DATASET_FEE_PER_MONTH + SYBIL_FEE + LIFECYCLE_RESERVE_TARGET + 1e15; // 0.225 USDFC (just above 0.224 minimum)
+        uint256 limitedAmount = DATASET_FEE_PER_MONTH + LIFECYCLE_RESERVE_TARGET + 1e15; // 0.125 USDFC (just above 0.124 minimum)
 
         mockUSDFC.safeTransfer(limitedClient, limitedAmount);
 
@@ -1458,7 +1456,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         address testClient = makeAddr("testClient3");
         uint256 depositAmount = 10e18; // 10 USDFC (plenty of funds)
 
-        uint256 minimumLockupRequired = DATASET_FEE_PER_MONTH + SYBIL_FEE + LIFECYCLE_RESERVE_TARGET;
+        uint256 minimumLockupRequired = DATASET_FEE_PER_MONTH + LIFECYCLE_RESERVE_TARGET;
         uint256 insufficientLockupAllowance = minimumLockupRequired - 1; // Just below minimum
 
         // Transfer tokens and set up approvals
@@ -5506,130 +5504,6 @@ contract FilecoinWarmStorageServiceUpgradeTest is Test {
         // Second call should fail
         vm.expectRevert(abi.encodeWithSignature("InvalidInitialization()"));
         warmStorageService.migrate(address(0));
-    }
-}
-
-/**
- * @notice Tests for USDFC sybil fee burn rail in dataset creation
- */
-contract SybilFeeTest is FilecoinWarmStorageServiceTest {
-    using SafeERC20 for MockERC20;
-
-    function _createClientAndDeposit(string memory name, uint256 amount) internal returns (address clientAddr) {
-        clientAddr = makeAddr(name);
-        mockUSDFC.safeTransfer(clientAddr, amount);
-        vm.startPrank(clientAddr);
-        payments.setOperatorApproval(mockUSDFC, address(pdpServiceWithPayments), true, 1000e18, 1000e18, 365 days);
-        mockUSDFC.approve(address(payments), amount);
-        payments.deposit(mockUSDFC, clientAddr, amount);
-        vm.stopPrank();
-    }
-
-    function _encodeCreateData(address payer, uint256 clientDataSetId) internal pure returns (bytes memory) {
-        string[] memory keys = new string[](0);
-        string[] memory values = new string[](0);
-        return abi.encode(payer, clientDataSetId, keys, values, FAKE_SIGNATURE);
-    }
-
-    function testDataSetCreation_SybilFeeBurned() public {
-        // Setup client with enough funds
-        address testClient = _createClientAndDeposit("sybilClient", 1e18);
-        bytes memory encodedData = _encodeCreateData(testClient, 100);
-
-        // Get balances before
-        (,, uint256 availableBefore,) = payments.getAccountInfoIfSettled(mockUSDFC, testClient);
-
-        // Create dataset
-        makeSignaturePass(testClient);
-        vm.prank(serviceProvider);
-        uint256 dataSetId = mockPDPVerifier.createDataSet(pdpServiceWithPayments, encodedData);
-        assertEq(dataSetId, 1);
-
-        // Verify client funds decreased by sybil fee (plus lockup)
-        (,, uint256 availableAfter,) = payments.getAccountInfoIfSettled(mockUSDFC, testClient);
-        // Available funds decreased by at least the sybil fee
-        assertTrue(availableBefore - availableAfter >= 0.1e18, "Client funds should decrease by at least sybil fee");
-
-        // Verify full sybil fee landed in payments' own account (auction pool)
-        // Both network fee and net payee amount credit accounts[token][address(payments)]
-        (uint256 funds,,,) = payments.accounts(mockUSDFC, address(payments));
-        assertTrue(funds >= 0.1e18, "Payments auction pool should receive full sybil fee");
-    }
-
-    function testDataSetCreation_InsufficientFundsForSybilFee() public {
-        // Setup client with funds below minimum (0.16 USDFC = 0.06 lockup + 0.1 sybil)
-        address testClient = _createClientAndDeposit("poorClient", 10e16); // 0.10 USDFC
-
-        bytes memory encodedData = _encodeCreateData(testClient, 200);
-
-        // Expect revert due to insufficient funds
-        makeSignaturePass(testClient);
-        vm.expectRevert();
-        vm.prank(serviceProvider);
-        mockPDPVerifier.createDataSet(pdpServiceWithPayments, encodedData);
-    }
-
-    function testDataSetCreation_SybilFeeWithCDN() public {
-        // Setup client with enough for sybil + lockup + CDN
-        address testClient = _createClientAndDeposit("cdnClient", 5e18);
-
-        // Create data with CDN metadata
-        string[] memory keys = new string[](1);
-        string[] memory values = new string[](1);
-        keys[0] = "withCDN";
-        values[0] = "true";
-
-        FilecoinWarmStorageService.DataSetCreateData memory createData = FilecoinWarmStorageService.DataSetCreateData({
-            payer: testClient,
-            clientDataSetId: 300,
-            metadataKeys: keys,
-            metadataValues: values,
-            signature: FAKE_SIGNATURE
-        });
-
-        bytes memory encodedData = abi.encode(
-            createData.payer,
-            createData.clientDataSetId,
-            createData.metadataKeys,
-            createData.metadataValues,
-            createData.signature
-        );
-
-        // Create dataset with CDN
-        makeSignaturePass(testClient);
-        vm.prank(serviceProvider);
-        uint256 dataSetId = mockPDPVerifier.createDataSet(pdpServiceWithPayments, encodedData);
-        assertEq(dataSetId, 1);
-
-        // Verify dataset has CDN rails
-        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
-        assertTrue(info.pdpRailId > 0, "PDP rail should exist");
-        assertTrue(info.cacheMissRailId > 0, "Cache miss rail should exist");
-        assertTrue(info.cdnRailId > 0, "CDN rail should exist");
-
-        // Verify full sybil fee landed in payments' own account (auction pool)
-        (uint256 funds,,,) = payments.accounts(mockUSDFC, address(payments));
-        assertTrue(funds >= 0.1e18, "Payments auction pool should receive full sybil fee");
-    }
-
-    function testDataSetCreation_BurnRailTerminated() public {
-        // Setup client
-        address testClient = _createClientAndDeposit("terminateClient", 1e18);
-        bytes memory encodedData = _encodeCreateData(testClient, 400);
-
-        makeSignaturePass(testClient);
-        vm.prank(serviceProvider);
-        uint256 dataSetId = mockPDPVerifier.createDataSet(pdpServiceWithPayments, encodedData);
-        assertEq(dataSetId, 1);
-
-        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
-        assertEq(info.pdpRailId, 1, "PDP rail should be ID 1");
-
-        // The burn rail (ID 2) was terminated and settled in the same tx.
-        // With lockupPeriod=0, finalization zeroes out all rail state.
-        // getRail reverts with RailInactiveOrSettled for finalized rails.
-        vm.expectRevert(abi.encodeWithSelector(PayErrors.RailInactiveOrSettled.selector, 2));
-        payments.getRail(2);
     }
 }
 

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -2042,10 +2042,14 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
         assertTrue(info.pdpEndEpoch > 0, "pdpEndEpoch should be set after termination");
         console.log("PDP termination successful. PDP end epoch:", info.pdpEndEpoch);
-        // Check withCDN metadata is cleared
+        // CDN service persists through the lockup window — metadata and rails still active
         (bool exists, string memory withCDN) = viewContract.getDataSetMetadata(dataSetId, "withCDN");
-        assertFalse(exists, "withCDN metadata should not exist after termination");
-        assertEq(withCDN, "", "withCDN value should be cleared for dataset");
+        assertTrue(exists, "withCDN metadata should still exist after terminateService");
+        assertEq(withCDN, "", "withCDN value should be empty string");
+        FilecoinPayV1.RailView memory cdnRailView = payments.getRail(info.cdnRailId);
+        assertEq(cdnRailView.endEpoch, 0, "CDN rail should still be active after terminateService");
+        FilecoinPayV1.RailView memory cacheMissRailView = payments.getRail(info.cacheMissRailId);
+        assertEq(cacheMissRailView.endEpoch, 0, "Cache miss rail should still be active after terminateService");
 
         // check status remains active (terminated datasets are still Active)
         status = viewContract.getDataSetStatus(dataSetId);
@@ -2137,6 +2141,17 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         assertEq(
             uint256(status), uint256(FilecoinWarmStorageService.DataSetStatus.Inactive), "expected Inactive (deleted)"
         );
+
+        // CDN rails terminated in dataSetDeleted
+        FilecoinPayV1.RailView memory cdnRailAfter = payments.getRail(info.cdnRailId);
+        assertTrue(cdnRailAfter.endEpoch > 0, "CDN rail should be terminated after dataSetDeleted");
+        FilecoinPayV1.RailView memory cacheMissRailAfter = payments.getRail(info.cacheMissRailId);
+        assertTrue(cacheMissRailAfter.endEpoch > 0, "Cache miss rail should be terminated after dataSetDeleted");
+
+        // withCDN metadata cleared as part of dataset cleanup
+        (exists,) = viewContract.getDataSetMetadata(dataSetId, "withCDN");
+        assertFalse(exists, "withCDN metadata should be cleared after dataSetDeleted");
+
         console.log("\n=== Test completed successfully! ===");
     }
 
@@ -2422,9 +2437,20 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         FilecoinPayV1.RailView memory pdpRail = payments.getRail(info.pdpRailId);
         assertTrue(pdpRail.endEpoch > 0, "PDP rail should be terminated");
 
-        // 5. Verify CDN metadata is cleaned up
+        // 5. CDN metadata persists after terminateService; cleared when dataSetDeleted runs
         (bool exists,) = viewContract.getDataSetMetadata(dataSetId, "withCDN");
-        assertFalse(exists, "withCDN flag should be deleted");
+        assertTrue(exists, "withCDN flag should still exist after terminateService");
+
+        // 6. Complete deletion lifecycle and verify metadata is cleared
+        FilecoinWarmStorageService.DataSetInfoView memory terminatedInfo = viewContract.getDataSet(dataSetId);
+        (uint64 maxProvingPeriod,,,) = viewContract.getPDPConfig();
+        vm.roll(terminatedInfo.pdpEndEpoch + maxProvingPeriod + 1);
+        FilecoinPayV1.RailView memory settledPdpRail = payments.getRail(terminatedInfo.pdpRailId);
+        payments.settleRail(terminatedInfo.pdpRailId, settledPdpRail.endEpoch);
+        vm.prank(address(mockPDPVerifier));
+        pdpServiceWithPayments.dataSetDeleted(dataSetId, 0, bytes(""));
+        (bool existsAfter,) = viewContract.getDataSetMetadata(dataSetId, "withCDN");
+        assertFalse(existsAfter, "withCDN metadata should be cleared after dataSetDeleted");
 
         console.log("=== Test completed successfully! ===");
     }
@@ -2507,9 +2533,20 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         FilecoinPayV1.RailView memory pdpRail = payments.getRail(info.pdpRailId);
         assertTrue(pdpRail.endEpoch > 0, "PDP rail should be terminated");
 
-        // 6. Verify CDN metadata is cleaned up
+        // 6. CDN metadata persists after terminateService; cleared when dataSetDeleted runs
         (bool exists,) = viewContract.getDataSetMetadata(dataSetId, "withCDN");
-        assertFalse(exists, "withCDN flag should be deleted");
+        assertTrue(exists, "withCDN flag should still exist after terminateService");
+
+        // 7. Complete deletion lifecycle and verify metadata is cleared
+        FilecoinWarmStorageService.DataSetInfoView memory terminatedInfo = viewContract.getDataSet(dataSetId);
+        (uint64 maxProvingPeriod,,,) = viewContract.getPDPConfig();
+        vm.roll(terminatedInfo.pdpEndEpoch + maxProvingPeriod + 1);
+        FilecoinPayV1.RailView memory settledPdpRail = payments.getRail(terminatedInfo.pdpRailId);
+        payments.settleRail(terminatedInfo.pdpRailId, settledPdpRail.endEpoch);
+        vm.prank(address(mockPDPVerifier));
+        pdpServiceWithPayments.dataSetDeleted(dataSetId, 0, bytes(""));
+        (bool existsAfter,) = viewContract.getDataSetMetadata(dataSetId, "withCDN");
+        assertFalse(existsAfter, "withCDN metadata should be cleared after dataSetDeleted");
 
         console.log("=== Test completed successfully! ===");
     }
@@ -4420,9 +4457,9 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         vm.prank(client);
         pdpServiceWithPayments.terminateService(dataSetId);
 
-        // Verify withCDN metadata is removed
+        // CDN service persists through lockup window — withCDN metadata still present
         (bool exists,) = viewContract.getDataSetMetadata(dataSetId, "withCDN");
-        assertFalse(exists, "withCDN metadata should be removed after service termination");
+        assertTrue(exists, "withCDN metadata should still exist after service termination");
 
         // Should still be able to settle CDN payment rails after termination
         uint256 cdnAmount = 50000;
@@ -4622,12 +4659,19 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         vm.prank(client);
         pdpServiceWithPayments.topUpCDNPaymentRails(dataSetId, cdnTopUp, cacheMissTopUp);
 
-        // Terminate entire service (including CDN rails)
+        // Terminate storage service — CDN rails remain active through the lockup window
         vm.prank(client);
         pdpServiceWithPayments.terminateService(dataSetId);
 
-        // Attempt to top up again (should fail because withCDN metadata was removed)
-        vm.expectRevert(abi.encodeWithSelector(Errors.FilBeamServiceNotConfigured.selector, dataSetId));
+        // Top-up should still succeed: CDN rails are active and withCDN metadata persists
+        vm.expectEmit(true, false, false, true);
+        emit CDNPaymentRailsToppedUp(
+            dataSetId,
+            cdnTopUp,
+            defaultCDNLockup + cdnTopUp + cdnTopUp,
+            cacheMissTopUp,
+            defaultCacheMissLockup + cacheMissTopUp + cacheMissTopUp
+        );
         vm.prank(client);
         pdpServiceWithPayments.topUpCDNPaymentRails(dataSetId, cdnTopUp, cacheMissTopUp);
     }

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -30,6 +30,7 @@ import {
     DATASET_FEE_PER_MONTH,
     EPOCHS_PER_MONTH,
     DEFAULT_LOCKUP_PERIOD,
+    LIFECYCLE_RESERVE_TARGET,
     SYBIL_FEE,
     STORAGE_PRICE_PER_TIB_PER_MONTH,
     CDN_EGRESS_PRICE_PER_TIB,
@@ -636,7 +637,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         assertEq(pdpRail.operator, address(pdpServiceWithPayments), "Operator should be the PDP service");
         assertEq(pdpRail.validator, address(pdpServiceWithPayments), "Validator should be the PDP service");
         assertEq(pdpRail.commissionRateBps, 0, "No commission");
-        assertEq(pdpRail.lockupFixed, 0, "Lockup fixed should be 0 after one-time payment");
+        assertEq(pdpRail.lockupFixed, LIFECYCLE_RESERVE_TARGET, "Lockup fixed should be lifecycle reserve target");
         assertEq(pdpRail.paymentRate, 0, "Initial payment rate should be 0");
 
         FilecoinPayV1.RailView memory cacheMissRail = payments.getRail(cacheMissRailId);
@@ -999,9 +1000,9 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
 
     // Minimum Funds Validation Tests
     function testInsufficientFunds_BelowMinimum() public {
-        // Setup: Client with insufficient funds (below 0.124 USDFC minimum = 0.024 dataset fee + 0.1 sybil fee)
+        // Setup: Client with insufficient funds (below 0.224 USDFC minimum = 0.024 dataset fee + 0.1 sybil fee + 0.1 lifecycle reserve)
         address insufficientClient = makeAddr("insufficientClient");
-        uint256 insufficientAmount = 12e16; // 0.12 USDFC (below 0.124 minimum)
+        uint256 insufficientAmount = 12e16; // 0.12 USDFC (below 0.224 minimum)
 
         // Transfer tokens from test contract to the test client
         mockUSDFC.safeTransfer(insufficientClient, insufficientAmount);
@@ -1030,7 +1031,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
             createData.signature
         );
 
-        uint256 minimumRequired = DATASET_FEE_PER_MONTH + SYBIL_FEE;
+        uint256 minimumRequired = DATASET_FEE_PER_MONTH + SYBIL_FEE + LIFECYCLE_RESERVE_TARGET;
 
         // Expect revert with InsufficientLockupFunds error
         makeSignaturePass(insufficientClient);
@@ -1044,9 +1045,9 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
     }
 
     function testInsufficientFunds_ExactMinimum() public {
-        // Setup: Client with exactly the minimum funds (0.124 USDFC = 0.024 dataset fee + 0.1 sybil fee)
+        // Setup: Client with exactly the minimum funds (0.224 USDFC = 0.024 dataset fee + 0.1 sybil fee + 0.1 lifecycle reserve)
         address exactClient = makeAddr("exactClient");
-        uint256 exactAmount = 124e15; // Exactly 0.124 USDFC
+        uint256 exactAmount = DATASET_FEE_PER_MONTH + SYBIL_FEE + LIFECYCLE_RESERVE_TARGET; // Exactly 0.224 USDFC
 
         // Transfer tokens from test contract to the test client
         mockUSDFC.safeTransfer(exactClient, exactAmount);
@@ -1085,9 +1086,9 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
     }
 
     function testInsufficientFunds_JustAboveMinimum() public {
-        // Setup: Client with slightly more than minimum (0.125 USDFC)
+        // Setup: Client with slightly more than minimum (0.225 USDFC)
         address aboveMinClient = makeAddr("aboveMinClient");
-        uint256 aboveMinAmount = 125e15; // 0.125 USDFC (just above 0.124 minimum)
+        uint256 aboveMinAmount = DATASET_FEE_PER_MONTH + SYBIL_FEE + LIFECYCLE_RESERVE_TARGET + 1e15; // 0.225 USDFC (just above 0.224 minimum)
 
         // Transfer tokens from test contract to the test client
         mockUSDFC.safeTransfer(aboveMinClient, aboveMinAmount);
@@ -1132,7 +1133,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
 
         // Setup: Client with minimal funds - just enough to create an empty dataset
         address limitedClient = makeAddr("limitedClient");
-        uint256 limitedAmount = 125e15; // 0.125 USDFC (just above 0.124 minimum = 0.024 dataset fee + 0.1 sybil fee)
+        uint256 limitedAmount = DATASET_FEE_PER_MONTH + SYBIL_FEE + LIFECYCLE_RESERVE_TARGET + 1e15; // 0.225 USDFC (just above 0.224 minimum)
 
         mockUSDFC.safeTransfer(limitedClient, limitedAmount);
 
@@ -1457,7 +1458,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         address testClient = makeAddr("testClient3");
         uint256 depositAmount = 10e18; // 10 USDFC (plenty of funds)
 
-        uint256 minimumLockupRequired = DATASET_FEE_PER_MONTH + SYBIL_FEE;
+        uint256 minimumLockupRequired = DATASET_FEE_PER_MONTH + SYBIL_FEE + LIFECYCLE_RESERVE_TARGET;
         uint256 insufficientLockupAllowance = minimumLockupRequired - 1; // Just below minimum
 
         // Transfer tokens and set up approvals

--- a/service_contracts/test/OpFees.t.sol
+++ b/service_contracts/test/OpFees.t.sol
@@ -7,6 +7,7 @@ import {FilecoinWarmStorageService} from "../src/FilecoinWarmStorageService.sol"
 import {FilecoinPayV1} from "@fws-payments/FilecoinPayV1.sol";
 import {
     ADD_PIECES_FEE,
+    CREATE_DATA_SET_FEE,
     LIFECYCLE_RESERVE_TARGET,
     SCHEDULE_PIECE_REMOVALS_FEE,
     TERMINATE_FEE
@@ -18,7 +19,7 @@ contract OpFeesTest is FilecoinWarmStorageServiceTest {
 
     // Creates a dataset with one piece added and the first proving period initialized.
     // Returns (dataSetId, pdpRailId, leafCount, firstDeadline, maxProvingPeriod).
-    // On return: pendingOneTimePayments == 0, lifecycleReserveBalance == LIFECYCLE_RESERVE_TARGET - ADD_PIECES_FEE.
+    // On return: pendingOneTimePayments == 0, lifecycleReserveBalance == LIFECYCLE_RESERVE_TARGET - CREATE_DATA_SET_FEE - ADD_PIECES_FEE.
     function _createDataSetWithPiece()
         internal
         returns (uint256 dataSetId, uint256 pdpRailId, uint256 leafCount, uint256 firstDeadline, uint256 maxPeriod)
@@ -65,7 +66,7 @@ contract OpFeesTest is FilecoinWarmStorageServiceTest {
         uint256 pdpRailId = info.pdpRailId;
 
         assertEq(info.lifecycleReserveBalance, LIFECYCLE_RESERVE_TARGET);
-        assertEq(info.pendingOneTimePayments, 0);
+        assertEq(info.pendingOneTimePayments, CREATE_DATA_SET_FEE, "create dataset fee pending");
 
         Cids.Cid[] memory pieces = new Cids.Cid[](1);
         pieces[0] = Cids.CommPv2FromDigest(0, uint8(PIECE_HEIGHT), keccak256("piece0"));
@@ -77,8 +78,12 @@ contract OpFeesTest is FilecoinWarmStorageServiceTest {
         );
 
         info = viewContract.getDataSet(dataSetId);
-        assertEq(info.pendingOneTimePayments, 0, "fee flushed immediately in piecesAdded");
-        assertEq(info.lifecycleReserveBalance, LIFECYCLE_RESERVE_TARGET - ADD_PIECES_FEE, "reserve decreased by fee");
+        assertEq(info.pendingOneTimePayments, 0, "fees flushed immediately in piecesAdded");
+        assertEq(
+            info.lifecycleReserveBalance,
+            LIFECYCLE_RESERVE_TARGET - CREATE_DATA_SET_FEE - ADD_PIECES_FEE,
+            "reserve decreased by both fees"
+        );
 
         FilecoinPayV1.RailView memory rail = payments.getRail(pdpRailId);
         assertEq(rail.lockupFixed, info.lifecycleReserveBalance, "lockupFixed mirrors reserve");

--- a/service_contracts/test/OpFees.t.sol
+++ b/service_contracts/test/OpFees.t.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 pragma solidity ^0.8.20;
 
-import "./FilecoinWarmStorageService.t.sol";
+import {FilecoinWarmStorageServiceTest} from "./FilecoinWarmStorageService.t.sol";
+import {Cids} from "@pdp/Cids.sol";
+import {FilecoinWarmStorageService} from "../src/FilecoinWarmStorageService.sol";
+import {FilecoinPayV1} from "@fws-payments/FilecoinPayV1.sol";
 import {
     ADD_PIECES_FEE,
     LIFECYCLE_RESERVE_TARGET,

--- a/service_contracts/test/OpFees.t.sol
+++ b/service_contracts/test/OpFees.t.sol
@@ -197,7 +197,7 @@ contract OpFeesTest is FilecoinWarmStorageServiceTest {
     }
 
     function test_terminateFee_chargedOnConsentCase() public {
-        (uint256 dataSetId,,,,) = _createDataSetWithPiece();
+        (uint256 dataSetId, uint256 pdpRailId,,,) = _createDataSetWithPiece();
 
         FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
         uint96 reserveBefore = info.lifecycleReserveBalance;
@@ -209,8 +209,9 @@ contract OpFeesTest is FilecoinWarmStorageServiceTest {
         pdpServiceWithPayments.terminateService(dataSetId, abi.encode(FAKE_SIGNATURE));
 
         info = viewContract.getDataSet(dataSetId);
-        assertEq(info.pendingOneTimePayments, TERMINATE_FEE, "fee charged on consent termination");
-        assertEq(info.lifecycleReserveBalance, reserveBefore, "reserve unchanged until flush");
+        assertEq(info.pendingOneTimePayments, 0, "fee flushed at termination");
+        assertEq(info.lifecycleReserveBalance, reserveBefore - TERMINATE_FEE, "reserve decreased by fee");
+        assertEq(payments.getRail(pdpRailId).lockupFixed, info.lifecycleReserveBalance, "lockupFixed mirrors reserve");
     }
 
     function test_terminateFee_notChargedOnPayerDirectCall() public {
@@ -324,10 +325,9 @@ contract OpFeesTest is FilecoinWarmStorageServiceTest {
         );
     }
 
-    // TERMINATE_FEE must flush at nextProvingPeriod even when no piece removals are pending.
+    // TERMINATE_FEE must flush at termination time even when no piece removals are pending.
     function test_terminateFee_flushedWithoutRemovals() public {
-        (uint256 dataSetId, uint256 pdpRailId, uint256 leafCount, uint256 firstDeadline, uint256 maxPeriod) =
-            _createDataSetWithPiece();
+        (uint256 dataSetId, uint256 pdpRailId,,,) = _createDataSetWithPiece();
 
         FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
         uint96 reserveAfterAdd = info.lifecycleReserveBalance;
@@ -338,16 +338,32 @@ contract OpFeesTest is FilecoinWarmStorageServiceTest {
         pdpServiceWithPayments.terminateService(dataSetId, abi.encode(FAKE_SIGNATURE));
 
         info = viewContract.getDataSet(dataSetId);
-        assertEq(info.pendingOneTimePayments, TERMINATE_FEE);
-
-        // Advance proving period with no removals — fee must still flush
-        _advanceProvingPeriod(dataSetId, firstDeadline, maxPeriod, leafCount);
-
-        info = viewContract.getDataSet(dataSetId);
-        assertEq(info.pendingOneTimePayments, 0, "TERMINATE_FEE flushed despite no removals");
+        assertEq(info.pendingOneTimePayments, 0, "TERMINATE_FEE flushed at termination");
         assertEq(info.lifecycleReserveBalance, reserveAfterAdd - TERMINATE_FEE, "reserve decreased by fee");
 
         FilecoinPayV1.RailView memory rail = payments.getRail(pdpRailId);
         assertEq(rail.lockupFixed, info.lifecycleReserveBalance, "lockupFixed mirrors reserve");
+    }
+
+    // CREATE_DATA_SET_FEE must be collected even when the dataset is terminated before any proving.
+    function test_createTerminate_createFeeFlushes() public {
+        uint256 dataSetId = createDataSetForServiceProviderTest(sp1, client, "");
+        uint256 pdpRailId = viewContract.getDataSet(dataSetId).pdpRailId;
+
+        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
+        assertEq(info.pendingOneTimePayments, CREATE_DATA_SET_FEE, "create fee pending before termination");
+        assertEq(info.lifecycleReserveBalance, LIFECYCLE_RESERVE_TARGET);
+
+        vm.prank(client);
+        pdpServiceWithPayments.terminateService(dataSetId);
+
+        info = viewContract.getDataSet(dataSetId);
+        assertEq(info.pendingOneTimePayments, 0, "create fee flushed at termination");
+        assertEq(
+            info.lifecycleReserveBalance,
+            LIFECYCLE_RESERVE_TARGET - CREATE_DATA_SET_FEE,
+            "reserve decreased by create fee"
+        );
+        assertEq(payments.getRail(pdpRailId).lockupFixed, info.lifecycleReserveBalance, "lockupFixed mirrors reserve");
     }
 }

--- a/service_contracts/test/OpFees.t.sol
+++ b/service_contracts/test/OpFees.t.sol
@@ -196,19 +196,32 @@ contract OpFeesTest is FilecoinWarmStorageServiceTest {
         assertEq(rail.lockupFixed, info.lifecycleReserveBalance, "lockupFixed mirrors reserve");
     }
 
-    function test_terminateFee_chargedOnPayerInitiated() public {
+    function test_terminateFee_chargedOnConsentCase() public {
         (uint256 dataSetId,,,,) = _createDataSetWithPiece();
 
         FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
         uint96 reserveBefore = info.lifecycleReserveBalance;
         assertEq(info.pendingOneTimePayments, 0);
 
+        // Consent case: payer signs off-chain, SP submits with signature in extraData
+        makeSignaturePass(client);
+        vm.prank(sp1);
+        pdpServiceWithPayments.terminateService(dataSetId, abi.encode(FAKE_SIGNATURE));
+
+        info = viewContract.getDataSet(dataSetId);
+        assertEq(info.pendingOneTimePayments, TERMINATE_FEE, "fee charged on consent termination");
+        assertEq(info.lifecycleReserveBalance, reserveBefore, "reserve unchanged until flush");
+    }
+
+    function test_terminateFee_notChargedOnPayerDirectCall() public {
+        (uint256 dataSetId,,,,) = _createDataSetWithPiece();
+
+        assertEq(viewContract.getDataSet(dataSetId).pendingOneTimePayments, 0);
+
         vm.prank(client);
         pdpServiceWithPayments.terminateService(dataSetId);
 
-        info = viewContract.getDataSet(dataSetId);
-        assertEq(info.pendingOneTimePayments, TERMINATE_FEE, "fee charged on payer termination");
-        assertEq(info.lifecycleReserveBalance, reserveBefore, "reserve unchanged until flush");
+        assertEq(viewContract.getDataSet(dataSetId).pendingOneTimePayments, 0, "no fee on payer direct termination");
     }
 
     function test_terminateFee_notChargedOnSpInitiated() public {
@@ -319,9 +332,10 @@ contract OpFeesTest is FilecoinWarmStorageServiceTest {
         FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
         uint96 reserveAfterAdd = info.lifecycleReserveBalance;
 
-        // Payer terminates; no removals scheduled
-        vm.prank(client);
-        pdpServiceWithPayments.terminateService(dataSetId);
+        // Consent case: payer signs off-chain, SP submits; no removals scheduled
+        makeSignaturePass(client);
+        vm.prank(sp1);
+        pdpServiceWithPayments.terminateService(dataSetId, abi.encode(FAKE_SIGNATURE));
 
         info = viewContract.getDataSet(dataSetId);
         assertEq(info.pendingOneTimePayments, TERMINATE_FEE);

--- a/service_contracts/test/OpFees.t.sol
+++ b/service_contracts/test/OpFees.t.sol
@@ -44,6 +44,14 @@ contract OpFeesTest is FilecoinWarmStorageServiceTest {
     // Full-BATCH_CAP calls that flush safely before the reserve crosses the replenishment threshold.
     uint256 constant NUM_SAFE_CALLS =
         (LIFECYCLE_RESERVE_TARGET - CREATE_DATA_SET_FEE - REPLENISH_THRESHOLD) / PER_CALL_DRAIN;
+    // Reserve remaining after createDataSet + NUM_SAFE_CALLS batch addPieces (CREATE_DATA_SET_FEE
+    // is folded into the first addPieces flush).
+    uint256 constant RESERVE_AFTER_SAFE_ADD_CALLS =
+        LIFECYCLE_RESERVE_TARGET - CREATE_DATA_SET_FEE - NUM_SAFE_CALLS * PER_CALL_DRAIN;
+    // Complete removal+flush cycles that safely drain SCHEDULE_PIECE_REMOVALS_FEE each before the
+    // reserve falls below the replenishment threshold for the next scheduling call.
+    uint256 constant NUM_SAFE_REMOVAL_CYCLES =
+        (RESERVE_AFTER_SAFE_ADD_CALLS - REPLENISH_THRESHOLD) / SCHEDULE_PIECE_REMOVALS_FEE;
 
     function _buildBatch(uint256 n) internal pure returns (Cids.Cid[] memory pieces) {
         pieces = new Cids.Cid[](n);
@@ -457,6 +465,91 @@ contract OpFeesTest is FilecoinWarmStorageServiceTest {
             new string[](0),
             new string[](0)
         );
+    }
+
+    // With reserve exhausted, piecesScheduledRemove fails at scheduling time (approach 2: replenish
+    // at the operation, not at flush). nextProvingPeriod still succeeds and pays out whatever
+    // fees were already accumulated from the last successful scheduling call.
+    function test_schedulePieceRemoval_depleted_reserve_reverts_remainingPaid() public {
+        address minClient = makeAddr("minClient3");
+        uint256 minAmount = LIFECYCLE_RESERVE_TARGET + 2 * DATASET_FEE_PER_MONTH;
+        require(mockUSDFC.transfer(minClient, minAmount));
+        vm.startPrank(minClient);
+        payments.setOperatorApproval(mockUSDFC, address(pdpServiceWithPayments), true, 1000e18, 1000e18, 365 days);
+        mockUSDFC.approve(address(payments), minAmount);
+        payments.deposit(mockUSDFC, minClient, minAmount);
+        vm.stopPrank();
+
+        bytes memory encodedData =
+            abi.encode(minClient, nextClientDataSetId++, new string[](0), new string[](0), FAKE_SIGNATURE);
+        makeSignaturePass(minClient);
+        vm.prank(sp1);
+        uint256 dataSetId = mockPDPVerifier.createDataSet(pdpServiceWithPayments, encodedData);
+
+        // Drain reserve via NUM_SAFE_CALLS batch addPieces.
+        uint256 added = 0;
+        for (uint256 i = 0; i < NUM_SAFE_CALLS; i++) {
+            makeSignaturePass(minClient);
+            mockPDPVerifier.addPieces(
+                pdpServiceWithPayments,
+                dataSetId,
+                added,
+                _buildBatch(BATCH_CAP),
+                nextClientDataSetId++,
+                FAKE_SIGNATURE,
+                new string[](0),
+                new string[](0)
+            );
+            added += BATCH_CAP;
+        }
+
+        // Initialize proving (pending=0, no drain).
+        (uint256 maxPeriod, uint256 challengeWindow,,) = viewContract.getPDPConfig();
+        uint256 leafCount = added * PIECE_LEAVES;
+        uint256 deadline = block.number + maxPeriod;
+        mockPDPVerifier.nextProvingPeriod(
+            pdpServiceWithPayments, dataSetId, deadline - challengeWindow / 2, leafCount, ""
+        );
+
+        // NUM_SAFE_REMOVAL_CYCLES - 1 complete removal+flush cycles each safely drain the fee.
+        uint256[] memory pieceIds = new uint256[](1);
+        pieceIds[0] = 0;
+        for (uint256 i = 0; i < NUM_SAFE_REMOVAL_CYCLES - 1; i++) {
+            makeSignaturePass(minClient);
+            mockPDPVerifier.piecesScheduledRemove(
+                dataSetId, pieceIds, address(pdpServiceWithPayments), abi.encode(FAKE_SIGNATURE)
+            );
+            deadline = _advanceProvingPeriod(dataSetId, deadline, maxPeriod, leafCount);
+        }
+
+        // One final removal succeeds — reserve still covers it without replenishment.
+        makeSignaturePass(minClient);
+        mockPDPVerifier.piecesScheduledRemove(
+            dataSetId, pieceIds, address(pdpServiceWithPayments), abi.encode(FAKE_SIGNATURE)
+        );
+
+        // With the unflushed fee in pending, the next removal would push accumulated pending
+        // above the replenishment threshold and the payer cannot fund the top-up.
+        assertLt(
+            viewContract.getDataSet(dataSetId).lifecycleReserveBalance,
+            2 * SCHEDULE_PIECE_REMOVALS_FEE + REPLENISH_THRESHOLD,
+            "reserve below trigger for next removal given unflushed pending"
+        );
+        makeSignaturePass(minClient);
+        vm.expectRevert("invariant failure: insufficient funds to cover lockup after function execution");
+        mockPDPVerifier.piecesScheduledRemove(
+            dataSetId, pieceIds, address(pdpServiceWithPayments), abi.encode(FAKE_SIGNATURE)
+        );
+
+        // nextProvingPeriod still succeeds and pays the fee from the last successful removal.
+        uint256 pdpRailId = viewContract.getDataSet(dataSetId).pdpRailId;
+        uint96 reserveBefore = viewContract.getDataSet(dataSetId).lifecycleReserveBalance;
+        deadline = _advanceProvingPeriod(dataSetId, deadline, maxPeriod, leafCount);
+
+        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
+        assertEq(info.pendingOneTimePayments, 0, "pending flushed");
+        assertEq(info.lifecycleReserveBalance, reserveBefore - SCHEDULE_PIECE_REMOVALS_FEE, "fee paid in full");
+        assertEq(payments.getRail(pdpRailId).lockupFixed, info.lifecycleReserveBalance, "lockupFixed mirrors reserve");
     }
 
     // When amount has bits above the uint96 range set, uint96(amount) silently truncates them;

--- a/service_contracts/test/OpFees.t.sol
+++ b/service_contracts/test/OpFees.t.sol
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+pragma solidity ^0.8.20;
+
+import "./FilecoinWarmStorageService.t.sol";
+import {
+    ADD_PIECES_FEE,
+    LIFECYCLE_RESERVE_TARGET,
+    SCHEDULE_PIECE_REMOVALS_FEE,
+    TERMINATE_FEE
+} from "../src/lib/PriceListUSDFC.sol";
+
+contract OpFeesTest is FilecoinWarmStorageServiceTest {
+    uint256 constant PIECE_HEIGHT = 4;
+    uint256 constant PIECE_LEAVES = 1 << PIECE_HEIGHT;
+
+    // Creates a dataset with one piece added and the first proving period initialized.
+    // Returns (dataSetId, pdpRailId, leafCount, firstDeadline, maxProvingPeriod).
+    // On return: pendingOneTimePayments == 0, lifecycleReserveBalance == LIFECYCLE_RESERVE_TARGET - ADD_PIECES_FEE.
+    function _createDataSetWithPiece()
+        internal
+        returns (uint256 dataSetId, uint256 pdpRailId, uint256 leafCount, uint256 firstDeadline, uint256 maxPeriod)
+    {
+        dataSetId = createDataSetForServiceProviderTest(sp1, client, "");
+        pdpRailId = viewContract.getDataSet(dataSetId).pdpRailId;
+        leafCount = PIECE_LEAVES;
+
+        Cids.Cid[] memory pieces = new Cids.Cid[](1);
+        pieces[0] = Cids.CommPv2FromDigest(0, uint8(PIECE_HEIGHT), keccak256("op-fees-piece"));
+        string[] memory keys = new string[](0);
+        string[] memory values = new string[](0);
+        makeSignaturePass(client);
+        mockPDPVerifier.addPieces(
+            pdpServiceWithPayments, dataSetId, 0, pieces, nextClientDataSetId++, FAKE_SIGNATURE, keys, values
+        );
+
+        uint256 challengeWindow;
+        (maxPeriod, challengeWindow,,) = viewContract.getPDPConfig();
+        firstDeadline = block.number + maxPeriod;
+        mockPDPVerifier.nextProvingPeriod(
+            pdpServiceWithPayments, dataSetId, firstDeadline - challengeWindow / 2, leafCount, ""
+        );
+    }
+
+    // Rolls past currentDeadline, calls nextProvingPeriod, and returns the new deadline.
+    function _advanceProvingPeriod(uint256 dataSetId, uint256 currentDeadline, uint256 maxPeriod, uint256 leafCount)
+        internal
+        returns (uint256 newDeadline)
+    {
+        vm.roll(currentDeadline + 1);
+        newDeadline = currentDeadline + maxPeriod;
+        (, uint256 challengeWindow,,) = viewContract.getPDPConfig();
+        mockPDPVerifier.nextProvingPeriod(
+            pdpServiceWithPayments, dataSetId, newDeadline - challengeWindow / 2, leafCount, ""
+        );
+    }
+
+    // -------------------------------------------------------------------------
+
+    function test_addPiecesFee_immediateFlush() public {
+        uint256 dataSetId = createDataSetForServiceProviderTest(sp1, client, "");
+        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
+        uint256 pdpRailId = info.pdpRailId;
+
+        assertEq(info.lifecycleReserveBalance, LIFECYCLE_RESERVE_TARGET);
+        assertEq(info.pendingOneTimePayments, 0);
+
+        Cids.Cid[] memory pieces = new Cids.Cid[](1);
+        pieces[0] = Cids.CommPv2FromDigest(0, uint8(PIECE_HEIGHT), keccak256("piece0"));
+        string[] memory keys = new string[](0);
+        string[] memory values = new string[](0);
+        makeSignaturePass(client);
+        mockPDPVerifier.addPieces(
+            pdpServiceWithPayments, dataSetId, 0, pieces, nextClientDataSetId++, FAKE_SIGNATURE, keys, values
+        );
+
+        info = viewContract.getDataSet(dataSetId);
+        assertEq(info.pendingOneTimePayments, 0, "fee flushed immediately in piecesAdded");
+        assertEq(info.lifecycleReserveBalance, LIFECYCLE_RESERVE_TARGET - ADD_PIECES_FEE, "reserve decreased by fee");
+
+        FilecoinPayV1.RailView memory rail = payments.getRail(pdpRailId);
+        assertEq(rail.lockupFixed, info.lifecycleReserveBalance, "lockupFixed mirrors reserve");
+    }
+
+    function test_scheduledRemovalFee_deferredThenFlushed() public {
+        (uint256 dataSetId, uint256 pdpRailId,, uint256 firstDeadline, uint256 maxPeriod) = _createDataSetWithPiece();
+
+        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
+        uint96 reserveBefore = info.lifecycleReserveBalance;
+
+        uint256[] memory pieceIds = new uint256[](1);
+        pieceIds[0] = 0;
+        makeSignaturePass(client);
+        mockPDPVerifier.piecesScheduledRemove(
+            dataSetId, pieceIds, address(pdpServiceWithPayments), abi.encode(FAKE_SIGNATURE)
+        );
+
+        info = viewContract.getDataSet(dataSetId);
+        assertEq(info.pendingOneTimePayments, SCHEDULE_PIECE_REMOVALS_FEE, "fee pending, not yet flushed");
+        assertEq(info.lifecycleReserveBalance, reserveBefore, "reserve unchanged before flush");
+
+        // nextProvingPeriod processes the removal and flushes the fee
+        _advanceProvingPeriod(dataSetId, firstDeadline, maxPeriod, 0);
+
+        info = viewContract.getDataSet(dataSetId);
+        assertEq(info.pendingOneTimePayments, 0, "fee flushed");
+        assertEq(info.lifecycleReserveBalance, reserveBefore - SCHEDULE_PIECE_REMOVALS_FEE, "reserve decreased by fee");
+
+        FilecoinPayV1.RailView memory rail = payments.getRail(pdpRailId);
+        assertEq(rail.lockupFixed, info.lifecycleReserveBalance, "lockupFixed mirrors reserve");
+    }
+
+    function test_multipleRemovalFees_accumulate() public {
+        (uint256 dataSetId, uint256 pdpRailId, uint256 leafCount, uint256 firstDeadline, uint256 maxPeriod) =
+            _createDataSetWithPiece();
+
+        // Add a second piece
+        Cids.Cid[] memory pieces = new Cids.Cid[](1);
+        pieces[0] = Cids.CommPv2FromDigest(0, uint8(PIECE_HEIGHT), keccak256("piece1"));
+        string[] memory keys = new string[](0);
+        string[] memory values = new string[](0);
+        makeSignaturePass(client);
+        mockPDPVerifier.addPieces(
+            pdpServiceWithPayments, dataSetId, 1, pieces, nextClientDataSetId++, FAKE_SIGNATURE, keys, values
+        );
+        leafCount += PIECE_LEAVES;
+
+        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
+        uint96 reserveBefore = info.lifecycleReserveBalance;
+
+        // Schedule two separate removal batches
+        uint256[] memory ids0 = new uint256[](1);
+        ids0[0] = 0;
+        makeSignaturePass(client);
+        mockPDPVerifier.piecesScheduledRemove(
+            dataSetId, ids0, address(pdpServiceWithPayments), abi.encode(FAKE_SIGNATURE)
+        );
+
+        uint256[] memory ids1 = new uint256[](1);
+        ids1[0] = 1;
+        makeSignaturePass(client);
+        mockPDPVerifier.piecesScheduledRemove(
+            dataSetId, ids1, address(pdpServiceWithPayments), abi.encode(FAKE_SIGNATURE)
+        );
+
+        info = viewContract.getDataSet(dataSetId);
+        assertEq(info.pendingOneTimePayments, 2 * SCHEDULE_PIECE_REMOVALS_FEE, "both fees accumulated");
+
+        _advanceProvingPeriod(dataSetId, firstDeadline, maxPeriod, 0);
+
+        info = viewContract.getDataSet(dataSetId);
+        assertEq(info.pendingOneTimePayments, 0);
+        assertEq(info.lifecycleReserveBalance, reserveBefore - 2 * SCHEDULE_PIECE_REMOVALS_FEE);
+
+        FilecoinPayV1.RailView memory rail = payments.getRail(pdpRailId);
+        assertEq(rail.lockupFixed, info.lifecycleReserveBalance, "lockupFixed mirrors reserve");
+    }
+
+    function test_terminateFee_chargedOnPayerInitiated() public {
+        (uint256 dataSetId,,,,) = _createDataSetWithPiece();
+
+        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
+        uint96 reserveBefore = info.lifecycleReserveBalance;
+        assertEq(info.pendingOneTimePayments, 0);
+
+        vm.prank(client);
+        pdpServiceWithPayments.terminateService(dataSetId);
+
+        info = viewContract.getDataSet(dataSetId);
+        assertEq(info.pendingOneTimePayments, TERMINATE_FEE, "fee charged on payer termination");
+        assertEq(info.lifecycleReserveBalance, reserveBefore, "reserve unchanged until flush");
+    }
+
+    function test_terminateFee_notChargedOnSpInitiated() public {
+        (uint256 dataSetId,,,,) = _createDataSetWithPiece();
+
+        assertEq(viewContract.getDataSet(dataSetId).pendingOneTimePayments, 0);
+
+        vm.prank(sp1);
+        pdpServiceWithPayments.terminateService(dataSetId);
+
+        assertEq(viewContract.getDataSet(dataSetId).pendingOneTimePayments, 0, "no fee on SP-initiated termination");
+    }
+
+    // TERMINATE_FEE must flush at nextProvingPeriod even when no piece removals are pending.
+    function test_terminateFee_flushedWithoutRemovals() public {
+        (uint256 dataSetId, uint256 pdpRailId, uint256 leafCount, uint256 firstDeadline, uint256 maxPeriod) =
+            _createDataSetWithPiece();
+
+        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
+        uint96 reserveAfterAdd = info.lifecycleReserveBalance;
+
+        // Payer terminates; no removals scheduled
+        vm.prank(client);
+        pdpServiceWithPayments.terminateService(dataSetId);
+
+        info = viewContract.getDataSet(dataSetId);
+        assertEq(info.pendingOneTimePayments, TERMINATE_FEE);
+
+        // Advance proving period with no removals — fee must still flush
+        _advanceProvingPeriod(dataSetId, firstDeadline, maxPeriod, leafCount);
+
+        info = viewContract.getDataSet(dataSetId);
+        assertEq(info.pendingOneTimePayments, 0, "TERMINATE_FEE flushed despite no removals");
+        assertEq(info.lifecycleReserveBalance, reserveAfterAdd - TERMINATE_FEE, "reserve decreased by fee");
+
+        FilecoinPayV1.RailView memory rail = payments.getRail(pdpRailId);
+        assertEq(rail.lockupFixed, info.lifecycleReserveBalance, "lockupFixed mirrors reserve");
+    }
+}

--- a/service_contracts/test/OpFees.t.sol
+++ b/service_contracts/test/OpFees.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.20;
 
 import {FilecoinWarmStorageServiceTest} from "./FilecoinWarmStorageService.t.sol";
+import {stdError} from "forge-std/StdError.sol";
 import {Cids} from "@pdp/Cids.sol";
 import {FilecoinWarmStorageService, MAX_ADD_PIECES_EXTRA_DATA_SIZE} from "../src/FilecoinWarmStorageService.sol";
 import {FilecoinPayV1} from "@fws-payments/FilecoinPayV1.sol";
@@ -365,5 +366,37 @@ contract OpFeesTest is FilecoinWarmStorageServiceTest {
             "reserve decreased by create fee"
         );
         assertEq(payments.getRail(pdpRailId).lockupFixed, info.lifecycleReserveBalance, "lockupFixed mirrors reserve");
+    }
+
+    // topUpLifecycleReserve must revert rather than silently wrap around and produce a newBalance
+    // smaller than lifecycleReserveBalance.
+    function test_topUpLifecycleReserve_overflow_reverts() public {
+        uint256 dataSetId = createDataSetForServiceProviderTest(sp1, client, "");
+        uint96 currentBalance = viewContract.getDataSet(dataSetId).lifecycleReserveBalance;
+        // amount chosen so uint96(amount) == amount (no truncation) yet currentBalance + amount overflows uint96
+        uint256 amount = uint256(type(uint96).max) - currentBalance + 1;
+        vm.prank(client);
+        vm.expectRevert(stdError.arithmeticError);
+        pdpServiceWithPayments.topUpLifecycleReserve(dataSetId, amount);
+    }
+
+    // When amount has bits above the uint96 range set, uint96(amount) silently truncates them;
+    // only the lower 96 bits contribute to the balance increase.
+    function test_topUpLifecycleReserve_bit97_truncated() public {
+        uint256 dataSetId = createDataSetForServiceProviderTest(sp1, client, "");
+        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
+        uint256 pdpRailId = info.pdpRailId;
+
+        uint256 topUp = 1e18;
+        // bit 97 is above the uint96 range; uint96(amount) == topUp after truncation
+        uint256 amount = (uint256(1) << 97) | topUp;
+        uint96 expectedBalance = info.lifecycleReserveBalance + uint96(topUp);
+
+        vm.prank(client);
+        pdpServiceWithPayments.topUpLifecycleReserve(dataSetId, amount);
+
+        info = viewContract.getDataSet(dataSetId);
+        assertEq(info.lifecycleReserveBalance, expectedBalance, "upper bits truncated, lower bits applied");
+        assertEq(payments.getRail(pdpRailId).lockupFixed, expectedBalance, "lockupFixed mirrors reserve");
     }
 }

--- a/service_contracts/test/OpFees.t.sol
+++ b/service_contracts/test/OpFees.t.sol
@@ -6,6 +6,7 @@ import {stdError} from "forge-std/StdError.sol";
 import {Cids} from "@pdp/Cids.sol";
 import {FilecoinWarmStorageService, MAX_ADD_PIECES_EXTRA_DATA_SIZE} from "../src/FilecoinWarmStorageService.sol";
 import {FilecoinPayV1} from "@fws-payments/FilecoinPayV1.sol";
+import {Errors} from "../src/Errors.sol";
 import {
     ADD_PIECES_BASE_FEE,
     ADD_PIECES_PER_PIECE_FEE,
@@ -366,6 +367,30 @@ contract OpFeesTest is FilecoinWarmStorageServiceTest {
             "reserve decreased by create fee"
         );
         assertEq(payments.getRail(pdpRailId).lockupFixed, info.lifecycleReserveBalance, "lockupFixed mirrors reserve");
+    }
+
+    function test_topUpLifecycleReserve_nonExistentDataSet_reverts() public {
+        uint256 nonExistentId = 9999;
+        vm.prank(client);
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidDataSetId.selector, nonExistentId));
+        pdpServiceWithPayments.topUpLifecycleReserve(nonExistentId, 1e18);
+    }
+
+    function test_topUpLifecycleReserve_callerNotPayer_reverts() public {
+        uint256 dataSetId = createDataSetForServiceProviderTest(sp1, client, "");
+        address notPayer = makeAddr("notPayer");
+        vm.prank(notPayer);
+        vm.expectRevert(abi.encodeWithSelector(Errors.CallerNotPayer.selector, dataSetId, client, notPayer));
+        pdpServiceWithPayments.topUpLifecycleReserve(dataSetId, 1e18);
+    }
+
+    function test_topUpLifecycleReserve_terminated_reverts() public {
+        uint256 dataSetId = createDataSetForServiceProviderTest(sp1, client, "");
+        vm.prank(client);
+        pdpServiceWithPayments.terminateService(dataSetId);
+        vm.prank(client);
+        vm.expectRevert(abi.encodeWithSelector(Errors.DataSetPaymentAlreadyTerminated.selector, dataSetId));
+        pdpServiceWithPayments.topUpLifecycleReserve(dataSetId, 1e18);
     }
 
     // topUpLifecycleReserve must revert rather than silently wrap around and produce a newBalance

--- a/service_contracts/test/OpFees.t.sol
+++ b/service_contracts/test/OpFees.t.sol
@@ -405,6 +405,60 @@ contract OpFeesTest is FilecoinWarmStorageServiceTest {
         pdpServiceWithPayments.topUpLifecycleReserve(dataSetId, amount);
     }
 
+    // Depleting the reserve prevents addPieces: after NUM_SAFE_CALLS the reserve is too low for
+    // replenishment and one more call reverts.
+    function test_addPieces_depleted_reserve_reverts() public {
+        address minClient = makeAddr("minClient2");
+        uint256 minAmount = LIFECYCLE_RESERVE_TARGET + 2 * DATASET_FEE_PER_MONTH;
+        require(mockUSDFC.transfer(minClient, minAmount));
+        vm.startPrank(minClient);
+        payments.setOperatorApproval(mockUSDFC, address(pdpServiceWithPayments), true, 1000e18, 1000e18, 365 days);
+        mockUSDFC.approve(address(payments), minAmount);
+        payments.deposit(mockUSDFC, minClient, minAmount);
+        vm.stopPrank();
+
+        bytes memory encodedData =
+            abi.encode(minClient, nextClientDataSetId++, new string[](0), new string[](0), FAKE_SIGNATURE);
+        makeSignaturePass(minClient);
+        vm.prank(sp1);
+        uint256 dataSetId = mockPDPVerifier.createDataSet(pdpServiceWithPayments, encodedData);
+
+        uint256 added = 0;
+        for (uint256 i = 0; i < NUM_SAFE_CALLS; i++) {
+            makeSignaturePass(minClient);
+            mockPDPVerifier.addPieces(
+                pdpServiceWithPayments,
+                dataSetId,
+                added,
+                _buildBatch(BATCH_CAP),
+                nextClientDataSetId++,
+                FAKE_SIGNATURE,
+                new string[](0),
+                new string[](0)
+            );
+            added += BATCH_CAP;
+        }
+
+        assertLt(
+            viewContract.getDataSet(dataSetId).lifecycleReserveBalance,
+            REPLENISH_THRESHOLD + PER_CALL_DRAIN,
+            "reserve is now below the replenishment trigger for one more batch"
+        );
+
+        makeSignaturePass(minClient);
+        vm.expectRevert("invariant failure: insufficient funds to cover lockup after function execution");
+        mockPDPVerifier.addPieces(
+            pdpServiceWithPayments,
+            dataSetId,
+            added,
+            _buildBatch(BATCH_CAP),
+            nextClientDataSetId++,
+            FAKE_SIGNATURE,
+            new string[](0),
+            new string[](0)
+        );
+    }
+
     // When amount has bits above the uint96 range set, uint96(amount) silently truncates them;
     // only the lower 96 bits contribute to the balance increase.
     function test_topUpLifecycleReserve_bit97_truncated() public {

--- a/service_contracts/test/OpFees.t.sol
+++ b/service_contracts/test/OpFees.t.sol
@@ -3,12 +3,15 @@ pragma solidity ^0.8.20;
 
 import {FilecoinWarmStorageServiceTest} from "./FilecoinWarmStorageService.t.sol";
 import {Cids} from "@pdp/Cids.sol";
-import {FilecoinWarmStorageService} from "../src/FilecoinWarmStorageService.sol";
+import {FilecoinWarmStorageService, MAX_ADD_PIECES_EXTRA_DATA_SIZE} from "../src/FilecoinWarmStorageService.sol";
 import {FilecoinPayV1} from "@fws-payments/FilecoinPayV1.sol";
 import {
-    ADD_PIECES_FEE,
+    ADD_PIECES_BASE_FEE,
+    ADD_PIECES_PER_PIECE_FEE,
     CREATE_DATA_SET_FEE,
+    DATASET_FEE_PER_MONTH,
     LIFECYCLE_RESERVE_TARGET,
+    REPLENISH_THRESHOLD,
     SCHEDULE_PIECE_REMOVALS_FEE,
     TERMINATE_FEE
 } from "../src/lib/PriceListUSDFC.sol";
@@ -16,10 +19,40 @@ import {
 contract OpFeesTest is FilecoinWarmStorageServiceTest {
     uint256 constant PIECE_HEIGHT = 4;
     uint256 constant PIECE_LEAVES = 1 << PIECE_HEIGHT;
+    // Minimum N such that pending = CREATE_DATA_SET_FEE + ADD_PIECES_BASE_FEE + N * ADD_PIECES_PER_PIECE_FEE
+    // satisfies LIFECYCLE_RESERVE_TARGET < pending + REPLENISH_THRESHOLD, i.e. triggers replenishment.
+    uint256 constant REPLENISH_BATCH = (
+        LIFECYCLE_RESERVE_TARGET - REPLENISH_THRESHOLD - CREATE_DATA_SET_FEE - ADD_PIECES_BASE_FEE
+    ) / ADD_PIECES_PER_PIECE_FEE + 1;
+    // ABI encoding of abi.encode(nonce, allKeys, allValues, sig) with N empty-metadata pieces:
+    //   overhead  = 4*32 (nonce + 3 dynamic offsets)
+    //             + 2*32 (outer array lengths for allKeys and allValues)
+    //             + 32   (signature length word)
+    //             + ceil(FAKE_SIGNATURE.length / 32) * 32 (padded signature data)
+    //   per piece = 4*32 (offset + empty array for each of allKeys[i] and allValues[i])
+    uint256 constant FAKE_SIGNATURE_LEN = 65; // r(32) + s(32) + v(1)
+    // Round up to next 32-byte boundary without divide-then-multiply.
+    uint256 constant FAKE_SIGNATURE_PADDED = FAKE_SIGNATURE_LEN + (32 - FAKE_SIGNATURE_LEN % 32) % 32;
+    uint256 constant ADD_PIECES_EXTRA_DATA_PER_PIECE = 4 * 32;
+    uint256 constant ADD_PIECES_EXTRA_DATA_OVERHEAD = 4 * 32 + 2 * 32 + 32 + FAKE_SIGNATURE_PADDED;
+    uint256 constant BATCH_CAP =
+        (MAX_ADD_PIECES_EXTRA_DATA_SIZE - ADD_PIECES_EXTRA_DATA_OVERHEAD) / ADD_PIECES_EXTRA_DATA_PER_PIECE;
+    // Fee drained by each full-BATCH_CAP addPieces call (CREATE_DATA_SET_FEE only appears in the first call).
+    uint256 constant PER_CALL_DRAIN = ADD_PIECES_BASE_FEE + BATCH_CAP * ADD_PIECES_PER_PIECE_FEE;
+    // Full-BATCH_CAP calls that flush safely before the reserve crosses the replenishment threshold.
+    uint256 constant NUM_SAFE_CALLS =
+        (LIFECYCLE_RESERVE_TARGET - CREATE_DATA_SET_FEE - REPLENISH_THRESHOLD) / PER_CALL_DRAIN;
+
+    function _buildBatch(uint256 n) internal pure returns (Cids.Cid[] memory pieces) {
+        pieces = new Cids.Cid[](n);
+        for (uint256 i = 0; i < n; i++) {
+            pieces[i] = Cids.CommPv2FromDigest(0, uint8(PIECE_HEIGHT), keccak256(abi.encodePacked(i)));
+        }
+    }
 
     // Creates a dataset with one piece added and the first proving period initialized.
     // Returns (dataSetId, pdpRailId, leafCount, firstDeadline, maxProvingPeriod).
-    // On return: pendingOneTimePayments == 0, lifecycleReserveBalance == LIFECYCLE_RESERVE_TARGET - CREATE_DATA_SET_FEE - ADD_PIECES_FEE.
+    // On return: pendingOneTimePayments == 0, lifecycleReserveBalance == LIFECYCLE_RESERVE_TARGET - CREATE_DATA_SET_FEE - ADD_PIECES_BASE_FEE - ADD_PIECES_PER_PIECE_FEE.
     function _createDataSetWithPiece()
         internal
         returns (uint256 dataSetId, uint256 pdpRailId, uint256 leafCount, uint256 firstDeadline, uint256 maxPeriod)
@@ -81,7 +114,7 @@ contract OpFeesTest is FilecoinWarmStorageServiceTest {
         assertEq(info.pendingOneTimePayments, 0, "fees flushed immediately in piecesAdded");
         assertEq(
             info.lifecycleReserveBalance,
-            LIFECYCLE_RESERVE_TARGET - CREATE_DATA_SET_FEE - ADD_PIECES_FEE,
+            LIFECYCLE_RESERVE_TARGET - CREATE_DATA_SET_FEE - ADD_PIECES_BASE_FEE - ADD_PIECES_PER_PIECE_FEE,
             "reserve decreased by both fees"
         );
 
@@ -187,6 +220,95 @@ contract OpFeesTest is FilecoinWarmStorageServiceTest {
         pdpServiceWithPayments.terminateService(dataSetId);
 
         assertEq(viewContract.getDataSet(dataSetId).pendingOneTimePayments, 0, "no fee on SP-initiated termination");
+    }
+
+    function test_addPiecesFee_largeBatch_triggersReplenishment() public {
+        uint256 dataSetId = createDataSetForServiceProviderTest(sp1, client, "");
+
+        uint256 added = 0;
+        for (uint256 i = 0; i < NUM_SAFE_CALLS; i++) {
+            makeSignaturePass(client);
+            mockPDPVerifier.addPieces(
+                pdpServiceWithPayments,
+                dataSetId,
+                added,
+                _buildBatch(BATCH_CAP),
+                nextClientDataSetId++,
+                FAKE_SIGNATURE,
+                new string[](0),
+                new string[](0)
+            );
+            added += BATCH_CAP;
+        }
+        // One more call crosses the threshold and triggers replenishment.
+        makeSignaturePass(client);
+        mockPDPVerifier.addPieces(
+            pdpServiceWithPayments,
+            dataSetId,
+            added,
+            _buildBatch(BATCH_CAP),
+            nextClientDataSetId++,
+            FAKE_SIGNATURE,
+            new string[](0),
+            new string[](0)
+        );
+
+        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
+        assertEq(info.pendingOneTimePayments, 0, "fees flushed");
+        assertEq(info.lifecycleReserveBalance, LIFECYCLE_RESERVE_TARGET, "reserve replenished to target");
+
+        FilecoinPayV1.RailView memory rail = payments.getRail(info.pdpRailId);
+        assertEq(rail.lockupFixed, LIFECYCLE_RESERVE_TARGET, "lockupFixed reflects replenishment");
+    }
+
+    function test_addPiecesFee_largeBatch_revertsInsufficientFunds() public {
+        // Client has just enough for safe flushes (lifecycle reserve + 2× dataset fee covers
+        // the rate-based lockup from adding pieces) but not enough for replenishment
+        // (which needs ≈ LIFECYCLE_RESERVE_TARGET - REPLENISH_THRESHOLD ≈ 0.095 USDFC more).
+        address minClient = makeAddr("minClient");
+        uint256 minAmount = LIFECYCLE_RESERVE_TARGET + 2 * DATASET_FEE_PER_MONTH;
+        require(mockUSDFC.transfer(minClient, minAmount));
+        vm.startPrank(minClient);
+        payments.setOperatorApproval(mockUSDFC, address(pdpServiceWithPayments), true, 1000e18, 1000e18, 365 days);
+        mockUSDFC.approve(address(payments), minAmount);
+        payments.deposit(mockUSDFC, minClient, minAmount);
+        vm.stopPrank();
+
+        string[] memory emptyKeys = new string[](0);
+        string[] memory emptyValues = new string[](0);
+        bytes memory encodedData = abi.encode(minClient, nextClientDataSetId++, emptyKeys, emptyValues, FAKE_SIGNATURE);
+        makeSignaturePass(minClient);
+        vm.prank(sp1);
+        uint256 dataSetId = mockPDPVerifier.createDataSet(pdpServiceWithPayments, encodedData);
+
+        uint256 added = 0;
+        for (uint256 i = 0; i < NUM_SAFE_CALLS; i++) {
+            makeSignaturePass(minClient);
+            mockPDPVerifier.addPieces(
+                pdpServiceWithPayments,
+                dataSetId,
+                added,
+                _buildBatch(BATCH_CAP),
+                nextClientDataSetId++,
+                FAKE_SIGNATURE,
+                new string[](0),
+                new string[](0)
+            );
+            added += BATCH_CAP;
+        }
+
+        makeSignaturePass(minClient);
+        vm.expectRevert("invariant failure: insufficient funds to cover lockup after function execution");
+        mockPDPVerifier.addPieces(
+            pdpServiceWithPayments,
+            dataSetId,
+            added,
+            _buildBatch(BATCH_CAP),
+            nextClientDataSetId++,
+            FAKE_SIGNATURE,
+            new string[](0),
+            new string[](0)
+        );
     }
 
     // TERMINATE_FEE must flush at nextProvingPeriod even when no piece removals are pending.

--- a/service_contracts/tools/check_storage_layout.sh
+++ b/service_contracts/tools/check_storage_layout.sh
@@ -61,6 +61,35 @@ validate_layout_json() {
     return 0
 }
 
+# Check if two typeDetails JSON blobs are compatible, allowing struct members to be appended.
+# Struct members appended at higher slot numbers are permitted; all other changes are not.
+typedetails_compatible() {
+    local base_td="$1"
+    local new_td="$2"
+
+    local result
+    result=$(jq -n --argjson base "$base_td" --argjson new "$new_td" '
+        def compatible:
+            .base as $base | .new as $new |
+            if $base == $new then true
+            elif (($base | type) == "object") and (($new | type) == "object") then
+                if (($base | has("encoding")) and $base.encoding == "inplace" and ($base | has("members"))) and
+                   (($new  | has("encoding")) and $new.encoding  == "inplace" and ($new  | has("members"))) then
+                    ($base.label == $new.label) and
+                    (($new.members | length) >= ($base.members | length)) and
+                    ($base.members == ($new.members[0:($base.members | length)]))
+                else
+                    (($base | keys_unsorted) == ($new | keys_unsorted)) and
+                    (reduce ($base | keys_unsorted[]) as $k (true; . and ({base: $base[$k], new: $new[$k]} | compatible)))
+                end
+            else $base == $new
+            end;
+        {base: $base, new: $new} | compatible
+    ' 2>/dev/null)
+
+    [ "$result" = "true" ]
+}
+
 # Compare two JSON layout files and detect destructive changes
 compare_layouts() {
     local base_file="$1"
@@ -136,12 +165,15 @@ compare_layouts() {
         fi
 
         if [ "$type_comparison" != "$new_type_comparison" ]; then
-            if [ "$type" = "$new_type" ]; then
+            if typedetails_compatible "$type_comparison" "$new_type_comparison"; then
+                : # struct member(s) appended — allowed
+            elif [ "$type" = "$new_type" ]; then
                 echo "  DESTRUCTIVE: Variable '$label' type details changed within '$type' (slot $slot)" >&2
+                errors=$((errors + 1))
             else
                 echo "  DESTRUCTIVE: Variable '$label' type changed from '$type' to '$new_type' (slot $slot)" >&2
+                errors=$((errors + 1))
             fi
-            errors=$((errors + 1))
         fi
     done < <(jq -c '.[]' "$base_file")
 


### PR DESCRIPTION

Reviewer @rvagg
Implements #469
One difficulty of this task is that one-time payments have to come from the fixed lockup, and, after termination, the lockup cannot be increased further.
One design goal is to avoid reading `getRail`, which reads many fields.
Another goal is to limit the additional calls to `modifyRailPayment` and `modifyRailLockup`.
The main approach is to aggregate the fees into batches.
Fixed lockup is replenished when the lockup (lifecycle reserve) gets low.
It can also be prefunded by `topUpLifecycleReserve`
I also remove the sybil fee (briefly discussed [here](https://github.com/FilOzone/filecoin-services/issues/469#issuecomment-4558269399)) in a separate commit (allowing an easy revert if necessary).
#### Changes
* remove sybil fee
* add create dataset fee, add pieces fee, remove pieces fee, and terminate dataset fee
* add `topUpLifecycleReserve`