### PR TITLE
fix(fwss): remove PDPVerifier sybil fee dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [1.2.1] - TBD - FWSS Hotfix
+
+This hotfix restores FWSS compatibility with PDPVerifier v3.4.0.
+
+### Fixed
+- Replaced the FWSS dependency on `IPDPVerifier.USDFC_SYBIL_FEE()` with a local `0.1 USDFC` sybil-fee constant during data-set creation and pre-flight lockup validation. This preserves the FWSS v1.2.0 sybil-fee burn rail while remaining compatible with PDPVerifier v3.4.0, which removed that getter.
+
+### Upgrade Notes
+- Existing FWSS proxy addresses remain unchanged.
+- New data-set creation still requires enough USDFC funds and lockup allowance for the FWSS `0.1 USDFC` sybil fee.
+- Curio/SP software also needs to send the 0.1 FIL cleanup deposit required by PDPVerifier v3.4.0 when creating new data sets.
+
 ## [1.2.0] - 2026-03-23 - FWSS Upgrade
 
 This release improves data set creation and data set query behavior in FWSS, while fixing proving-period settlement logic and clarifying funding requirements for new data sets.

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -60,7 +60,7 @@ contract FilecoinWarmStorageService is
     EIP712Upgradeable
 {
     // Version tracking
-    string public constant VERSION = "1.2.0";
+    string public constant VERSION = "1.2.1";
 
     // =========================================================================
     // Events
@@ -199,6 +199,7 @@ contract FilecoinWarmStorageService is
     uint256 private constant GIB_IN_BYTES = MIB_IN_BYTES * 1024; // 1 GiB in bytes
     uint256 private constant TIB_IN_BYTES = GIB_IN_BYTES * 1024; // 1 TiB in bytes
     uint256 private constant EPOCHS_PER_MONTH = 2880 * 30;
+    uint256 private constant SYBIL_FEE = 0.1 ether; // 0.1 USDFC
 
     // Metadata size and count limits
     uint256 private constant MAX_KEY_LENGTH = 32;
@@ -694,7 +695,6 @@ contract FilecoinWarmStorageService is
 
         // --- Burn rail: extract USDFC sybil fee from client into payments auction pool ---
         {
-            uint256 sybilFee = IPDPVerifier(pdpVerifierAddress).USDFC_SYBIL_FEE();
             uint256 burnRailId = payments.createRail(
                 usdfcTokenAddress,
                 createData.payer, // from: client
@@ -703,8 +703,8 @@ contract FilecoinWarmStorageService is
                 0, // no commission
                 address(0) // service fee recipient (unused, commission=0)
             );
-            payments.modifyRailLockup(burnRailId, 0, sybilFee);
-            payments.modifyRailPayment(burnRailId, 0, sybilFee);
+            payments.modifyRailLockup(burnRailId, 0, SYBIL_FEE);
+            payments.modifyRailPayment(burnRailId, 0, SYBIL_FEE);
             payments.terminateRail(burnRailId);
             payments.settleRail(burnRailId, block.number);
         }
@@ -1249,7 +1249,7 @@ contract FilecoinWarmStorageService is
         }
 
         // Include sybil fee (burn rail lockup consumes funds and lockup allowance)
-        minimumLockupRequired += IPDPVerifier(pdpVerifierAddress).USDFC_SYBIL_FEE();
+        minimumLockupRequired += SYBIL_FEE;
 
         // Check that payer has sufficient available funds
         (,, uint256 availableFunds,) = payments.getAccountInfoIfSettled(usdfcTokenAddress, payer);

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -5345,7 +5345,7 @@ contract FilecoinWarmStorageServiceUpgradeTest is Test {
             if (logs[i].topics[0] == expectedTopic) {
                 // Decode and verify the event data
                 (string memory version, address implementation) = abi.decode(logs[i].data, (string, address));
-                assertEq(version, "1.2.0", "Version should be 1.2.0");
+                assertEq(version, "1.2.1", "Version should be 1.2.1");
                 assertTrue(implementation != address(0), "Implementation address should not be zero");
                 foundEvent = true;
                 break;
@@ -5366,9 +5366,9 @@ contract FilecoinWarmStorageServiceUpgradeTest is Test {
 }
 
 /**
- * @notice Tests for USDFC sybil fee burn rail in dataset creation
+ * @notice Tests for USDFC sybil fee burn rail in dataset creation.
  */
-contract SybilFeeTest is FilecoinWarmStorageServiceTest {
+contract PDPVerifierV34CompatibilityTest is FilecoinWarmStorageServiceTest {
     using SafeERC20 for MockERC20;
 
     function _createClientAndDeposit(string memory name, uint256 amount) internal returns (address clientAddr) {
@@ -5387,13 +5387,14 @@ contract SybilFeeTest is FilecoinWarmStorageServiceTest {
         return abi.encode(payer, clientDataSetId, keys, values, FAKE_SIGNATURE);
     }
 
-    function testDataSetCreation_SybilFeeBurned() public {
+    function testDataSetCreation_SybilFeeBurnedWithoutPDPVerifierGetter() public {
         // Setup client with enough funds
-        address testClient = _createClientAndDeposit("sybilClient", 1e18);
+        address testClient = _createClientAndDeposit("pdpV34Client", 1e18);
         bytes memory encodedData = _encodeCreateData(testClient, 100);
 
-        // Get balances before
+        // MockPDPVerifier intentionally does not expose USDFC_SYBIL_FEE().
         (,, uint256 availableBefore,) = payments.getAccountInfoIfSettled(mockUSDFC, testClient);
+        (uint256 paymentsFundsBefore,,,) = payments.accounts(mockUSDFC, address(payments));
 
         // Create dataset
         makeSignaturePass(testClient);
@@ -5403,13 +5404,14 @@ contract SybilFeeTest is FilecoinWarmStorageServiceTest {
 
         // Verify client funds decreased by sybil fee (plus lockup)
         (,, uint256 availableAfter,) = payments.getAccountInfoIfSettled(mockUSDFC, testClient);
-        // Available funds decreased by at least the sybil fee
         assertTrue(availableBefore - availableAfter >= 0.1e18, "Client funds should decrease by at least sybil fee");
 
         // Verify full sybil fee landed in payments' own account (auction pool)
         // Both network fee and net payee amount credit accounts[token][address(payments)]
-        (uint256 funds,,,) = payments.accounts(mockUSDFC, address(payments));
-        assertTrue(funds >= 0.1e18, "Payments auction pool should receive full sybil fee");
+        (uint256 paymentsFundsAfter,,,) = payments.accounts(mockUSDFC, address(payments));
+        assertTrue(
+            paymentsFundsAfter - paymentsFundsBefore >= 0.1e18, "Payments auction pool should receive full sybil fee"
+        );
     }
 
     function testDataSetCreation_InsufficientFundsForSybilFee() public {

--- a/service_contracts/test/mocks/SharedMocks.sol
+++ b/service_contracts/test/mocks/SharedMocks.sol
@@ -95,7 +95,6 @@ contract MockERC20 is IERC20, IERC20Metadata {
 
 // MockPDPVerifier is used to simulate the PDPVerifier for our tests
 contract MockPDPVerifier {
-    uint256 public USDFC_SYBIL_FEE = 0.1e18;
     uint256 public nextDataSetId = 1;
 
     // Track data set service providers for testing


### PR DESCRIPTION
## Summary

Hotfixes the FWSS v1.2.x release line for PDPVerifier v3.4.0 compatibility.

PDPVerifier v3.4.0 removed the `USDFC_SYBIL_FEE()` getter. Deployed FWSS v1.2.0 still called `IPDPVerifier.USDFC_SYBIL_FEE()` during data-set creation and pre-flight lockup validation, causing new data-set creation to revert after the PDPVerifier upgrade.

This PR preserves the FWSS v1.2.0 sybil-fee behavior, but stops reading the value from PDPVerifier:
- bumps FWSS `VERSION` to `1.2.1`
- adds a local FWSS `SYBIL_FEE = 0.1 ether` constant
- keeps the FWSS-side USDFC sybil-fee burn rail
- keeps the sybil fee in FWSS lockup validation
- updates tests so the mock PDPVerifier no longer exposes `USDFC_SYBIL_FEE()`, which catches accidental reintroduction of the removed getter dependency
- adds a v1.2.1 changelog draft

Related:
- Closes #490
- PDP incident thread: FilOzone/pdp#278

## Validation

- `forge test --match-contract 'FilecoinWarmStorageServiceTest|PDPVerifierV34CompatibilityTest|FilecoinWarmStorageServiceUpgradeTest'`
  - 231 passed, 0 failed
- `forge test`
  - 603 passed, 0 failed