### PR TITLE
fix: trigger Synapse SDK update on published releases

### DIFF
--- a/.github/workflows/notify-synapse-sdk.yml
+++ b/.github/workflows/notify-synapse-sdk.yml
@@ -1,6 +1,8 @@
 name: Update Synapse SDK
 
 on:
+  release:
+    types: [published]
   push:
     tags:
       - 'v*'
@@ -55,12 +57,17 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           REF_NAME: ${{ github.ref_name }}
           REF_TYPE: ${{ github.ref_type }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
           INPUT_TAG: ${{ inputs.tag }}
           INPUT_SHA: ${{ inputs.sha }}
         run: |
           set -euo pipefail
 
           tag="$REF_NAME"
+          if [ "$EVENT_NAME" = "release" ] && [ -n "$RELEASE_TAG" ]; then
+            tag="$RELEASE_TAG"
+          fi
+
           if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUT_TAG" ]; then
             tag="$INPUT_TAG"
           fi


### PR DESCRIPTION
## Summary

- Trigger the Synapse SDK update workflow when a GitHub Release is published.
- Keep the existing tag-push and manual dispatch paths.
- Resolve the release tag from the release event payload when applicable.

## Why

The `v1.2.1` release publication emitted a `release: published` event, but the workflow only listened for tag pushes and manual dispatches, so no Synapse SDK PR was created.
