### PR TITLE
feat(pricing): set createDataSet fee to $0.025

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository contains smart contracts and services for the Filecoin ecosystem
 The service uses static global pricing set by the contract owner (currently 2.5 USDFC per TiB/month).
 Rail payment rates are calculated as a size-proportional component plus a flat per-dataset fee of 0.024 USDFC/month.
 
-Storage providers submit on-chain transactions on behalf of clients (piece additions, removal scheduling, proving). To reimburse SPs for these gas costs, FWSS charges small one-time operation fees: $0.0025 on dataset creation, $0.0005 + $0.0003/piece per add-pieces call, $0.002 per removal-scheduling call, and $0.00112 when an SP terminates service with payer consent. Fees are drawn from a $0.10 lifecycle reserve maintained as fixed lockup on the PDP rail.
+Storage providers submit on-chain transactions on behalf of clients (piece additions, removal scheduling, proving). To reimburse SPs for these gas costs, FWSS charges small one-time operation fees: $0.025 on dataset creation, $0.0005 + $0.0003/piece per add-pieces call, $0.002 per removal-scheduling call, and $0.00112 when an SP terminates service with payer consent. Fees are drawn from a $0.10 lifecycle reserve maintained as fixed lockup on the PDP rail.
 
 See [SPEC.md](SPEC.md) for details on rate calculation, operation fees, pricing updates, and top-up/renewal behavior.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -37,7 +37,7 @@ In addition to the ongoing storage rate, FWSS charges one-time fees for specific
 
 | Operation | Fee | Trigger | Recipient |
 |---|---|---|---|
-| Create dataset | $0.0025 | `dataSetCreated` callback | SP |
+| Create dataset | $0.025 | `dataSetCreated` callback | SP |
 | Add pieces | $0.0005 + $0.0003 × n | `piecesAdded` callback (n = piece count) | SP |
 | Schedule piece removals | $0.002 | `piecesScheduledRemove` callback | SP |
 | Terminate service (consent) | $0.00112 | SP-initiated termination with payer EIP-712 signature | SP |

--- a/service_contracts/src/lib/PriceListUSDFC.sol
+++ b/service_contracts/src/lib/PriceListUSDFC.sol
@@ -27,7 +27,7 @@ uint256 constant DEFAULT_CACHE_MISS_LOCKUP_AMOUNT = (3 * 10 ** TOKEN_DECIMALS) /
 uint256 constant SERVICE_COMMISSION_BPS = 0;
 
 // Operation fees (one-time, paid from the lifecycle reserve on the PDP rail)
-uint256 constant CREATE_DATA_SET_FEE = (25 * 10 ** TOKEN_DECIMALS) / 10000; // $0.0025 per dataset created
+uint256 constant CREATE_DATA_SET_FEE = (25 * 10 ** TOKEN_DECIMALS) / 1000; // $0.025 per dataset created
 uint256 constant ADD_PIECES_BASE_FEE = (5 * 10 ** TOKEN_DECIMALS) / 10000; // $0.0005 base per addPieces call
 uint256 constant ADD_PIECES_PER_PIECE_FEE = (3 * 10 ** TOKEN_DECIMALS) / 10000; // $0.0003 per piece added
 uint256 constant SCHEDULE_PIECE_REMOVALS_FEE = (2 * 10 ** TOKEN_DECIMALS) / 1000; // $0.002 per schedulePieceRemovals call


### PR DESCRIPTION
With the sybil burn removed, this fee is now the economic friction against frivolous dataset creation. 10x keeps it negligible for legitimate use (single-copy $0.025, 2-copy $0.05) while meaningfully compensating the SP and adding a slight behavioural disincentive.