### PR TITLE
refactor(pricing): rename "minimum" to "required" in payer validation

### DIFF
--- a/service_contracts/abi/Errors.abi.json
+++ b/service_contracts/abi/Errors.abi.json
@@ -286,7 +286,7 @@
         "internalType": "uint256"
       },
       {
-        "name": "minimumLockupRequired",
+        "name": "lockupRequired",
         "type": "uint256",
         "internalType": "uint256"
       }
@@ -302,7 +302,7 @@
         "internalType": "address"
       },
       {
-        "name": "minimumRequired",
+        "name": "required",
         "type": "uint256",
         "internalType": "uint256"
       },
@@ -364,7 +364,7 @@
         "internalType": "uint256"
       },
       {
-        "name": "minimumRateRequired",
+        "name": "rateRequired",
         "type": "uint256",
         "internalType": "uint256"
       }

--- a/service_contracts/src/Errors.sol
+++ b/service_contracts/src/Errors.sol
@@ -308,35 +308,35 @@ library Errors {
     /// @param productType The kind of service product attempted to be registered
     error InsufficientCapabilitiesForProduct(ServiceProviderRegistryStorage.ProductType productType);
 
-    /// @notice Payer has insufficient available funds to cover the minimum storage rate
+    /// @notice Payer has insufficient available funds to cover the required lockup
     /// @param payer The payer address
-    /// @param minimumRequired The minimum lockup required to cover the minimum storage rate
+    /// @param required The lockup required for dataset creation
     /// @param available The available funds in the payer's account
-    error InsufficientLockupFunds(address payer, uint256 minimumRequired, uint256 available);
+    error InsufficientLockupFunds(address payer, uint256 required, uint256 available);
 
     /// @notice Operator is not approved for the payer
     /// @param payer The payer address
     /// @param operator The operator address (warm storage service)
     error OperatorNotApproved(address payer, address operator);
 
-    /// @notice Operator has insufficient rate allowance for the minimum storage rate
+    /// @notice Operator has insufficient rate allowance to cover the per-dataset fee rate
     /// @param payer The payer address
     /// @param operator The operator address (warm storage service)
     /// @param rateAllowance The total rate allowance approved
     /// @param rateUsage The current rate usage
-    /// @param minimumRateRequired The minimum rate required per epoch
+    /// @param rateRequired The rate required per epoch
     error InsufficientRateAllowance(
-        address payer, address operator, uint256 rateAllowance, uint256 rateUsage, uint256 minimumRateRequired
+        address payer, address operator, uint256 rateAllowance, uint256 rateUsage, uint256 rateRequired
     );
 
-    /// @notice Operator has insufficient lockup allowance for the minimum lockup
+    /// @notice Operator has insufficient lockup allowance to cover the required lockup
     /// @param payer The payer address
     /// @param operator The operator address (warm storage service)
     /// @param lockupAllowance The total lockup allowance approved
     /// @param lockupUsage The current lockup usage
-    /// @param minimumLockupRequired The minimum lockup required
+    /// @param lockupRequired The required lockup
     error InsufficientLockupAllowance(
-        address payer, address operator, uint256 lockupAllowance, uint256 lockupUsage, uint256 minimumLockupRequired
+        address payer, address operator, uint256 lockupAllowance, uint256 lockupUsage, uint256 lockupRequired
     );
 
     /// @notice Operator's max lockup period is insufficient for the default lockup period

--- a/service_contracts/src/lib/Rails.sol
+++ b/service_contracts/src/lib/Rails.sol
@@ -33,7 +33,10 @@ event CDNServiceTerminated(
 event RailRateUpdated(uint256 indexed dataSetId, uint256 railId, uint256 newRate);
 
 library Rails {
-    /// @notice Validates that the payer has sufficient funds and operator approvals for minimum pricing
+    /// @notice Validates the payer is set up to add pieces, not just create the dataset.
+    /// @dev    The lifecycle reserve is consumed at creation; the per-dataset fee headroom is only
+    ///         consumed once pieces are added. Empty datasets leave it as approved headroom.
+    ///         Required up front intentionally: creation assumes pieces will follow.
     /// @param payments The FilecoinPayV1 contract instance
     /// @param payer The address of the payer
     function validatePayerOperatorApprovalAndFunds(
@@ -42,24 +45,21 @@ library Rails {
         address payer,
         bool includeCDN
     ) internal view {
-        // Calculate required lockup for the per-dataset fee.
-        // We use multiply-first here to preserve the exact monthly value for cleaner error messages.
-        // This is slightly more conservative than the actual rail lockup (which uses the truncated
-        // per-epoch rate), but the difference is under 0.0001% and always in the user's favor.
-        uint256 minimumLockupRequired =
+        // Required capacity: lifecycle reserve plus per-dataset fee lockup at the default period.
+        // Multiply-first preserves the exact monthly value for cleaner error messages; slightly
+        // more conservative than the actual rail lockup (truncated per-epoch), within 0.0001%
+        // and always in the user's favor.
+        uint256 requiredLockup =
             (DATASET_FEE_PER_MONTH * DEFAULT_LOCKUP_PERIOD) / EPOCHS_PER_MONTH + LIFECYCLE_RESERVE_TARGET;
 
         // If CDN is enabled, include the fixed cache-miss and CDN lockup amounts
         if (includeCDN) {
-            minimumLockupRequired += DEFAULT_CACHE_MISS_LOCKUP_AMOUNT + DEFAULT_CDN_LOCKUP_AMOUNT;
+            requiredLockup += DEFAULT_CACHE_MISS_LOCKUP_AMOUNT + DEFAULT_CDN_LOCKUP_AMOUNT;
         }
 
         // Check that payer has sufficient available funds
         (,, uint256 availableFunds,) = payments.getAccountInfoIfSettled(usdfcTokenAddress, payer);
-        require(
-            availableFunds >= minimumLockupRequired,
-            Errors.InsufficientLockupFunds(payer, minimumLockupRequired, availableFunds)
-        );
+        require(availableFunds >= requiredLockup, Errors.InsufficientLockupFunds(payer, requiredLockup, availableFunds));
 
         // Check operator approval settings
         (
@@ -74,20 +74,18 @@ library Rails {
         // Verify operator is approved
         require(isApproved, Errors.OperatorNotApproved(payer, address(this)));
 
-        uint256 minimumRatePerEpoch = DATASET_FEE_PER_EPOCH;
-
-        // Verify rate allowance is sufficient
+        // Rate-allowance headroom for the per-dataset fee rate: the floor of any non-empty
+        // dataset's rate (size-proportional component sits on top). Empty datasets never consume
+        // it; required up front for the dataset to be eligible to receive pieces.
         require(
-            rateAllowance >= rateUsage + minimumRatePerEpoch,
-            Errors.InsufficientRateAllowance(payer, address(this), rateAllowance, rateUsage, minimumRatePerEpoch)
+            rateAllowance >= rateUsage + DATASET_FEE_PER_EPOCH,
+            Errors.InsufficientRateAllowance(payer, address(this), rateAllowance, rateUsage, DATASET_FEE_PER_EPOCH)
         );
 
         // Verify lockup allowance is sufficient
         require(
-            lockupAllowance >= lockupUsage + minimumLockupRequired,
-            Errors.InsufficientLockupAllowance(
-                payer, address(this), lockupAllowance, lockupUsage, minimumLockupRequired
-            )
+            lockupAllowance >= lockupUsage + requiredLockup,
+            Errors.InsufficientLockupAllowance(payer, address(this), lockupAllowance, lockupUsage, requiredLockup)
         );
 
         // Verify max lockup period is sufficient
@@ -106,7 +104,7 @@ library Rails {
         address filBeamBeneficiaryAddress
     ) public returns (uint256 pdpRailId, uint256 cacheMissRailId, uint256 cdnRailId) {
         bool hasCDN = filBeamBeneficiaryAddress != address(0);
-        // Validate payer has sufficient funds and operator approvals for minimum pricing
+        // Validate payer has sufficient funds and operator approvals to cover the required lockup
         // If CDN is enabled, validation must account for the additional fixed lockup amounts
         validatePayerOperatorApprovalAndFunds(payments, usdfcTokenAddress, payer, hasCDN);
 

--- a/service_contracts/src/lib/Rails.sol
+++ b/service_contracts/src/lib/Rails.sol
@@ -38,7 +38,9 @@ library Rails {
     ///         consumed once pieces are added. Empty datasets leave it as approved headroom.
     ///         Required up front intentionally: creation assumes pieces will follow.
     /// @param payments The FilecoinPayV1 contract instance
+    /// @param usdfcTokenAddress The USDFC token used for deposits and operator approvals
     /// @param payer The address of the payer
+    /// @param includeCDN Whether to include fixed CDN/cache-miss lockups in the requirement checks
     function validatePayerOperatorApprovalAndFunds(
         FilecoinPayV1 payments,
         IERC20 usdfcTokenAddress,

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -1029,13 +1029,13 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
             createData.signature
         );
 
-        uint256 minimumRequired = DATASET_FEE_PER_MONTH + LIFECYCLE_RESERVE_TARGET;
+        uint256 required = DATASET_FEE_PER_MONTH + LIFECYCLE_RESERVE_TARGET;
 
         // Expect revert with InsufficientLockupFunds error
         makeSignaturePass(insufficientClient);
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.InsufficientLockupFunds.selector, insufficientClient, minimumRequired, insufficientAmount
+                Errors.InsufficientLockupFunds.selector, insufficientClient, required, insufficientAmount
             )
         );
         vm.prank(serviceProvider);
@@ -1456,8 +1456,8 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         address testClient = makeAddr("testClient3");
         uint256 depositAmount = 10e18; // 10 USDFC (plenty of funds)
 
-        uint256 minimumLockupRequired = DATASET_FEE_PER_MONTH + LIFECYCLE_RESERVE_TARGET;
-        uint256 insufficientLockupAllowance = minimumLockupRequired - 1; // Just below minimum
+        uint256 lockupRequired = DATASET_FEE_PER_MONTH + LIFECYCLE_RESERVE_TARGET;
+        uint256 insufficientLockupAllowance = lockupRequired - 1; // Just below required
 
         // Transfer tokens and set up approvals
         mockUSDFC.safeTransfer(testClient, depositAmount);
@@ -1503,7 +1503,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
                 address(pdpServiceWithPayments),
                 insufficientLockupAllowance,
                 0, // lockupUsage is 0 initially
-                minimumLockupRequired
+                lockupRequired
             )
         );
         vm.prank(serviceProvider);


### PR DESCRIPTION
Cosmetic, for clarification purposes since I noticed that some of the old floor price language carried over so I want to clear that up. Shouldn't change the event signatures even though the param names are changing.

Pre-flight checks aren't enforcing minimum charges, they verify the payer has approved capacity to add pieces later. Empty datasets leave the per-dataset fee headroom untouched; required up front intentionally so creation assumes pieces can follow. Error selectors unchanged (computed from types, not names).