### PR TITLE
fix(metadata): remove addPieces extraData byte cap, adjust limits

### DIFF
--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -49,12 +49,6 @@ uint256 constant COMMISSION_MAX_BPS = 10000; // 100% in basis points
 uint256 constant MAX_CREATE_DATA_SET_EXTRA_DATA_SIZE = 4096; // 4 KiB
 
 /*
-* Maximum extraData for addPieces
-* Supports: 5 pieces with full metadata, or 61 pieces with no metadata
-*/
-uint256 constant MAX_ADD_PIECES_EXTRA_DATA_SIZE = 8192; // 8 KiB
-
-/*
 * Maximum extraData for schedulePieceRemovals
 * Supports: signature (160 bytes needed)
 */
@@ -219,9 +213,9 @@ contract FilecoinWarmStorageService is
 
     // Metadata size and count limits
     uint256 private constant MAX_KEY_LENGTH = 32;
-    uint256 private constant MAX_VALUE_LENGTH = 128;
+    uint256 private constant MAX_VALUE_LENGTH = 96;
     uint256 private constant MAX_KEYS_PER_DATASET = 10;
-    uint256 private constant MAX_KEYS_PER_PIECE = 5;
+    uint256 private constant MAX_KEYS_PER_PIECE = 3;
 
     // Metadata key constants
     string private constant METADATA_KEY_WITH_CDN = "withCDN";
@@ -730,7 +724,7 @@ contract FilecoinWarmStorageService is
         address payer = info.payer;
         uint256 len = extraData.length;
         require(len > 0, Errors.ExtraDataRequired());
-        require(len <= MAX_ADD_PIECES_EXTRA_DATA_SIZE, Errors.ExtraDataTooLarge(len, MAX_ADD_PIECES_EXTRA_DATA_SIZE));
+        // PDPVerifier currently hits the FVM PiecesAdded event size limit before FWSS needs a byte cap.
         // Decode the extra data
         (uint256 nonce, string[][] memory metadataKeys, string[][] memory metadataValues, bytes memory signature) =
             abi.decode(extraData, (uint256, string[][], string[][], bytes));

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -11,7 +11,6 @@ import {SessionKeyRegistry} from "@session-key-registry/SessionKeyRegistry.sol";
 
 import {
     CHALLENGES_PER_PROOF,
-    MAX_ADD_PIECES_EXTRA_DATA_SIZE,
     MAX_CREATE_DATA_SET_EXTRA_DATA_SIZE,
     FilecoinWarmStorageService
 } from "../src/FilecoinWarmStorageService.sol";
@@ -80,9 +79,9 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
 
     // Metadata size and count limits
     uint256 private constant MAX_KEY_LENGTH = 32;
-    uint256 private constant MAX_VALUE_LENGTH = 128;
+    uint256 private constant MAX_VALUE_LENGTH = 96;
     uint256 private constant MAX_KEYS_PER_DATASET = 10;
-    uint256 private constant MAX_KEYS_PER_PIECE = 5;
+    uint256 private constant MAX_KEYS_PER_PIECE = 3;
 
     bytes32 private constant CREATE_DATA_SET_TYPEHASH = keccak256(
         "CreateDataSet(uint256 clientDataSetId,address payee,MetadataEntry[] metadata)"
@@ -2916,11 +2915,11 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
     }
 
     function testDataSetMetadataValueLengthBoundaries() public {
-        // Test value lengths: just below max (127), at max (128), and exceeding max (129)
+        // Test value lengths: just below max, at max, and exceeding max
         uint256[] memory valueLengths = new uint256[](3);
-        valueLengths[0] = 127; // Just below max
-        valueLengths[1] = 128; // At max
-        valueLengths[2] = 129; // Exceeds max
+        valueLengths[0] = MAX_VALUE_LENGTH - 1; // Just below max
+        valueLengths[1] = MAX_VALUE_LENGTH; // At max
+        valueLengths[2] = MAX_VALUE_LENGTH + 1; // Exceeds max
 
         for (uint256 i = 0; i < valueLengths.length; i++) {
             uint256 valueLength = valueLengths[i];
@@ -2929,7 +2928,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
             metadataKeys[0] = "key";
             metadataValues[0] = _makeStringOfLength(valueLength);
 
-            if (valueLength <= 128) {
+            if (valueLength <= MAX_VALUE_LENGTH) {
                 // Should succeed for valid lengths
                 uint256 dataSetId = createDataSetForClient(sp1, client, metadataKeys, metadataValues);
 
@@ -2956,7 +2955,9 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
                 bytes memory encodedData = prepareDataSetForClient(sp1, client, metadataKeys, metadataValues);
                 vm.prank(sp1);
                 vm.expectRevert(
-                    abi.encodeWithSelector(Errors.MetadataValueExceedsMaxLength.selector, 0, 128, valueLength)
+                    abi.encodeWithSelector(
+                        Errors.MetadataValueExceedsMaxLength.selector, 0, MAX_VALUE_LENGTH, valueLength
+                    )
                 );
                 mockPDPVerifier.createDataSet(pdpServiceWithPayments, encodedData);
             }
@@ -3042,8 +3043,8 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
                 //key must be unique with length 32 bytes
                 metadataKeys[i] = _generateKey(i);
                 assertEq(bytes(metadataKeys[i]).length, 32, "Key length should be 32 bytes");
-                // Max key length
-                metadataValues[i] = _makeStringOfLength(128); // Max value length
+                // Max key and value lengths
+                metadataValues[i] = _makeStringOfLength(MAX_VALUE_LENGTH);
             }
 
             if (keyCount <= MAX_KEYS_PER_DATASET) {
@@ -3066,9 +3067,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
                 bytes memory encodedData = prepareDataSetForClient(sp1, client, metadataKeys, metadataValues);
                 vm.prank(sp1);
                 vm.expectRevert(
-                    abi.encodeWithSelector(
-                        Errors.ExtraDataTooLarge.selector, encodedData.length, MAX_CREATE_DATA_SET_EXTRA_DATA_SIZE
-                    )
+                    abi.encodeWithSelector(Errors.TooManyMetadataKeys.selector, MAX_KEYS_PER_DATASET, keyCount)
                 );
                 mockPDPVerifier.createDataSet(pdpServiceWithPayments, encodedData);
             }
@@ -3207,11 +3206,11 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
     function testPieceMetadataValueLengthBoundaries() public {
         uint256 pieceId = 42;
 
-        // Test value lengths: just below max (127), at max (128), and exceeding max (129)
+        // Test value lengths: just below max, at max, and exceeding max
         uint256[] memory valueLengths = new uint256[](3);
-        valueLengths[0] = 127; // Just below max
-        valueLengths[1] = 128; // At max
-        valueLengths[2] = 129; // Exceeds max
+        valueLengths[0] = MAX_VALUE_LENGTH - 1; // Just below max
+        valueLengths[1] = MAX_VALUE_LENGTH; // At max
+        valueLengths[2] = MAX_VALUE_LENGTH + 1; // Exceeds max
 
         for (uint256 i = 0; i < valueLengths.length; i++) {
             uint256 valueLength = valueLengths[i];
@@ -3235,7 +3234,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
             allValues[0] = values;
             bytes memory encodedData = abi.encode(pieceId + i + 4000, allKeys, allValues, FAKE_SIGNATURE);
 
-            if (valueLength <= 128) {
+            if (valueLength <= MAX_VALUE_LENGTH) {
                 // Should succeed for valid lengths
                 vm.expectEmit(true, false, false, true);
                 emit FilecoinWarmStorageService.PieceAdded(dataSetId, pieceId + i, pieceData[0], keys, values);
@@ -3259,7 +3258,9 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
             } else {
                 // Should fail for exceeding max
                 vm.expectRevert(
-                    abi.encodeWithSelector(Errors.MetadataValueExceedsMaxLength.selector, 0, 128, valueLength)
+                    abi.encodeWithSelector(
+                        Errors.MetadataValueExceedsMaxLength.selector, 0, MAX_VALUE_LENGTH, valueLength
+                    )
                 );
                 vm.prank(address(mockPDPVerifier));
                 pdpServiceWithPayments.piecesAdded(dataSetId, pieceId + i, pieceData, encodedData);
@@ -3272,9 +3273,9 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
 
         // Test key counts: just below max, at max, and exceeding max
         uint256[] memory keyCounts = new uint256[](3);
-        keyCounts[0] = MAX_KEYS_PER_PIECE - 1; // Just below max (4)
-        keyCounts[1] = MAX_KEYS_PER_PIECE; // At max (5)
-        keyCounts[2] = MAX_KEYS_PER_PIECE + 1; // Exceeds max (6)
+        keyCounts[0] = MAX_KEYS_PER_PIECE - 1; // Just below max
+        keyCounts[1] = MAX_KEYS_PER_PIECE; // At max
+        keyCounts[2] = MAX_KEYS_PER_PIECE + 1; // Exceeds max
 
         for (uint256 testIdx = 0; testIdx < keyCounts.length; testIdx++) {
             uint256 keyCount = keyCounts[testIdx];
@@ -3364,7 +3365,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
                     // Generate globally unique keys by combining piece index and key index
                     keys[k] = _generateKey(p * 1000 + k);
                     assertEq(bytes(keys[k]).length, 32, "Key length should be 32 bytes");
-                    values[k] = _makeStringOfLength(128); // max value length
+                    values[k] = _makeStringOfLength(MAX_VALUE_LENGTH);
                 }
 
                 allKeys[p] = keys;
@@ -3399,7 +3400,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
                 for (uint256 k = 0; k < keyCount; k++) {
                     // Ensure uniqueness across all pieces
                     keys[k] = _generateKey(p * 1000 + k + 1);
-                    values[k] = _makeStringOfLength(128);
+                    values[k] = _makeStringOfLength(MAX_VALUE_LENGTH);
                 }
 
                 allKeys[p] = keys;
@@ -3409,12 +3410,10 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
             uint256 nonce = pieceId + 2000;
             bytes memory encodedData = abi.encode(nonce, allKeys, allValues, FAKE_SIGNATURE);
 
-            // Expect revert when at least one piece has too many keys or extraData becomes too large
+            // Expect revert when at least one piece has too many keys
             vm.prank(address(mockPDPVerifier));
             vm.expectRevert(
-                abi.encodeWithSelector(
-                    Errors.ExtraDataTooLarge.selector, encodedData.length, MAX_ADD_PIECES_EXTRA_DATA_SIZE
-                )
+                abi.encodeWithSelector(Errors.TooManyMetadataKeys.selector, MAX_KEYS_PER_PIECE, MAX_KEYS_PER_PIECE + 1)
             );
             pdpServiceWithPayments.piecesAdded(dataSetId, pieceId + totalPieces, pieceData, encodedData);
             console.log("encodedData length (exceeding limits):", encodedData.length);

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -11,7 +11,6 @@ import {SessionKeyRegistry} from "@session-key-registry/SessionKeyRegistry.sol";
 
 import {
     CHALLENGES_PER_PROOF,
-    MAX_CREATE_DATA_SET_EXTRA_DATA_SIZE,
     FilecoinWarmStorageService
 } from "../src/FilecoinWarmStorageService.sol";
 import {FilecoinWarmStorageServiceStateView} from "../src/FilecoinWarmStorageServiceStateView.sol";

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -9,10 +9,7 @@ import {Cids} from "@pdp/Cids.sol";
 import {MyERC1967Proxy} from "@pdp/ERC1967Proxy.sol";
 import {SessionKeyRegistry} from "@session-key-registry/SessionKeyRegistry.sol";
 
-import {
-    CHALLENGES_PER_PROOF,
-    FilecoinWarmStorageService
-} from "../src/FilecoinWarmStorageService.sol";
+import {CHALLENGES_PER_PROOF, FilecoinWarmStorageService} from "../src/FilecoinWarmStorageService.sol";
 import {FilecoinWarmStorageServiceStateView} from "../src/FilecoinWarmStorageServiceStateView.sol";
 import {SignatureVerificationLib} from "../src/lib/SignatureVerificationLib.sol";
 import {FilecoinWarmStorageServiceStateLibrary} from "../src/lib/FilecoinWarmStorageServiceStateLibrary.sol";

--- a/service_contracts/test/OpFees.t.sol
+++ b/service_contracts/test/OpFees.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 import {FilecoinWarmStorageServiceTest} from "./FilecoinWarmStorageService.t.sol";
 import {stdError} from "forge-std/StdError.sol";
 import {Cids} from "@pdp/Cids.sol";
-import {FilecoinWarmStorageService, MAX_ADD_PIECES_EXTRA_DATA_SIZE} from "../src/FilecoinWarmStorageService.sol";
+import {FilecoinWarmStorageService} from "../src/FilecoinWarmStorageService.sol";
 import {FilecoinPayV1} from "@fws-payments/FilecoinPayV1.sol";
 import {Errors} from "../src/Errors.sol";
 import {
@@ -26,19 +26,8 @@ contract OpFeesTest is FilecoinWarmStorageServiceTest {
     uint256 constant REPLENISH_BATCH = (
         LIFECYCLE_RESERVE_TARGET - REPLENISH_THRESHOLD - CREATE_DATA_SET_FEE - ADD_PIECES_BASE_FEE
     ) / ADD_PIECES_PER_PIECE_FEE + 1;
-    // ABI encoding of abi.encode(nonce, allKeys, allValues, sig) with N empty-metadata pieces:
-    //   overhead  = 4*32 (nonce + 3 dynamic offsets)
-    //             + 2*32 (outer array lengths for allKeys and allValues)
-    //             + 32   (signature length word)
-    //             + ceil(FAKE_SIGNATURE.length / 32) * 32 (padded signature data)
-    //   per piece = 4*32 (offset + empty array for each of allKeys[i] and allValues[i])
-    uint256 constant FAKE_SIGNATURE_LEN = 65; // r(32) + s(32) + v(1)
-    // Round up to next 32-byte boundary without divide-then-multiply.
-    uint256 constant FAKE_SIGNATURE_PADDED = FAKE_SIGNATURE_LEN + (32 - FAKE_SIGNATURE_LEN % 32) % 32;
-    uint256 constant ADD_PIECES_EXTRA_DATA_PER_PIECE = 4 * 32;
-    uint256 constant ADD_PIECES_EXTRA_DATA_OVERHEAD = 4 * 32 + 2 * 32 + 32 + FAKE_SIGNATURE_PADDED;
-    uint256 constant BATCH_CAP =
-        (MAX_ADD_PIECES_EXTRA_DATA_SIZE - ADD_PIECES_EXTRA_DATA_OVERHEAD) / ADD_PIECES_EXTRA_DATA_PER_PIECE;
+    // Current upstream ceiling from PDPVerifier's PiecesAdded event under the FVM event value limit.
+    uint256 constant BATCH_CAP = 41;
     // Fee drained by each full-BATCH_CAP addPieces call (CREATE_DATA_SET_FEE only appears in the first call).
     uint256 constant PER_CALL_DRAIN = ADD_PIECES_BASE_FEE + BATCH_CAP * ADD_PIECES_PER_PIECE_FEE;
     // Full-BATCH_CAP calls that flush safely before the reserve crosses the replenishment threshold.


### PR DESCRIPTION
Drop the FWSS addPieces extraData size limit since batch size is bounded upstream by PDPVerifier/FVM event size.

Tighten piece metadata limits to 3 keys per piece and 96 bytes per value, and update tests for the new boundaries. This keeps gas low enough to provide a (relatively) stable 40 piece limit even with metadata; limit can be hard-applied in SP & SDK software for clearer errors to users.

Ref: https://app.notion.com/p/filecoindev/addPieces-Batch-Limits-and-Proposed-Changes-36ddc41950c180d39f45f0da8982090c