### PR TITLE
feat: cleanup abandoned data set

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -125,6 +125,8 @@ Each proving period is in one of three states:
 - **Faulted**: Deadline has passed with no proof. Settlement advances but payment is zero.
 - **Open**: Deadline has not yet passed, no proof. Settlement is blocked at the period boundary because the provider may still submit a proof.
 
+When `provingActivationEpoch == 0` (data set created, possibly populated, but the SP has not yet called `nextProvingPeriod`), `validatePayment()` short-circuits with zero payment and `settleUpto = toEpoch`, so settlement can advance through pre-activation epochs. Without this, `settleRail()` reverts with `NoProgressInSettlement` on never-activated data sets.
+
 ### Partial-Period Settlement (FilecoinPay Rate Changes)
 
 Where base rail rate changes have occurred (e.g. pieces were added mid-period, changing the payment rate), FilecoinPay settles each rate "segment" independently (see `_settleWithRateChanges`). Each segment gets its own `validatePayment()` call with a `toEpoch` that may fall anywhere within a proving period. So `validatePayment()` must be able to handle settlement of near-arbitrary ranges (see `_findProvenEpochs`).
@@ -155,6 +157,8 @@ If the dataset has CDN rails (`withCDN` metadata set), `terminateService` also t
 
 Client-initiated termination of a zero-rate rail (a CDN rail called directly on FilecoinPay) is permitted because `isAccountLockupFullySettled` is trivially true when the payment rate is zero. For a non-zero-rate rail like the PDP rail, a client whose account has fallen behind on lockup settlement cannot call `FilecoinPay.terminateRail` directly. However, `terminateService` on FWSS still works for the payer, because FWSS is the caller of `terminateRail` in that path.
 
+Data sets can also reach teardown without `terminateService` via the abandonment path; see below.
+
 ### Dataset Deletion Requirements
 
 Dataset deletion (`dataSetDeleted`) requires the payment rail to be fully settled before the dataset can be removed:
@@ -180,6 +184,8 @@ require(settledUpTo >= endEpoch, RailNotFullySettled)
 **State cleared**: The `dataSetDeleted` callback removes `dataSetInfo`, `provingDeadlines`, `provenThisPeriod`, `provingActivationEpoch`, `railToDataSet[pdpRailId]`, the dataset's entry in `clientDataSets[payer]`, and all `dataSetMetadata` entries. `clientNonces[payer][nonce]` is **not** cleared. It is retained to prevent replay of authorization signatures.
 
 **CDN rails are not checked**: The settled-up-to requirement above and the `pdpEndEpoch` checks in the timing list both apply to the PDP rail only. FWSS does not verify CDN rail termination or settlement before allowing dataset deletion, because it does not track the CDN rails' `endEpoch` (there is no validator callback to set it). In the normal flow this is safe: CDN rails are terminated in the same `terminateService` call that initiates PDP rail termination.
+
+**Abandonment path**: When `pdpEndEpoch == 0` (the SP never called `terminateService`), the data set can still be deleted once inactive for `INACTIVITY_WINDOW` (30 days from `lastProvenEpoch`, or from `provingActivationEpoch` for activated-but-never-proven data sets). PDPVerifier gates this: SP-only within the window, permissionless after. FWSS layers its own `_verifyInactivity` check on top so the SP cannot use this path to skip `terminateService` on an active data set. Inline teardown via `Rails.abandonRails` settles the PDP rail (advancing through unproven epochs via the pre-activation short-circuit), releases the lifecycle reserve and streaming buffer back to the payer, terminates and finalises the rail, and best-efforts the CDN rails. The SP forfeits any pending one-time op-fees; this is intentional, since the SP walked away.
 
 ## CDN Payment Rails
 

--- a/service_contracts/abi/Errors.abi.json
+++ b/service_contracts/abi/Errors.abi.json
@@ -150,6 +150,27 @@
   },
   {
     "type": "error",
+    "name": "DataSetNotAbandoned",
+    "inputs": [
+      {
+        "name": "dataSetId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "requiredEpoch",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "currentBlock",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
     "name": "DataSetNotFoundForRail",
     "inputs": [
       {

--- a/service_contracts/abi/FilecoinWarmStorageService.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageService.abi.json
@@ -949,37 +949,6 @@
   },
   {
     "type": "event",
-    "name": "DataSetAbandoned",
-    "inputs": [
-      {
-        "name": "dataSetId",
-        "type": "uint256",
-        "indexed": true,
-        "internalType": "uint256"
-      },
-      {
-        "name": "pdpRailId",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "cacheMissRailId",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "cdnRailId",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
     "name": "DataSetCreated",
     "inputs": [
       {

--- a/service_contracts/abi/FilecoinWarmStorageService.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageService.abi.json
@@ -949,6 +949,37 @@
   },
   {
     "type": "event",
+    "name": "DataSetAbandoned",
+    "inputs": [
+      {
+        "name": "dataSetId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "pdpRailId",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "cacheMissRailId",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "cdnRailId",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "DataSetCreated",
     "inputs": [
       {
@@ -1424,6 +1455,27 @@
     "inputs": [
       {
         "name": "clientDataSetId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "DataSetNotAbandoned",
+    "inputs": [
+      {
+        "name": "dataSetId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "requiredEpoch",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "currentBlock",
         "type": "uint256",
         "internalType": "uint256"
       }

--- a/service_contracts/src/Errors.sol
+++ b/service_contracts/src/Errors.sol
@@ -351,4 +351,10 @@ library Errors {
     error ProviderIdMismatchAtIndex(uint256 index, uint256 providerId);
 
     error StorageProviderChangesNotSupported();
+
+    /// @notice The data set has not been inactive for the required inactivity window
+    /// @param dataSetId The data set ID
+    /// @param requiredEpoch The first epoch at which abandonment is allowed
+    /// @param currentBlock The current block number
+    error DataSetNotAbandoned(uint256 dataSetId, uint256 requiredEpoch, uint256 currentBlock);
 }

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -34,6 +34,8 @@ import {SignatureVerificationLib} from "./lib/SignatureVerificationLib.sol";
 uint256 constant NO_PROVING_DEADLINE = 0;
 uint64 constant CHALLENGES_PER_PROOF = 5;
 uint256 constant COMMISSION_MAX_BPS = 10000; // 100% in basis points
+// Mirror of PDPVerifier.INACTIVITY_WINDOW (lib/pdp/src/PDPVerifier.sol)
+uint256 constant PDP_INACTIVITY_WINDOW = 86400;
 
 /*
 * Maximum extraData for createDataSet
@@ -117,6 +119,8 @@ contract FilecoinWarmStorageService is
         uint256 cacheMissRailId,
         uint256 cdnRailId
     );
+
+    event DataSetAbandoned(uint256 indexed dataSetId, uint256 pdpRailId, uint256 cacheMissRailId, uint256 cdnRailId);
 
     event PDPPaymentTerminated(uint256 indexed dataSetId, uint256 endEpoch, uint256 pdpRailId);
 
@@ -621,8 +625,10 @@ contract FilecoinWarmStorageService is
     }
 
     /**
-     * @notice Handles data set deletion after the payment rails were terminated
-     * @dev Called by the PDPVerifier contract when a data set is deleted
+     * @notice Handles data set deletion after voluntary termination or via the abandonment path.
+     * @dev Called by the PDPVerifier contract when a data set is deleted.
+     *      When pdpEndEpoch == 0 the rail was never terminated via terminateService; FWSS verifies
+     *      30-day inactivity and performs inline teardown so a keeper needs only one transaction.
      * @param dataSetId The ID of the data set being deleted
      */
     function dataSetDeleted(
@@ -630,31 +636,29 @@ contract FilecoinWarmStorageService is
         uint256, // deletedLeafCount, - not used
         bytes calldata // extraData, - not used
     ) external onlyPDPVerifier {
-        // Verify the data set exists in our mapping
         DataSetInfo storage info = dataSetInfo[dataSetId];
         require(info.pdpRailId != 0, Errors.DataSetNotRegistered(dataSetId));
 
-        // Get the payer address for this data set
-        address payer = dataSetInfo[dataSetId].payer;
-
-        // Check if the data set's payment rails have finalized
-        require(
-            info.pdpEndEpoch != 0 && block.number > info.pdpEndEpoch,
-            Errors.PaymentRailsNotFinalized(dataSetId, info.pdpEndEpoch)
-        );
-
-        // Check if the rail is fully settled before allowing deletion.
-        // This ensures validatePayment() can still read dataset state during settlement.
-        // If deleted before settlement, clients would be forced to use
-        // settleTerminatedRailWithoutValidation() which pays full amount for unproven epochs.
+        address payer = info.payer;
         FilecoinPayV1 payments = FilecoinPayV1(paymentsContractAddress);
-        try payments.getRail(info.pdpRailId) returns (FilecoinPayV1.RailView memory rail) {
-            require(
-                rail.settledUpTo >= rail.endEpoch,
-                Errors.RailNotFullySettled(info.pdpRailId, rail.settledUpTo, rail.endEpoch)
-            );
-        } catch {
-            // Rail is finalized (zeroed out), meaning it was already fully settled
+
+        if (info.pdpEndEpoch == 0) {
+            // Abandonment path: rail was never terminated via terminateService.
+            // Verify 30-day inactivity, then perform inline teardown.
+            _verifyInactivity(dataSetId);
+            _abandonmentTeardown(dataSetId, info, payments);
+        } else {
+            // Normal path: terminateService was already called.
+            // Verify the payment window has elapsed and the rail is fully settled.
+            require(block.number > info.pdpEndEpoch, Errors.PaymentRailsNotFinalized(dataSetId, info.pdpEndEpoch));
+            try payments.getRail(info.pdpRailId) returns (FilecoinPayV1.RailView memory rail) {
+                require(
+                    rail.settledUpTo >= rail.endEpoch,
+                    Errors.RailNotFullySettled(info.pdpRailId, rail.settledUpTo, rail.endEpoch)
+                );
+            } catch {
+                // Rail is finalized (zeroed out), meaning it was already fully settled
+            }
         }
 
         // NOTE keep clientNonces[payer][clientDataSetId] to prevent replay
@@ -663,14 +667,11 @@ contract FilecoinWarmStorageService is
         uint256[] storage clientDataSetList = clientDataSets[payer];
         for (uint256 i = 0; i < clientDataSetList.length; i++) {
             if (clientDataSetList[i] == dataSetId) {
-                // Remove this dataset from the array
                 clientDataSetList[i] = clientDataSetList[clientDataSetList.length - 1];
                 clientDataSetList.pop();
                 break;
             }
         }
-
-        // Remove the dataset from all mappings
 
         // Clean up proving-related state
         delete provingDeadlines[dataSetId];
@@ -689,6 +690,67 @@ contract FilecoinWarmStorageService is
 
         // Complete cleanup
         delete dataSetInfo[dataSetId];
+    }
+
+    /**
+     * @notice Verifies that a data set has been inactive for the required inactivity window.
+     * @dev Reverts if the SP has been active within PDPVerifier.INACTIVITY_WINDOW epochs.
+     *      Never-activated datasets (provingActivationEpoch == 0) are unconditionally accepted.
+     */
+    function _verifyInactivity(uint256 dataSetId) internal view {
+        uint256 activation = provingActivationEpoch[dataSetId];
+        if (activation == 0) return;
+
+        uint256 lastProvenEpoch = IPDPVerifier(pdpVerifierAddress).getDataSetLastProvenEpoch(dataSetId);
+        // If proving was activated but no proof was ever submitted, use the activation epoch as the baseline.
+        uint256 lastActivity = lastProvenEpoch == 0 ? activation : lastProvenEpoch;
+        uint256 requiredEpoch = lastActivity + PDP_INACTIVITY_WINDOW;
+        require(block.number > requiredEpoch, Errors.DataSetNotAbandoned(dataSetId, requiredEpoch, block.number));
+    }
+
+    /**
+     * @notice Performs inline teardown of payment rails during the abandonment path.
+     * @dev Settles, modifies lockup, terminates, and re-settles the PDP rail so it finalizes
+     *      within this single transaction. CDN rails (if present) follow the same sequence.
+     *      FWSS dataset state must not be deleted before this function returns because
+     *      validatePayment reads it during the final settleRail.
+     */
+    function _abandonmentTeardown(uint256 dataSetId, DataSetInfo storage info, FilecoinPayV1 payments) internal {
+        // Settle the live PDP rail up to the current block.
+        // validatePayment returns zero payment for all unproven epochs, discharging lockupCurrent
+        // without transferring funds. The "after" settleAccountLockup then advances lockupLastSettledAt
+        // to block.number, satisfying isAccountLockupFullySettled for the modifyRailLockup below.
+        payments.settleRail(info.pdpRailId, block.number);
+
+        // Zero both lockup period and fixed lockup on the PDP rail.
+        // Requires isAccountLockupFullySettled (achieved above).
+        // Sets lockupPeriod = 0 so terminateRail produces endEpoch = block.number.
+        payments.modifyRailLockup(info.pdpRailId, 0, 0);
+
+        bool hasCDN = info.cdnRailId != 0;
+        if (hasCDN) {
+            // Zero CDN rail lockup periods (allowed since lockupLastSettledAt == block.number).
+            payments.modifyRailLockup(info.cacheMissRailId, 0, 0);
+            payments.modifyRailLockup(info.cdnRailId, 0, 0);
+            // Terminate CDN rails (endEpoch = lockupLastSettledAt + 0 = block.number).
+            payments.terminateCDNRails(dataSetId, info.cacheMissRailId, info.cdnRailId);
+            // Settle and finalize CDN rails (zero payment at rate 0, instant finalization).
+            payments.settleRail(info.cacheMissRailId, block.number);
+            payments.settleRail(info.cdnRailId, block.number);
+        }
+
+        // Terminate the PDP rail. FWSS is the operator so always authorized.
+        // endEpoch = lockupLastSettledAt + lockupPeriod = block.number + 0 = block.number.
+        // railTerminated callback fires and sets info.pdpEndEpoch = block.number.
+        payments.terminateRail(info.pdpRailId);
+
+        // Settle the now-terminated PDP rail.
+        // maxSettlementEpoch = min(block.number, endEpoch) = block.number.
+        // validatePayment reads FWSS state here — state must remain intact until this returns.
+        // After settlement settledUpTo >= endEpoch, rail finalizes via checkAndFinalizeTerminatedRail.
+        payments.settleRail(info.pdpRailId, block.number);
+
+        emit DataSetAbandoned(dataSetId, info.pdpRailId, info.cacheMissRailId, info.cdnRailId);
     }
 
     /**
@@ -1385,12 +1447,13 @@ contract FilecoinWarmStorageService is
         uint256 totalEpochsRequested = toEpoch - fromEpoch;
         require(totalEpochsRequested > 0, Errors.InvalidEpochRange(fromEpoch, toEpoch));
 
-        // If proving wasn't ever activated for this data set, don't pay anything
+        // If proving wasn't ever activated for this data set, don't pay anything.
+        // Return settleUpto = toEpoch (not fromEpoch) so settlement can still advance and discharge lockup.
         uint256 activationEpoch = provingActivationEpoch[dataSetId];
         if (activationEpoch == 0) {
             return ValidationResult({
                 modifiedAmount: 0,
-                settleUpto: fromEpoch,
+                settleUpto: toEpoch,
                 note: "Proving never activated for this data set"
             });
         }

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -28,7 +28,7 @@ import {
     STORAGE_PRICE_PER_TIB_PER_MONTH,
     TOKEN_DECIMALS
 } from "./lib/PriceListUSDFC.sol";
-import {Rails} from "./lib/Rails.sol";
+import {Rails, CDNServiceTerminated} from "./lib/Rails.sol";
 import {SignatureVerificationLib} from "./lib/SignatureVerificationLib.sol";
 
 uint256 constant NO_PROVING_DEADLINE = 0;
@@ -732,6 +732,7 @@ contract FilecoinWarmStorageService is
             // FilBeam controller called terminateCDNService). Handle each rail based on its state.
             _teardownCDNRail(info.cacheMissRailId, payments);
             _teardownCDNRail(info.cdnRailId, payments);
+            emit CDNServiceTerminated(msg.sender, dataSetId, info.cacheMissRailId, info.cdnRailId);
         }
 
         // Terminate the PDP rail. FWSS is the operator so always authorized.

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -28,7 +28,7 @@ import {
     STORAGE_PRICE_PER_TIB_PER_MONTH,
     TOKEN_DECIMALS
 } from "./lib/PriceListUSDFC.sol";
-import {Rails, CDNServiceTerminated} from "./lib/Rails.sol";
+import {Rails} from "./lib/Rails.sol";
 import {SignatureVerificationLib} from "./lib/SignatureVerificationLib.sol";
 
 uint256 constant NO_PROVING_DEADLINE = 0;
@@ -119,8 +119,6 @@ contract FilecoinWarmStorageService is
         uint256 cacheMissRailId,
         uint256 cdnRailId
     );
-
-    event DataSetAbandoned(uint256 indexed dataSetId, uint256 pdpRailId, uint256 cacheMissRailId, uint256 cdnRailId);
 
     event PDPPaymentTerminated(uint256 indexed dataSetId, uint256 endEpoch, uint256 pdpRailId);
 
@@ -646,7 +644,7 @@ contract FilecoinWarmStorageService is
             // Abandonment path: rail was never terminated via terminateService.
             // Verify 30-day inactivity, then perform inline teardown.
             _verifyInactivity(dataSetId);
-            _abandonmentTeardown(dataSetId, info, payments);
+            payments.abandonRails(dataSetId, info.pdpRailId, info.cacheMissRailId, info.cdnRailId);
         } else {
             // Normal path: terminateService was already called.
             // Verify the payment window has elapsed and the rail is fully settled.
@@ -706,63 +704,6 @@ contract FilecoinWarmStorageService is
         uint256 lastActivity = lastProvenEpoch == 0 ? activation : lastProvenEpoch;
         uint256 requiredEpoch = lastActivity + PDP_INACTIVITY_WINDOW;
         require(block.number > requiredEpoch, Errors.DataSetNotAbandoned(dataSetId, requiredEpoch, block.number));
-    }
-
-    /**
-     * @notice Performs inline teardown of payment rails during the abandonment path.
-     * @dev Settles, modifies lockup, terminates, and re-settles the PDP rail so it finalizes
-     *      within this single transaction. CDN rails (if present) follow the same sequence.
-     *      FWSS dataset state must not be deleted before this function returns because
-     *      validatePayment reads it during the final settleRail.
-     */
-    function _abandonmentTeardown(uint256 dataSetId, DataSetInfo storage info, FilecoinPayV1 payments) internal {
-        // Settle the live PDP rail up to the current block.
-        // validatePayment returns zero payment for all unproven epochs, discharging lockupCurrent
-        // without transferring funds. The "after" settleAccountLockup then advances lockupLastSettledAt
-        // to block.number, satisfying isAccountLockupFullySettled for the modifyRailLockup below.
-        payments.settleRail(info.pdpRailId, block.number);
-
-        // Zero both lockup period and fixed lockup on the PDP rail.
-        // Requires isAccountLockupFullySettled (achieved above).
-        // Sets lockupPeriod = 0 so terminateRail produces endEpoch = block.number.
-        payments.modifyRailLockup(info.pdpRailId, 0, 0);
-
-        if (info.cdnRailId != 0) {
-            // CDN rails may have been terminated externally (payer called FilecoinPay directly, or
-            // FilBeam controller called terminateCDNService). Handle each rail based on its state.
-            _teardownCDNRail(info.cacheMissRailId, payments);
-            _teardownCDNRail(info.cdnRailId, payments);
-            emit CDNServiceTerminated(msg.sender, dataSetId, info.cacheMissRailId, info.cdnRailId);
-        }
-
-        // Terminate the PDP rail. FWSS is the operator so always authorized.
-        // endEpoch = lockupLastSettledAt + lockupPeriod = block.number + 0 = block.number.
-        // railTerminated callback fires and sets info.pdpEndEpoch = block.number.
-        payments.terminateRail(info.pdpRailId);
-
-        // Settle the now-terminated PDP rail.
-        // maxSettlementEpoch = min(block.number, endEpoch) = block.number.
-        // validatePayment reads FWSS state here — state must remain intact until this returns.
-        // After settlement settledUpTo >= endEpoch, rail finalizes via checkAndFinalizeTerminatedRail.
-        payments.settleRail(info.pdpRailId, block.number);
-
-        emit DataSetAbandoned(dataSetId, info.pdpRailId, info.cacheMissRailId, info.cdnRailId);
-    }
-
-    /**
-     * @notice Tears down a single CDN rail during the abandonment path.
-     * @dev CDN rails carry no validator, so the payer or FilBeam controller may have terminated
-     *      them externally before abandonment fires. Three states are handled:
-     *      - Active: zero lockup period, terminate, then settle to finalize.
-     *      - Terminated: modifyRailLockup and terminateRail are no-ops (caught), settle to finalize.
-     *      - Finalized: all three calls are no-ops (caught); nothing left to do.
-     *      The only errors possible here are "rail already in a more advanced state", so
-     *      swallowing all reverts is safe.
-     */
-    function _teardownCDNRail(uint256 railId, FilecoinPayV1 payments) internal {
-        try payments.modifyRailLockup(railId, 0, 0) {} catch {}
-        try payments.terminateRail(railId) {} catch {}
-        try payments.settleRail(railId, block.number) {} catch {}
     }
 
     /**

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -727,16 +727,11 @@ contract FilecoinWarmStorageService is
         // Sets lockupPeriod = 0 so terminateRail produces endEpoch = block.number.
         payments.modifyRailLockup(info.pdpRailId, 0, 0);
 
-        bool hasCDN = info.cdnRailId != 0;
-        if (hasCDN) {
-            // Zero CDN rail lockup periods (allowed since lockupLastSettledAt == block.number).
-            payments.modifyRailLockup(info.cacheMissRailId, 0, 0);
-            payments.modifyRailLockup(info.cdnRailId, 0, 0);
-            // Terminate CDN rails (endEpoch = lockupLastSettledAt + 0 = block.number).
-            payments.terminateCDNRails(dataSetId, info.cacheMissRailId, info.cdnRailId);
-            // Settle and finalize CDN rails (zero payment at rate 0, instant finalization).
-            payments.settleRail(info.cacheMissRailId, block.number);
-            payments.settleRail(info.cdnRailId, block.number);
+        if (info.cdnRailId != 0) {
+            // CDN rails may have been terminated externally (payer called FilecoinPay directly, or
+            // FilBeam controller called terminateCDNService). Handle each rail based on its state.
+            _teardownCDNRail(info.cacheMissRailId, payments);
+            _teardownCDNRail(info.cdnRailId, payments);
         }
 
         // Terminate the PDP rail. FWSS is the operator so always authorized.
@@ -751,6 +746,22 @@ contract FilecoinWarmStorageService is
         payments.settleRail(info.pdpRailId, block.number);
 
         emit DataSetAbandoned(dataSetId, info.pdpRailId, info.cacheMissRailId, info.cdnRailId);
+    }
+
+    /**
+     * @notice Tears down a single CDN rail during the abandonment path.
+     * @dev CDN rails carry no validator, so the payer or FilBeam controller may have terminated
+     *      them externally before abandonment fires. Three states are handled:
+     *      - Active: zero lockup period, terminate, then settle to finalize.
+     *      - Terminated: modifyRailLockup and terminateRail are no-ops (caught), settle to finalize.
+     *      - Finalized: all three calls are no-ops (caught); nothing left to do.
+     *      The only errors possible here are "rail already in a more advanced state", so
+     *      swallowing all reverts is safe.
+     */
+    function _teardownCDNRail(uint256 railId, FilecoinPayV1 payments) internal {
+        try payments.modifyRailLockup(railId, 0, 0) {} catch {}
+        try payments.terminateRail(railId) {} catch {}
+        try payments.settleRail(railId, block.number) {} catch {}
     }
 
     /**

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -665,6 +665,7 @@ contract FilecoinWarmStorageService is
         uint256[] storage clientDataSetList = clientDataSets[payer];
         for (uint256 i = 0; i < clientDataSetList.length; i++) {
             if (clientDataSetList[i] == dataSetId) {
+                // Remove this dataset from the array
                 clientDataSetList[i] = clientDataSetList[clientDataSetList.length - 1];
                 clientDataSetList.pop();
                 break;

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -642,7 +642,7 @@ contract FilecoinWarmStorageService is
 
         if (info.pdpEndEpoch == 0) {
             // Abandonment path: rail was never terminated via terminateService.
-            // Verify 30-day inactivity, then perform inline teardown.
+            // SP forfeits pending op-fees; lifecycle reserve returns to the payer.
             _verifyInactivity(dataSetId);
             payments.abandonRails(dataSetId, info.pdpRailId, info.cacheMissRailId, info.cdnRailId);
         } else {
@@ -692,16 +692,21 @@ contract FilecoinWarmStorageService is
     }
 
     /**
-     * @notice Verifies that a data set has been inactive for the required inactivity window.
-     * @dev Reverts if the SP has been active within PDPVerifier.INACTIVITY_WINDOW epochs.
-     *      Never-activated datasets (provingActivationEpoch == 0) are unconditionally accepted.
+     * @notice Verifies the data set has been inactive for INACTIVITY_WINDOW.
+     * @dev Layers on PDPVerifier.deleteDataSet's own gate, which restricts non-SP callers within
+     *      the window. This check stops the SP themselves from using deleteDataSet to skip
+     *      terminateService on an active data set.
+     *      Baseline: PDPVerifier's lastProvenEpoch (initialized at creation for current data
+     *      sets, updated on each proof). If 0, the data set is legacy and predates that
+     *      initialization; fall back to our local provingActivationEpoch.
+     *      Never-activated (activation == 0) is accepted unconditionally; PDPVerifier handles the
+     *      since-activation gate.
      */
     function _verifyInactivity(uint256 dataSetId) internal view {
         uint256 activation = provingActivationEpoch[dataSetId];
         if (activation == 0) return;
 
         uint256 lastProvenEpoch = IPDPVerifier(pdpVerifierAddress).getDataSetLastProvenEpoch(dataSetId);
-        // If proving was activated but no proof was ever submitted, use the activation epoch as the baseline.
         uint256 lastActivity = lastProvenEpoch == 0 ? activation : lastProvenEpoch;
         uint256 requiredEpoch = lastActivity + PDP_INACTIVITY_WINDOW;
         require(block.number > requiredEpoch, Errors.DataSetNotAbandoned(dataSetId, requiredEpoch, block.number));
@@ -1401,8 +1406,9 @@ contract FilecoinWarmStorageService is
         uint256 totalEpochsRequested = toEpoch - fromEpoch;
         require(totalEpochsRequested > 0, Errors.InvalidEpochRange(fromEpoch, toEpoch));
 
-        // If proving wasn't ever activated for this data set, don't pay anything.
-        // Return settleUpto = toEpoch (not fromEpoch) so settlement can still advance and discharge lockup.
+        // Proving never activated: no payment due, but settleUpto = toEpoch (not fromEpoch) lets
+        // settleRail advance and discharge lockup. Without this, settleRail reverts with
+        // NoProgressInSettlement, which blocks the abandonment teardown path.
         uint256 activationEpoch = provingActivationEpoch[dataSetId];
         if (activationEpoch == 0) {
             return ValidationResult({

--- a/service_contracts/src/lib/Rails.sol
+++ b/service_contracts/src/lib/Rails.sol
@@ -28,6 +28,8 @@ event CDNServiceTerminated(
     address indexed caller, uint256 indexed dataSetId, uint256 cacheMissRailId, uint256 cdnRailId
 );
 
+event DataSetAbandoned(uint256 indexed dataSetId, uint256 pdpRailId, uint256 cacheMissRailId, uint256 cdnRailId);
+
 event RailRateUpdated(uint256 indexed dataSetId, uint256 railId, uint256 newRate);
 
 library Rails {
@@ -180,6 +182,39 @@ library Rails {
         try payments.terminateRail(cacheMissRailId) {} catch {}
         try payments.terminateRail(cdnRailId) {} catch {}
         emit CDNServiceTerminated(msg.sender, dataSetId, cacheMissRailId, cdnRailId);
+    }
+
+    /// @notice Tears down all payment rails for an abandoned dataset in a single library call.
+    /// @dev Settling the PDP rail first discharges lockup for unproven epochs, advancing
+    ///      lockupLastSettledAt to block.number and satisfying isAccountLockupFullySettled for the
+    ///      subsequent modifyRailLockup. CDN rails are handled defensively since the payer or
+    ///      FilBeam controller may have terminated them externally before abandonment fires.
+    function abandonRails(
+        FilecoinPayV1 payments,
+        uint256 dataSetId,
+        uint256 pdpRailId,
+        uint256 cacheMissRailId,
+        uint256 cdnRailId
+    ) public {
+        payments.settleRail(pdpRailId, block.number);
+        payments.modifyRailLockup(pdpRailId, 0, 0);
+
+        if (cdnRailId != 0) {
+            _teardownCDNRail(payments, cacheMissRailId);
+            _teardownCDNRail(payments, cdnRailId);
+            emit CDNServiceTerminated(msg.sender, dataSetId, cacheMissRailId, cdnRailId);
+        }
+
+        payments.terminateRail(pdpRailId);
+        payments.settleRail(pdpRailId, block.number);
+        emit DataSetAbandoned(dataSetId, pdpRailId, cacheMissRailId, cdnRailId);
+    }
+
+    /// @notice Tears down one CDN rail, tolerating rails already terminated or finalized externally.
+    function _teardownCDNRail(FilecoinPayV1 payments, uint256 railId) internal {
+        try payments.modifyRailLockup(railId, 0, 0) {} catch {}
+        try payments.terminateRail(railId) {} catch {}
+        try payments.settleRail(railId, block.number) {} catch {}
     }
 
     function topUpCDNRails(

--- a/service_contracts/src/lib/Rails.sol
+++ b/service_contracts/src/lib/Rails.sol
@@ -184,11 +184,13 @@ library Rails {
         emit CDNServiceTerminated(msg.sender, dataSetId, cacheMissRailId, cdnRailId);
     }
 
-    /// @notice Tears down all payment rails for an abandoned dataset in a single library call.
-    /// @dev Settling the PDP rail first discharges lockup for unproven epochs, advancing
-    ///      lockupLastSettledAt to block.number and satisfying isAccountLockupFullySettled for the
-    ///      subsequent modifyRailLockup. CDN rails are handled defensively since the payer or
-    ///      FilBeam controller may have terminated them externally before abandonment fires.
+    /// @notice Tears down all rails for an abandoned data set.
+    /// @dev SP forfeits pending op-fees; lifecycle reserve and streaming buffer return to the
+    ///      payer. Intentional: abandonment means the SP walked away.
+    ///      PDP rail flow: settle to pay any proven epochs and advance settledUpTo; zero the
+    ///      lockup to release buffer+reserve to the payer; terminate (endEpoch = block.number
+    ///      since period is 0); settle again so settledUpTo >= endEpoch finalises the rail.
+    ///      CDN rails are best-effort, may have been terminated externally.
     function abandonRails(
         FilecoinPayV1 payments,
         uint256 dataSetId,
@@ -210,7 +212,10 @@ library Rails {
         emit DataSetAbandoned(dataSetId, pdpRailId, cacheMissRailId, cdnRailId);
     }
 
-    /// @notice Tears down one CDN rail, tolerating rails already terminated or finalized externally.
+    /// @notice Tears down one CDN rail.
+    /// @dev Each step may revert if the rail was independently terminated or finalised by the
+    ///      payer or FilBeam controller (CDN rails have no validator). Best-effort so abandonment
+    ///      completes regardless.
     function _teardownCDNRail(FilecoinPayV1 payments, uint256 railId) internal {
         try payments.modifyRailLockup(railId, 0, 0) {} catch {}
         try payments.terminateRail(railId) {} catch {}

--- a/service_contracts/test/Abandonment.t.sol
+++ b/service_contracts/test/Abandonment.t.sol
@@ -13,6 +13,7 @@ import {PROVING_ACTIVATION_EPOCH_SLOT} from "../src/lib/FilecoinWarmStorageServi
 import {FilecoinPayV1} from "@fws-payments/FilecoinPayV1.sol";
 import {Errors} from "../src/Errors.sol";
 import {MockERC20} from "./mocks/SharedMocks.sol";
+import {CDNServiceTerminated} from "../src/lib/Rails.sol";
 import {PDPOffering} from "./PDPOffering.sol";
 import {ServiceProviderRegistry} from "../src/ServiceProviderRegistry.sol";
 import {ServiceProviderRegistryStorage} from "../src/ServiceProviderRegistryStorage.sol";
@@ -216,6 +217,9 @@ contract AbandonmentTest is MockFVMTest {
 
         vm.roll(vm.getBlockNumber() + PDP_INACTIVITY_WINDOW + 1);
 
+        vm.expectEmit(true, true, false, true, address(fwss));
+        emit CDNServiceTerminated(address(pdpVerifier), dataSetId, before.cacheMissRailId, before.cdnRailId);
+
         vm.expectEmit(true, false, false, true, address(fwss));
         emit FilecoinWarmStorageService.DataSetAbandoned(
             dataSetId, before.pdpRailId, before.cacheMissRailId, before.cdnRailId
@@ -249,7 +253,9 @@ contract AbandonmentTest is MockFVMTest {
 
         vm.roll(vm.getBlockNumber() + PDP_INACTIVITY_WINDOW + 1);
 
-        // Abandonment should still complete without reverting.
+        vm.expectEmit(true, true, false, false, address(fwss));
+        emit CDNServiceTerminated(address(pdpVerifier), dataSetId, before.cacheMissRailId, before.cdnRailId);
+
         vm.prank(keeper);
         pdpVerifier.deleteDataSet(dataSetId, "");
 

--- a/service_contracts/test/Abandonment.t.sol
+++ b/service_contracts/test/Abandonment.t.sol
@@ -115,16 +115,26 @@ contract AbandonmentTest is MockFVMTest {
     }
 
     // Create a dataset via the real PDPVerifier and return its ID.
-    function _createDataSet() internal returns (uint256 dataSetId) {
+    // Pass withCDN=true to include the "withCDN" metadata key, enabling CDN rails.
+    function _createDataSet(bool withCDN) internal returns (uint256 dataSetId) {
         vm.startPrank(client);
         payments.setOperatorApproval(usdfc, address(fwss), true, 1000e18, 1000e18, 365 days);
         usdfc.approve(address(payments), 100e18);
         payments.deposit(usdfc, client, 100e18);
         vm.stopPrank();
 
-        string[] memory emptyKeys = new string[](0);
-        string[] memory emptyValues = new string[](0);
-        bytes memory extraData = abi.encode(client, uint256(0), emptyKeys, emptyValues, FAKE_SIG);
+        string[] memory keys;
+        string[] memory values;
+        if (withCDN) {
+            keys = new string[](1);
+            keys[0] = "withCDN";
+            values = new string[](1);
+            values[0] = "true";
+        } else {
+            keys = new string[](0);
+            values = new string[](0);
+        }
+        bytes memory extraData = abi.encode(client, uint256(0), keys, values, FAKE_SIG);
 
         _makeSignaturePass(client);
         vm.prank(sp);
@@ -133,7 +143,7 @@ contract AbandonmentTest is MockFVMTest {
 
     // A permissionless caller cannot trigger abandonment before INACTIVITY_WINDOW has elapsed.
     function testAbandonmentBlockedBeforeWindowByPDPVerifier() public {
-        uint256 dataSetId = _createDataSet();
+        uint256 dataSetId = _createDataSet(false);
 
         vm.roll(vm.getBlockNumber() + PDP_INACTIVITY_WINDOW / 2);
 
@@ -146,7 +156,7 @@ contract AbandonmentTest is MockFVMTest {
     // the abandonment path when INACTIVITY_WINDOW has not yet elapsed.
     // The SP's correct alternative is terminateService, which is always available.
     function testAbandonmentBlockedBeforeWindowByFWSS() public {
-        uint256 dataSetId = _createDataSet();
+        uint256 dataSetId = _createDataSet(false);
         uint256 creationBlock = vm.getBlockNumber();
 
         // Simulate proving activation by writing directly to FWSS storage.
@@ -172,7 +182,7 @@ contract AbandonmentTest is MockFVMTest {
     // After INACTIVITY_WINDOW blocks without activity, any caller can trigger abandonment.
     // FWSS should clear all dataset state and finalize the payment rail.
     function testAbandonmentClears() public {
-        uint256 dataSetId = _createDataSet();
+        uint256 dataSetId = _createDataSet(false);
 
         FilecoinWarmStorageService.DataSetInfoView memory before = viewContract.getDataSet(dataSetId);
         assertGt(before.pdpRailId, 0, "dataset should exist before abandonment");
@@ -188,6 +198,36 @@ contract AbandonmentTest is MockFVMTest {
 
         FilecoinWarmStorageService.DataSetInfoView memory after_ = viewContract.getDataSet(dataSetId);
         assertEq(after_.pdpRailId, 0, "pdpRailId should be cleared");
+        assertEq(after_.payer, address(0), "payer should be cleared");
+
+        uint256[] memory remaining = viewContract.clientDataSets(client);
+        assertEq(remaining.length, 0, "client dataset list should be empty");
+    }
+
+    // Same as testAbandonmentClears but with CDN rails enabled, exercising the CDN teardown branch.
+    function testAbandonmentClearsCDN() public {
+        uint256 dataSetId = _createDataSet(true);
+
+        FilecoinWarmStorageService.DataSetInfoView memory before = viewContract.getDataSet(dataSetId);
+        assertGt(before.pdpRailId, 0, "pdpRailId should be set");
+        assertGt(before.cacheMissRailId, 0, "cacheMissRailId should be set");
+        assertGt(before.cdnRailId, 0, "cdnRailId should be set");
+        assertEq(before.payer, client, "payer should be set");
+
+        vm.roll(vm.getBlockNumber() + PDP_INACTIVITY_WINDOW + 1);
+
+        vm.expectEmit(true, false, false, true, address(fwss));
+        emit FilecoinWarmStorageService.DataSetAbandoned(
+            dataSetId, before.pdpRailId, before.cacheMissRailId, before.cdnRailId
+        );
+
+        vm.prank(keeper);
+        pdpVerifier.deleteDataSet(dataSetId, "");
+
+        FilecoinWarmStorageService.DataSetInfoView memory after_ = viewContract.getDataSet(dataSetId);
+        assertEq(after_.pdpRailId, 0, "pdpRailId should be cleared");
+        assertEq(after_.cacheMissRailId, 0, "cacheMissRailId should be cleared");
+        assertEq(after_.cdnRailId, 0, "cdnRailId should be cleared");
         assertEq(after_.payer, address(0), "payer should be cleared");
 
         uint256[] memory remaining = viewContract.clientDataSets(client);

--- a/service_contracts/test/Abandonment.t.sol
+++ b/service_contracts/test/Abandonment.t.sol
@@ -110,6 +110,23 @@ contract AbandonmentTest is MockFVMTest {
         require(usdfc.transfer(client, 1000e18));
     }
 
+    // Assert that all storage-backed fields of a deleted dataset are zero and metadata is empty.
+    function _assertDataSetCleared(uint256 dataSetId) internal view {
+        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
+        assertEq(info.pdpRailId, 0, "pdpRailId");
+        assertEq(info.cacheMissRailId, 0, "cacheMissRailId");
+        assertEq(info.cdnRailId, 0, "cdnRailId");
+        assertEq(info.payer, address(0), "payer");
+        assertEq(info.payee, address(0), "payee");
+        assertEq(info.serviceProvider, address(0), "serviceProvider");
+        assertEq(info.commissionBps, 0, "commissionBps");
+        assertEq(info.pdpEndEpoch, 0, "pdpEndEpoch");
+        assertEq(info.providerId, 0, "providerId");
+
+        (string[] memory keys,) = viewContract.getAllDataSetMetadata(dataSetId);
+        assertEq(keys.length, 0, "metadata keys");
+    }
+
     // Mock ecrecover to return the expected signer, bypassing real EIP-712 verification.
     function _makeSignaturePass(address signer) internal {
         vm.mockCall(address(0x01), bytes(hex""), abi.encode(signer));
@@ -197,12 +214,8 @@ contract AbandonmentTest is MockFVMTest {
         vm.prank(keeper);
         pdpVerifier.deleteDataSet(dataSetId, "");
 
-        FilecoinWarmStorageService.DataSetInfoView memory after_ = viewContract.getDataSet(dataSetId);
-        assertEq(after_.pdpRailId, 0, "pdpRailId should be cleared");
-        assertEq(after_.payer, address(0), "payer should be cleared");
-
-        uint256[] memory remaining = viewContract.clientDataSets(client);
-        assertEq(remaining.length, 0, "client dataset list should be empty");
+        _assertDataSetCleared(dataSetId);
+        assertEq(viewContract.clientDataSets(client).length, 0, "client dataset list should be empty");
     }
 
     // Same as testAbandonmentClears but with CDN rails enabled, exercising the CDN teardown branch.
@@ -226,14 +239,8 @@ contract AbandonmentTest is MockFVMTest {
         vm.prank(keeper);
         pdpVerifier.deleteDataSet(dataSetId, "");
 
-        FilecoinWarmStorageService.DataSetInfoView memory after_ = viewContract.getDataSet(dataSetId);
-        assertEq(after_.pdpRailId, 0, "pdpRailId should be cleared");
-        assertEq(after_.cacheMissRailId, 0, "cacheMissRailId should be cleared");
-        assertEq(after_.cdnRailId, 0, "cdnRailId should be cleared");
-        assertEq(after_.payer, address(0), "payer should be cleared");
-
-        uint256[] memory remaining = viewContract.clientDataSets(client);
-        assertEq(remaining.length, 0, "client dataset list should be empty");
+        _assertDataSetCleared(dataSetId);
+        assertEq(viewContract.clientDataSets(client).length, 0, "client dataset list should be empty");
     }
 
     // CDN rails carry no validator callback, so the payer can terminate them directly via
@@ -257,11 +264,42 @@ contract AbandonmentTest is MockFVMTest {
         vm.prank(keeper);
         pdpVerifier.deleteDataSet(dataSetId, "");
 
-        FilecoinWarmStorageService.DataSetInfoView memory after_ = viewContract.getDataSet(dataSetId);
-        assertEq(after_.pdpRailId, 0, "pdpRailId should be cleared");
-        assertEq(after_.payer, address(0), "payer should be cleared");
+        _assertDataSetCleared(dataSetId);
+        assertEq(viewContract.clientDataSets(client).length, 0, "client dataset list should be empty");
+    }
 
-        uint256[] memory remaining = viewContract.clientDataSets(client);
-        assertEq(remaining.length, 0, "client dataset list should be empty");
+    // CDN rails are finalized before abandonment fires (modifyRailLockup and settleRail both fail).
+    // Payer terminates and settles the CDN rails externally, then abandonment still succeeds.
+    function testAbandonmentClearsCDNPreFinalized() public {
+        uint256 dataSetId = _createDataSet(true);
+
+        FilecoinWarmStorageService.DataSetInfoView memory before = viewContract.getDataSet(dataSetId);
+
+        // Payer terminates the CDN rails directly on FilecoinPay, bypassing FWSS.
+        vm.prank(client);
+        payments.terminateRail(before.cdnRailId);
+        vm.prank(client);
+        payments.terminateRail(before.cacheMissRailId);
+
+        // Roll past the inactivity window, which also puts us past endEpoch for the CDN rails
+        // (endEpoch = lockupLastSettledAt + DEFAULT_LOCKUP_PERIOD = ~28800, window = 86400).
+        vm.roll(vm.getBlockNumber() + PDP_INACTIVITY_WINDOW + 1);
+
+        // Settle both CDN rails to their endEpoch, finalizing them (rail struct is zeroed out).
+        payments.settleRail(before.cdnRailId, block.number);
+        payments.settleRail(before.cacheMissRailId, block.number);
+
+        // Confirm finalization: getRail reverts for a zeroed-out rail.
+        vm.expectRevert();
+        payments.getRail(before.cdnRailId);
+
+        vm.expectEmit(true, true, false, false, address(fwss));
+        emit CDNServiceTerminated(address(pdpVerifier), dataSetId, before.cacheMissRailId, before.cdnRailId);
+
+        vm.prank(keeper);
+        pdpVerifier.deleteDataSet(dataSetId, "");
+
+        _assertDataSetCleared(dataSetId);
+        assertEq(viewContract.clientDataSets(client).length, 0, "client dataset list should be empty");
     }
 }

--- a/service_contracts/test/Abandonment.t.sol
+++ b/service_contracts/test/Abandonment.t.sol
@@ -13,7 +13,7 @@ import {PROVING_ACTIVATION_EPOCH_SLOT} from "../src/lib/FilecoinWarmStorageServi
 import {FilecoinPayV1} from "@fws-payments/FilecoinPayV1.sol";
 import {Errors} from "../src/Errors.sol";
 import {MockERC20} from "./mocks/SharedMocks.sol";
-import {CDNServiceTerminated} from "../src/lib/Rails.sol";
+import {CDNServiceTerminated, DataSetAbandoned} from "../src/lib/Rails.sol";
 import {PDPOffering} from "./PDPOffering.sol";
 import {ServiceProviderRegistry} from "../src/ServiceProviderRegistry.sol";
 import {ServiceProviderRegistryStorage} from "../src/ServiceProviderRegistryStorage.sol";
@@ -192,7 +192,7 @@ contract AbandonmentTest is MockFVMTest {
         vm.roll(vm.getBlockNumber() + PDP_INACTIVITY_WINDOW + 1);
 
         vm.expectEmit(true, false, false, false, address(fwss));
-        emit FilecoinWarmStorageService.DataSetAbandoned(dataSetId, before.pdpRailId, 0, 0);
+        emit DataSetAbandoned(dataSetId, before.pdpRailId, 0, 0);
 
         vm.prank(keeper);
         pdpVerifier.deleteDataSet(dataSetId, "");
@@ -221,9 +221,7 @@ contract AbandonmentTest is MockFVMTest {
         emit CDNServiceTerminated(address(pdpVerifier), dataSetId, before.cacheMissRailId, before.cdnRailId);
 
         vm.expectEmit(true, false, false, true, address(fwss));
-        emit FilecoinWarmStorageService.DataSetAbandoned(
-            dataSetId, before.pdpRailId, before.cacheMissRailId, before.cdnRailId
-        );
+        emit DataSetAbandoned(dataSetId, before.pdpRailId, before.cacheMissRailId, before.cdnRailId);
 
         vm.prank(keeper);
         pdpVerifier.deleteDataSet(dataSetId, "");

--- a/service_contracts/test/Abandonment.t.sol
+++ b/service_contracts/test/Abandonment.t.sol
@@ -233,4 +233,31 @@ contract AbandonmentTest is MockFVMTest {
         uint256[] memory remaining = viewContract.clientDataSets(client);
         assertEq(remaining.length, 0, "client dataset list should be empty");
     }
+
+    // CDN rails carry no validator callback, so the payer can terminate them directly via
+    // FilecoinPay before abandonment fires. Abandonment should still succeed.
+    function testAbandonmentClearsCDNPreTerminated() public {
+        uint256 dataSetId = _createDataSet(true);
+
+        FilecoinWarmStorageService.DataSetInfoView memory before = viewContract.getDataSet(dataSetId);
+
+        // Payer terminates the CDN rails directly on FilecoinPay, bypassing FWSS.
+        vm.prank(client);
+        payments.terminateRail(before.cdnRailId);
+        vm.prank(client);
+        payments.terminateRail(before.cacheMissRailId);
+
+        vm.roll(vm.getBlockNumber() + PDP_INACTIVITY_WINDOW + 1);
+
+        // Abandonment should still complete without reverting.
+        vm.prank(keeper);
+        pdpVerifier.deleteDataSet(dataSetId, "");
+
+        FilecoinWarmStorageService.DataSetInfoView memory after_ = viewContract.getDataSet(dataSetId);
+        assertEq(after_.pdpRailId, 0, "pdpRailId should be cleared");
+        assertEq(after_.payer, address(0), "payer should be cleared");
+
+        uint256[] memory remaining = viewContract.clientDataSets(client);
+        assertEq(remaining.length, 0, "client dataset list should be empty");
+    }
 }

--- a/service_contracts/test/Abandonment.t.sol
+++ b/service_contracts/test/Abandonment.t.sol
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {MockFVMTest} from "@fvm-solidity/mocks/MockFVMTest.sol";
+import {MyERC1967Proxy} from "@pdp/ERC1967Proxy.sol";
+import {PDPVerifier} from "@pdp/PDPVerifier.sol";
+import {SessionKeyRegistry} from "@session-key-registry/SessionKeyRegistry.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {FilecoinWarmStorageService, PDP_INACTIVITY_WINDOW} from "../src/FilecoinWarmStorageService.sol";
+import {FilecoinWarmStorageServiceStateView} from "../src/FilecoinWarmStorageServiceStateView.sol";
+import {PROVING_ACTIVATION_EPOCH_SLOT} from "../src/lib/FilecoinWarmStorageServiceLayout.sol";
+import {FilecoinPayV1} from "@fws-payments/FilecoinPayV1.sol";
+import {Errors} from "../src/Errors.sol";
+import {MockERC20} from "./mocks/SharedMocks.sol";
+import {PDPOffering} from "./PDPOffering.sol";
+import {ServiceProviderRegistry} from "../src/ServiceProviderRegistry.sol";
+import {ServiceProviderRegistryStorage} from "../src/ServiceProviderRegistryStorage.sol";
+
+contract AbandonmentTest is MockFVMTest {
+    using PDPOffering for PDPOffering.Schema;
+
+    PDPVerifier pdpVerifier;
+    FilecoinWarmStorageService fwss;
+    FilecoinWarmStorageServiceStateView viewContract;
+    FilecoinPayV1 payments;
+    MockERC20 usdfc;
+    ServiceProviderRegistry serviceProviderRegistry;
+    SessionKeyRegistry sessionKeyRegistry;
+
+    address sp = address(0xb1);
+    address client = address(0xb2);
+    address keeper = address(0xb3);
+    address filBeamBeneficiary = address(0xb4);
+    address filBeamController = address(0xb5);
+
+    uint256 constant CLEANUP_DEPOSIT = 0.1 ether;
+
+    bytes constant FAKE_SIG = abi.encodePacked(
+        bytes32(0xc0ffee7890abcdef1234567890abcdef1234567890abcdef1234567890abcdef),
+        bytes32(0x9999997890abcdef1234567890abcdef1234567890abcdef1234567890abcdef),
+        uint8(27)
+    );
+
+    function setUp() public override {
+        super.setUp();
+
+        vm.deal(sp, 10 ether);
+        vm.deal(client, 10 ether);
+        vm.deal(keeper, 10 ether);
+
+        usdfc = new MockERC20();
+        payments = new FilecoinPayV1();
+        sessionKeyRegistry = new SessionKeyRegistry();
+
+        // Deploy real PDPVerifier as a proxy
+        PDPVerifier pdpVerifierImpl = new PDPVerifier(1, 0);
+        MyERC1967Proxy pdpProxy =
+            new MyERC1967Proxy(address(pdpVerifierImpl), abi.encodeCall(PDPVerifier.initialize, ()));
+        pdpVerifier = PDPVerifier(address(pdpProxy));
+
+        // Deploy ServiceProviderRegistry
+        ServiceProviderRegistry registryImpl = new ServiceProviderRegistry(1);
+        MyERC1967Proxy regProxy =
+            new MyERC1967Proxy(address(registryImpl), abi.encodeCall(ServiceProviderRegistry.initialize, ()));
+        serviceProviderRegistry = ServiceProviderRegistry(address(regProxy));
+
+        // Register SP
+        PDPOffering.Schema memory offering = PDPOffering.Schema({
+            serviceURL: "https://sp.example.com",
+            minPieceSizeInBytes: 1024,
+            maxPieceSizeInBytes: 1024 * 1024,
+            ipniPiece: true,
+            ipniIpfs: false,
+            storagePricePerTibPerDay: 1 ether,
+            minProvingPeriodInEpochs: 2880,
+            location: "US-West",
+            paymentTokenAddress: IERC20(address(0))
+        });
+        (string[] memory capKeys, bytes[] memory capValues) = offering.toCapabilities();
+        vm.prank(sp);
+        serviceProviderRegistry.registerProvider{value: 5 ether}(
+            sp, "SP", "Storage Provider", ServiceProviderRegistryStorage.ProductType.PDP, capKeys, capValues
+        );
+
+        // Deploy FWSS pointing to the real PDPVerifier
+        FilecoinWarmStorageService fwssImpl = new FilecoinWarmStorageService(
+            address(pdpVerifier),
+            address(payments),
+            usdfc,
+            filBeamBeneficiary,
+            serviceProviderRegistry,
+            sessionKeyRegistry,
+            4
+        );
+        MyERC1967Proxy fwssProxy = new MyERC1967Proxy(
+            address(fwssImpl),
+            abi.encodeCall(
+                FilecoinWarmStorageService.initialize,
+                (uint64(2880), uint256(60), filBeamController, "Test FWSS", "Abandonment test service")
+            )
+        );
+        fwss = FilecoinWarmStorageService(address(fwssProxy));
+
+        viewContract = new FilecoinWarmStorageServiceStateView(fwss);
+        fwss.setViewContract(address(viewContract));
+        fwss.addApprovedProvider(1); // SP registered as provider ID 1
+
+        require(usdfc.transfer(client, 1000e18));
+    }
+
+    // Mock ecrecover to return the expected signer, bypassing real EIP-712 verification.
+    function _makeSignaturePass(address signer) internal {
+        vm.mockCall(address(0x01), bytes(hex""), abi.encode(signer));
+    }
+
+    // Create a dataset via the real PDPVerifier and return its ID.
+    function _createDataSet() internal returns (uint256 dataSetId) {
+        vm.startPrank(client);
+        payments.setOperatorApproval(usdfc, address(fwss), true, 1000e18, 1000e18, 365 days);
+        usdfc.approve(address(payments), 100e18);
+        payments.deposit(usdfc, client, 100e18);
+        vm.stopPrank();
+
+        string[] memory emptyKeys = new string[](0);
+        string[] memory emptyValues = new string[](0);
+        bytes memory extraData = abi.encode(client, uint256(0), emptyKeys, emptyValues, FAKE_SIG);
+
+        _makeSignaturePass(client);
+        vm.prank(sp);
+        dataSetId = pdpVerifier.createDataSet{value: CLEANUP_DEPOSIT}(address(fwss), extraData);
+    }
+
+    // A permissionless caller cannot trigger abandonment before INACTIVITY_WINDOW has elapsed.
+    function testAbandonmentBlockedBeforeWindowByPDPVerifier() public {
+        uint256 dataSetId = _createDataSet();
+
+        vm.roll(vm.getBlockNumber() + PDP_INACTIVITY_WINDOW / 2);
+
+        vm.prank(keeper);
+        vm.expectRevert(PDPVerifier.OnlyStorageProviderCanDelete.selector);
+        pdpVerifier.deleteDataSet(dataSetId, "");
+    }
+
+    // The SP can delete its own dataset at any time, but if proving was activated FWSS rejects
+    // the abandonment path when INACTIVITY_WINDOW has not yet elapsed.
+    // The SP's correct alternative is terminateService, which is always available.
+    function testAbandonmentBlockedBeforeWindowByFWSS() public {
+        uint256 dataSetId = _createDataSet();
+        uint256 creationBlock = vm.getBlockNumber();
+
+        // Simulate proving activation by writing directly to FWSS storage.
+        bytes32 slot = keccak256(abi.encode(dataSetId, uint256(PROVING_ACTIVATION_EPOCH_SLOT)));
+        vm.store(address(fwss), slot, bytes32(creationBlock));
+
+        // PDPVerifier allows the SP to delete at any time, but FWSS should reject it because
+        // the inactivity window has not yet passed.
+        vm.prank(sp);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.DataSetNotAbandoned.selector, dataSetId, creationBlock + PDP_INACTIVITY_WINDOW, block.number
+            )
+        );
+        pdpVerifier.deleteDataSet(dataSetId, "");
+
+        // terminateService is always available as the proper termination path.
+        vm.prank(sp);
+        fwss.terminateService(dataSetId, "");
+        assertGt(viewContract.getDataSet(dataSetId).pdpEndEpoch, 0, "pdpEndEpoch should be set after terminateService");
+    }
+
+    // After INACTIVITY_WINDOW blocks without activity, any caller can trigger abandonment.
+    // FWSS should clear all dataset state and finalize the payment rail.
+    function testAbandonmentClears() public {
+        uint256 dataSetId = _createDataSet();
+
+        FilecoinWarmStorageService.DataSetInfoView memory before = viewContract.getDataSet(dataSetId);
+        assertGt(before.pdpRailId, 0, "dataset should exist before abandonment");
+        assertEq(before.payer, client, "payer should be set before abandonment");
+
+        vm.roll(vm.getBlockNumber() + PDP_INACTIVITY_WINDOW + 1);
+
+        vm.expectEmit(true, false, false, false, address(fwss));
+        emit FilecoinWarmStorageService.DataSetAbandoned(dataSetId, before.pdpRailId, 0, 0);
+
+        vm.prank(keeper);
+        pdpVerifier.deleteDataSet(dataSetId, "");
+
+        FilecoinWarmStorageService.DataSetInfoView memory after_ = viewContract.getDataSet(dataSetId);
+        assertEq(after_.pdpRailId, 0, "pdpRailId should be cleared");
+        assertEq(after_.payer, address(0), "payer should be cleared");
+
+        uint256[] memory remaining = viewContract.clientDataSets(client);
+        assertEq(remaining.length, 0, "client dataset list should be empty");
+    }
+}

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -5951,7 +5951,7 @@ contract ValidatePaymentTest is FilecoinWarmStorageServiceTest {
             pdpServiceWithPayments.validatePayment(info.pdpRailId, proposedAmount, fromEpoch, toEpoch, 0);
 
         assertEq(result.modifiedAmount, 0, "Should pay nothing");
-        assertEq(result.settleUpto, fromEpoch, "Should not settle");
+        assertEq(result.settleUpto, toEpoch, "Should advance settlement at zero cost");
         assertEq(result.note, "Proving never activated for this data set");
     }
 
@@ -5976,7 +5976,7 @@ contract ValidatePaymentTest is FilecoinWarmStorageServiceTest {
             pdpServiceWithPayments.validatePayment(info.pdpRailId, 1000e18, fromEpoch, toEpoch, 0);
 
         assertEq(result.modifiedAmount, 0, "No payment to SP when dataset has no pieces");
-        assertEq(result.settleUpto, fromEpoch, "Settlement must not advance for empty dataset");
+        assertEq(result.settleUpto, toEpoch, "Settlement advances at zero cost when proving never activated");
     }
 
     /**


### PR DESCRIPTION

Reviewers @zenground0 @rvagg
Toward #484
This implements the abandonment path, which allows deleting the data set without `terminateService` if the rail has not been proven recently.
The motivation for this is that we want to allow cleanup.
Part of the abandonment logic (the gating and the deposit) is already implemented in `PDPVerifier`.
We need these additional `_verifyInactivity` checks to prevent the SP from skipping `terminateService` in the non-abandonment case.
#### Changes
* `_verifyInactivity`
* `Rails.abandonRails`
* tests