### PR TITLE
feat(pricing): add getPriceList() for full on-chain price discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Rail payment rates are calculated as a size-proportional component plus a flat p
 
 Storage providers submit on-chain transactions on behalf of clients (piece additions, removal scheduling, proving). To reimburse SPs for these gas costs, FWSS charges small one-time operation fees: $0.025 on dataset creation, $0.0005 + $0.0003/piece per add-pieces call, $0.002 per removal-scheduling call, and $0.00112 when an SP terminates service with payer consent. Fees are drawn from a $0.10 lifecycle reserve maintained as fixed lockup on the PDP rail.
 
-See [SPEC.md](SPEC.md) for details on rate calculation, operation fees, pricing updates, and top-up/renewal behavior.
+The complete on-chain price catalogue is exposed via `FilecoinWarmStorageServiceStateView.getPriceList()`. It returns a single nested `PriceList` struct covering token, streaming rates, one-time fees, and lockup amounts/periods. See [SPEC.md](SPEC.md) for details on rate calculation, operation fees, pricing updates, and top-up/renewal behavior.
 
 ## 🚀 Quick Start
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -69,6 +69,21 @@ This keeps the hot path at one external call per event.
 
 **Manual top-up**: The payer can call `topUpLifecycleReserve(dataSetId, amount)` at any time before termination. The payer must have sufficient available funds and `lockupAllowance` to cover the increase; `modifyRailLockup` enforces this via the standard operator approval checks.
 
+### Price Discovery
+
+The complete on-chain price catalogue is exposed via `FilecoinWarmStorageServiceStateView.getPriceList()`. It returns a single nested `PriceList` struct grouping the deployment's token address, streaming rates, one-time operation fees, and lockup amounts/periods:
+
+```solidity
+struct PriceList {
+    IERC20 token;
+    PriceListRates rates;       // storage, dataset fee, CDN egress, cache-miss egress
+    PriceListFees fees;          // create, add-pieces base+per-piece, schedule-removals, terminate
+    PriceListLockups lockups;    // lifecycle reserve, replenish threshold, CDN amounts, lockup periods
+}
+```
+
+This is the canonical price discovery API for SDKs and dashboards.
+
 ### Pricing Updates
 
 Only the contract owner can update pricing, by upgrading the contract.

--- a/service_contracts/abi/FilecoinWarmStorageServiceStateLibrary.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageServiceStateLibrary.abi.json
@@ -699,6 +699,128 @@
   },
   {
     "type": "function",
+    "name": "getPriceList",
+    "inputs": [
+      {
+        "name": "service",
+        "type": "FilecoinWarmStorageService",
+        "internalType": "contract FilecoinWarmStorageService"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "list",
+        "type": "tuple",
+        "internalType": "struct PriceList",
+        "components": [
+          {
+            "name": "token",
+            "type": "IERC20",
+            "internalType": "contract IERC20"
+          },
+          {
+            "name": "rates",
+            "type": "tuple",
+            "internalType": "struct PriceListRates",
+            "components": [
+              {
+                "name": "storagePerTibPerMonth",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "datasetFeePerMonth",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "cdnEgressPerTib",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "cacheMissEgressPerTib",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "fees",
+            "type": "tuple",
+            "internalType": "struct PriceListFees",
+            "components": [
+              {
+                "name": "createDataSetFee",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "addPiecesBaseFee",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "addPiecesPerPieceFee",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "schedulePieceRemovalsFee",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "terminateFee",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "lockups",
+            "type": "tuple",
+            "internalType": "struct PriceListLockups",
+            "components": [
+              {
+                "name": "lifecycleReserveTarget",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "replenishThreshold",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "defaultLockupPeriod",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "cdnLockupAmount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "cacheMissLockupAmount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "cdnLockupPeriod",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "isProviderApproved",
     "inputs": [
       {

--- a/service_contracts/abi/FilecoinWarmStorageServiceStateView.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageServiceStateView.abi.json
@@ -621,6 +621,122 @@
   },
   {
     "type": "function",
+    "name": "getPriceList",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "list",
+        "type": "tuple",
+        "internalType": "struct PriceList",
+        "components": [
+          {
+            "name": "token",
+            "type": "address",
+            "internalType": "contract IERC20"
+          },
+          {
+            "name": "rates",
+            "type": "tuple",
+            "internalType": "struct PriceListRates",
+            "components": [
+              {
+                "name": "storagePerTibPerMonth",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "datasetFeePerMonth",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "cdnEgressPerTib",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "cacheMissEgressPerTib",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "fees",
+            "type": "tuple",
+            "internalType": "struct PriceListFees",
+            "components": [
+              {
+                "name": "createDataSetFee",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "addPiecesBaseFee",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "addPiecesPerPieceFee",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "schedulePieceRemovalsFee",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "terminateFee",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "lockups",
+            "type": "tuple",
+            "internalType": "struct PriceListLockups",
+            "components": [
+              {
+                "name": "lifecycleReserveTarget",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "replenishThreshold",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "defaultLockupPeriod",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "cdnLockupAmount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "cacheMissLockupAmount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "cdnLockupPeriod",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "isProviderApproved",
     "inputs": [
       {

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -1307,6 +1307,8 @@ contract FilecoinWarmStorageService is
     /**
      * @notice Get the service pricing information
      * @return pricing A struct containing pricing details for storage and CDN/cache miss egress
+     * @custom:deprecated Use `FilecoinWarmStorageServiceStateView.getPriceList()` instead, which
+     *                    returns the complete price catalogue (rates, fees, lockups) in one call.
      */
     function getServicePrice() external view returns (ServicePricing memory pricing) {
         pricing = ServicePricing({
@@ -1323,6 +1325,9 @@ contract FilecoinWarmStorageService is
      * @notice Get the effective rates after commission for both service types
      * @return serviceFee Service fee (per TiB per month)
      * @return spPayment SP payment (per TiB per month)
+     * @custom:deprecated Service commission is fixed at zero; the SP receives the full storage
+     *                    rate. Use `FilecoinWarmStorageServiceStateView.getPriceList().rates`
+     *                    for the canonical pricing.
      */
     function getEffectiveRates() external pure returns (uint256 serviceFee, uint256 spPayment) {
         uint256 total = STORAGE_PRICE_PER_TIB_PER_MONTH;

--- a/service_contracts/src/FilecoinWarmStorageServiceStateView.sol
+++ b/service_contracts/src/FilecoinWarmStorageServiceStateView.sol
@@ -8,6 +8,7 @@ pragma solidity ^0.8.20;
 import {FilecoinWarmStorageService} from "./FilecoinWarmStorageService.sol";
 import {FilecoinWarmStorageServiceStateInternalLibrary} from "./lib/FilecoinWarmStorageServiceStateInternalLibrary.sol";
 import {IPDPProvingSchedule} from "@pdp/IPDPProvingSchedule.sol";
+import {PriceList} from "./lib/PriceList.sol";
 
 contract FilecoinWarmStorageServiceStateView is IPDPProvingSchedule {
     using FilecoinWarmStorageServiceStateInternalLibrary for FilecoinWarmStorageService;
@@ -133,6 +134,10 @@ contract FilecoinWarmStorageServiceStateView is IPDPProvingSchedule {
         returns (bool exists, string memory value)
     {
         return service.getPieceMetadata(dataSetId, pieceId, key);
+    }
+
+    function getPriceList() external view returns (PriceList memory list) {
+        return service.getPriceList();
     }
 
     function isProviderApproved(uint256 providerId) external view returns (bool) {

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
@@ -10,7 +10,14 @@ import {Errors} from "../Errors.sol";
 import {
     CHALLENGES_PER_PROOF, NO_PROVING_DEADLINE, FilecoinWarmStorageService
 } from "../FilecoinWarmStorageService.sol";
-import {DATASET_FEE_PER_MONTH, SERVICE_COMMISSION_BPS, STORAGE_PRICE_PER_TIB_PER_MONTH} from "./PriceListUSDFC.sol";
+import {
+    DATASET_FEE_PER_MONTH,
+    SERVICE_COMMISSION_BPS,
+    STORAGE_PRICE_PER_TIB_PER_MONTH,
+    priceList
+} from "./PriceListUSDFC.sol";
+import {PriceList} from "./PriceList.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./FilecoinWarmStorageServiceLayout.sol" as StorageLayout;
 
 // bytes32(bytes4(keccak256(abi.encodePacked("extsloadStruct(bytes32,uint256)"))));
@@ -612,6 +619,9 @@ library FilecoinWarmStorageServiceStateInternalLibrary {
      * @notice Get the current pricing rates
      * @return storagePrice Current storage price per TiB per month
      * @return datasetFee Per-dataset additive monthly fee
+     * @custom:deprecated Use `getPriceList()` for the complete catalogue. The same values appear
+     *                    as `getPriceList().rates.storagePerTibPerMonth` and
+     *                    `getPriceList().rates.datasetFeePerMonth`.
      */
     function getCurrentPricingRates(FilecoinWarmStorageService)
         internal
@@ -619,5 +629,18 @@ library FilecoinWarmStorageServiceStateInternalLibrary {
         returns (uint256 storagePrice, uint256 datasetFee)
     {
         return (STORAGE_PRICE_PER_TIB_PER_MONTH, DATASET_FEE_PER_MONTH);
+    }
+
+    /**
+     * @notice Get the full price catalogue for this FWSS deployment.
+     * @dev Single discovery point: streaming rates, one-time fees, and lockup amounts/periods in
+     *      one struct. The `token` field is populated from the FWSS proxy's `usdfcTokenAddress`
+     *      immutable; the rest comes from the on-chain price constants. Replaces the legacy
+     *      `getServicePrice`, `getCurrentPricingRates`, and `getEffectiveRates` for consumers
+     *      that want the complete price picture.
+     */
+    function getPriceList(FilecoinWarmStorageService service) internal view returns (PriceList memory list) {
+        list = priceList();
+        list.token = IERC20(address(service.usdfcTokenAddress()));
     }
 }

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceStateLibrary.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceStateLibrary.sol
@@ -6,7 +6,14 @@ import {Errors} from "../Errors.sol";
 import {
     CHALLENGES_PER_PROOF, NO_PROVING_DEADLINE, FilecoinWarmStorageService
 } from "../FilecoinWarmStorageService.sol";
-import {DATASET_FEE_PER_MONTH, SERVICE_COMMISSION_BPS, STORAGE_PRICE_PER_TIB_PER_MONTH} from "./PriceListUSDFC.sol";
+import {
+    DATASET_FEE_PER_MONTH,
+    SERVICE_COMMISSION_BPS,
+    STORAGE_PRICE_PER_TIB_PER_MONTH,
+    priceList
+} from "./PriceListUSDFC.sol";
+import {PriceList} from "./PriceList.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./FilecoinWarmStorageServiceLayout.sol" as StorageLayout;
 
 // bytes32(bytes4(keccak256(abi.encodePacked("extsloadStruct(bytes32,uint256)"))));
@@ -604,6 +611,9 @@ library FilecoinWarmStorageServiceStateLibrary {
      * @notice Get the current pricing rates
      * @return storagePrice Current storage price per TiB per month
      * @return datasetFee Per-dataset additive monthly fee
+     * @custom:deprecated Use `getPriceList()` for the complete catalogue. The same values appear
+     *                    as `getPriceList().rates.storagePerTibPerMonth` and
+     *                    `getPriceList().rates.datasetFeePerMonth`.
      */
     function getCurrentPricingRates(FilecoinWarmStorageService)
         public
@@ -611,5 +621,18 @@ library FilecoinWarmStorageServiceStateLibrary {
         returns (uint256 storagePrice, uint256 datasetFee)
     {
         return (STORAGE_PRICE_PER_TIB_PER_MONTH, DATASET_FEE_PER_MONTH);
+    }
+
+    /**
+     * @notice Get the full price catalogue for this FWSS deployment.
+     * @dev Single discovery point: streaming rates, one-time fees, and lockup amounts/periods in
+     *      one struct. The `token` field is populated from the FWSS proxy's `usdfcTokenAddress`
+     *      immutable; the rest comes from the on-chain price constants. Replaces the legacy
+     *      `getServicePrice`, `getCurrentPricingRates`, and `getEffectiveRates` for consumers
+     *      that want the complete price picture.
+     */
+    function getPriceList(FilecoinWarmStorageService service) public view returns (PriceList memory list) {
+        list = priceList();
+        list.token = IERC20(address(service.usdfcTokenAddress()));
     }
 }

--- a/service_contracts/src/lib/PriceList.sol
+++ b/service_contracts/src/lib/PriceList.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+pragma solidity ^0.8.20;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/// @notice Comprehensive price catalogue for an FWSS deployment. Returned by
+///         `FilecoinWarmStorageServiceStateView.getPriceList()`. All amounts are denominated in
+///         `token`'s smallest unit; rates are per-month (per-epoch values derived by dividing
+///         by `EPOCHS_PER_MONTH = 86400`).
+struct PriceList {
+    IERC20 token;
+    PriceListRates rates;
+    PriceListFees fees;
+    PriceListLockups lockups;
+}
+
+/// @notice Streaming rates. Storage and dataset fee accrue per epoch on the PDP rail when the
+///         dataset is non-empty (zero leaves yield a zero rate). CDN and cache-miss egress are
+///         usage-settled by FilBeam, not streamed.
+struct PriceListRates {
+    uint256 storagePerTibPerMonth;
+    uint256 datasetFeePerMonth;
+    uint256 cdnEgressPerTib;
+    uint256 cacheMissEgressPerTib;
+}
+
+/// @notice One-time fees paid to the SP out of the lifecycle reserve. The add-pieces fee for an
+///         n-piece batch is `addPiecesBaseFee + n * addPiecesPerPieceFee`. The terminate fee fires
+///         only in the consent case (SP-initiated termination with a valid payer EIP-712 signature).
+struct PriceListFees {
+    uint256 createDataSetFee;
+    uint256 addPiecesBaseFee;
+    uint256 addPiecesPerPieceFee;
+    uint256 schedulePieceRemovalsFee;
+    uint256 terminateFee;
+}
+
+/// @notice Fixed-lockup amounts and lockup periods. The lifecycle reserve sits on the PDP rail and
+///         is drawn down by fees; the replenish threshold triggers a top-up back to the target.
+///         CDN and cache-miss lockups sit on their respective rails with a shorter settle window.
+struct PriceListLockups {
+    uint256 lifecycleReserveTarget;
+    uint256 replenishThreshold;
+    uint256 defaultLockupPeriod;
+    uint256 cdnLockupAmount;
+    uint256 cacheMissLockupAmount;
+    uint256 cdnLockupPeriod;
+}

--- a/service_contracts/src/lib/PriceListUSDFC.sol
+++ b/service_contracts/src/lib/PriceListUSDFC.sol
@@ -2,6 +2,8 @@
 pragma solidity ^0.8.20;
 
 import {Cids} from "@pdp/Cids.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {PriceList, PriceListRates, PriceListFees, PriceListLockups} from "./PriceList.sol";
 
 uint256 constant MIB_IN_BYTES = 1024 * 1024; // 1 MiB in bytes
 uint256 constant GIB_IN_BYTES = MIB_IN_BYTES * 1024; // 1 GiB in bytes
@@ -59,4 +61,36 @@ function calculateStorageSizeBasedRatePerEpoch(uint256 totalBytes) pure returns 
 function calculateStorageRate(uint256 leafCount) pure returns (uint256 storageRatePerEpoch) {
     if (leafCount == 0) return 0;
     return calculateStorageSizeBasedRatePerEpoch(Cids.leafCountToRawSize(leafCount));
+}
+
+/**
+ * @notice Assemble the full PriceList from the USDFC constants.
+ * @dev `token` returns as the zero address; the caller populates it with the deployment's
+ *      USDFC instance address (FWSS holds it as an immutable).
+ */
+function priceList() pure returns (PriceList memory) {
+    return PriceList({
+        token: IERC20(address(0)),
+        rates: PriceListRates({
+            storagePerTibPerMonth: STORAGE_PRICE_PER_TIB_PER_MONTH,
+            datasetFeePerMonth: DATASET_FEE_PER_MONTH,
+            cdnEgressPerTib: CDN_EGRESS_PRICE_PER_TIB,
+            cacheMissEgressPerTib: CACHE_MISS_EGRESS_PRICE_PER_TIB
+        }),
+        fees: PriceListFees({
+            createDataSetFee: CREATE_DATA_SET_FEE,
+            addPiecesBaseFee: ADD_PIECES_BASE_FEE,
+            addPiecesPerPieceFee: ADD_PIECES_PER_PIECE_FEE,
+            schedulePieceRemovalsFee: SCHEDULE_PIECE_REMOVALS_FEE,
+            terminateFee: TERMINATE_FEE
+        }),
+        lockups: PriceListLockups({
+            lifecycleReserveTarget: LIFECYCLE_RESERVE_TARGET,
+            replenishThreshold: REPLENISH_THRESHOLD,
+            defaultLockupPeriod: DEFAULT_LOCKUP_PERIOD,
+            cdnLockupAmount: DEFAULT_CDN_LOCKUP_AMOUNT,
+            cacheMissLockupAmount: DEFAULT_CACHE_MISS_LOCKUP_AMOUNT,
+            cdnLockupPeriod: CDN_LOCKUP_PERIOD
+        })
+    });
 }

--- a/service_contracts/test/PriceList.t.sol
+++ b/service_contracts/test/PriceList.t.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+pragma solidity ^0.8.20;
+
+import {FilecoinWarmStorageServiceTest} from "./FilecoinWarmStorageService.t.sol";
+import {PriceList} from "../src/lib/PriceList.sol";
+import {
+    ADD_PIECES_BASE_FEE,
+    ADD_PIECES_PER_PIECE_FEE,
+    CACHE_MISS_EGRESS_PRICE_PER_TIB,
+    CDN_EGRESS_PRICE_PER_TIB,
+    CDN_LOCKUP_PERIOD,
+    CREATE_DATA_SET_FEE,
+    DATASET_FEE_PER_MONTH,
+    DEFAULT_CACHE_MISS_LOCKUP_AMOUNT,
+    DEFAULT_CDN_LOCKUP_AMOUNT,
+    DEFAULT_LOCKUP_PERIOD,
+    LIFECYCLE_RESERVE_TARGET,
+    REPLENISH_THRESHOLD,
+    SCHEDULE_PIECE_REMOVALS_FEE,
+    STORAGE_PRICE_PER_TIB_PER_MONTH,
+    TERMINATE_FEE
+} from "../src/lib/PriceListUSDFC.sol";
+
+/// @notice Round-trip the on-chain getPriceList() against the underlying constants.
+/// @dev If this test fails, the assembler in PriceListUSDFC.sol drifted from the constants —
+///      every constant should be wired through the struct exactly once.
+contract PriceListTest is FilecoinWarmStorageServiceTest {
+    function test_getPriceList_token() public view {
+        PriceList memory list = viewContract.getPriceList();
+        assertEq(address(list.token), address(mockUSDFC), "token should equal FWSS usdfcTokenAddress");
+    }
+
+    function test_getPriceList_rates() public view {
+        PriceList memory list = viewContract.getPriceList();
+        assertEq(list.rates.storagePerTibPerMonth, STORAGE_PRICE_PER_TIB_PER_MONTH, "storagePerTibPerMonth");
+        assertEq(list.rates.datasetFeePerMonth, DATASET_FEE_PER_MONTH, "datasetFeePerMonth");
+        assertEq(list.rates.cdnEgressPerTib, CDN_EGRESS_PRICE_PER_TIB, "cdnEgressPerTib");
+        assertEq(list.rates.cacheMissEgressPerTib, CACHE_MISS_EGRESS_PRICE_PER_TIB, "cacheMissEgressPerTib");
+    }
+
+    function test_getPriceList_fees() public view {
+        PriceList memory list = viewContract.getPriceList();
+        assertEq(list.fees.createDataSetFee, CREATE_DATA_SET_FEE, "createDataSetFee");
+        assertEq(list.fees.addPiecesBaseFee, ADD_PIECES_BASE_FEE, "addPiecesBaseFee");
+        assertEq(list.fees.addPiecesPerPieceFee, ADD_PIECES_PER_PIECE_FEE, "addPiecesPerPieceFee");
+        assertEq(list.fees.schedulePieceRemovalsFee, SCHEDULE_PIECE_REMOVALS_FEE, "schedulePieceRemovalsFee");
+        assertEq(list.fees.terminateFee, TERMINATE_FEE, "terminateFee");
+    }
+
+    function test_getPriceList_lockups() public view {
+        PriceList memory list = viewContract.getPriceList();
+        assertEq(list.lockups.lifecycleReserveTarget, LIFECYCLE_RESERVE_TARGET, "lifecycleReserveTarget");
+        assertEq(list.lockups.replenishThreshold, REPLENISH_THRESHOLD, "replenishThreshold");
+        assertEq(list.lockups.defaultLockupPeriod, DEFAULT_LOCKUP_PERIOD, "defaultLockupPeriod");
+        assertEq(list.lockups.cdnLockupAmount, DEFAULT_CDN_LOCKUP_AMOUNT, "cdnLockupAmount");
+        assertEq(list.lockups.cacheMissLockupAmount, DEFAULT_CACHE_MISS_LOCKUP_AMOUNT, "cacheMissLockupAmount");
+        assertEq(list.lockups.cdnLockupPeriod, CDN_LOCKUP_PERIOD, "cdnLockupPeriod");
+    }
+}

--- a/service_contracts/tools/generate_view_contract.sh
+++ b/service_contracts/tools/generate_view_contract.sh
@@ -11,6 +11,7 @@ echo
 echo 'import {FilecoinWarmStorageService} from "./FilecoinWarmStorageService.sol";'
 echo 'import {FilecoinWarmStorageServiceStateInternalLibrary} from "./lib/FilecoinWarmStorageServiceStateInternalLibrary.sol";'
 echo 'import {IPDPProvingSchedule} from "@pdp/IPDPProvingSchedule.sol";'
+echo 'import {PriceList} from "./lib/PriceList.sol";'
 
 echo contract FilecoinWarmStorageServiceStateView is IPDPProvingSchedule {
 echo "    using FilecoinWarmStorageServiceStateInternalLibrary for FilecoinWarmStorageService;"


### PR DESCRIPTION
Single nested PriceList struct (token, rates, fees, lockups) returned from FilecoinWarmStorageServiceStateView, replacing the scattered `getServicePrice` / `getEffectiveRates` / `getCurrentPricingRates`. Legacy methods are marked `@custom:deprecated`, behaviour unchanged.

Ref: https://github.com/FilOzone/synapse-sdk/issues/763
Ref: https://github.com/FilOzone/filecoin-services/issues/469