### PR TITLE
feat(terminateService): immediate termination in the consent case

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -451,7 +451,7 @@ sequenceDiagram
     SP->>FWSS: (consent) terminateService(datasetId, payerSignature)
     FWSS->>FilecoinPayV1: terminateRail(railId)
     FilecoinPayV1-->>FWSS: rail terminated
-    Note over FilecoinPayV1: unilateral: rail enters 30-day lockup; consent: endEpoch = block.number
+    Note over FilecoinPayV1: unilateral enters 30-day lockup<br/>consent sets endEpoch = block.number
   end
 ```
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -206,7 +206,11 @@ Service is terminated by calling `terminateService(dataSetId)` on FWSS. Only the
 
 `terminateService` calls `FilecoinPay.terminateRail(pdpRailId)`. That call sets the rail's `endEpoch` and starts the lockup-period countdown to finalization. FilecoinPay then calls `railTerminated()` back into FWSS, since FWSS is the PDP rail's validator. The callback sets `info.pdpEndEpoch`, emits `PDPPaymentTerminated`, and verifies that the terminator is FWSS itself. The effect of that last check is that the PDP rail can only be terminated through `terminateService`. A direct `FilecoinPay.terminateRail` call from a client or SP is rejected inside the callback.
 
-CDN rails are not touched by `terminateService`. They remain active through the PDP rail's 30-day lockup window, allowing FilBeam to continue settling CDN usage during that period. When the dataset is subsequently deleted (`dataSetDeleted` callback), FWSS performs best-effort termination of CDN rails, giving FilBeam a 5-day settle window from that point. Any unsettled fixed lockup returns to the payer after the window closes.
+**Unilateral termination**: When the payer or SP terminates without a consent signature, `lockupPeriod` is left at its existing 30-day value and `endEpoch = block.number + lockupPeriod`. The payer's funds continue flowing to the provider during that window.
+
+**Immediate termination (consent case)**: When the SP calls `terminateService(dataSetId, extraData)` with a valid payer EIP-712 signature, FWSS sets `lockupPeriod = 0` before calling `terminateRail`, so `endEpoch = block.number` and the payer's streaming buffer is released immediately. The terminate fee is charged; any remaining lifecycle reserve is released at the next settlement.
+
+CDN rails are not touched by `terminateService`. In the standard case they remain active through the PDP rail's 30-day lockup window; in the immediate case the lockup window is zero so CDN settlement can proceed right away. When the dataset is subsequently deleted (`dataSetDeleted` callback), FWSS performs best-effort termination of CDN rails, giving FilBeam a 5-day settle window from that point. Any unsettled fixed lockup returns to the payer after the window closes.
 
 Client-initiated termination of a zero-rate rail (a CDN rail called directly on FilecoinPay) is permitted because `isAccountLockupFullySettled` is trivially true when the payment rate is zero. For a non-zero-rate rail like the PDP rail, a client whose account has fallen behind on lockup settlement cannot call `FilecoinPay.terminateRail` directly. However, `terminateService` on FWSS still works for the payer, because FWSS is the caller of `terminateRail` in that path.
 
@@ -442,11 +446,12 @@ sequenceDiagram
 
   rect rgba(248, 248, 248, 0.2)
     Note over Client: 7. Termination
-    Client->>FWSS: (option 1) terminateService(datasetId)
-    SP->>FWSS: (option 2) terminateService(datasetId)
+    Client->>FWSS: (unilateral) terminateService(datasetId)
+    SP->>FWSS: (unilateral) terminateService(datasetId)
+    SP->>FWSS: (consent) terminateService(datasetId, payerSignature)
     FWSS->>FilecoinPayV1: terminateRail(railId)
     FilecoinPayV1-->>FWSS: rail terminated
-    Note over FilecoinPayV1: rail enters lockup, settlement continues
+    Note over FilecoinPayV1: unilateral: rail enters 30-day lockup; consent: endEpoch = block.number
   end
 ```
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -238,6 +238,8 @@ require(settledUpTo >= endEpoch, RailNotFullySettled)
 3. Call `settleRail()` to complete settlement (rail may auto-finalize)
 4. Call `deleteDataSet()` to remove the dataset
 
+In the immediate termination case (`lockupPeriod = 0`, so `endEpoch = block.number`), steps 1–4 can all be batched into a single transaction: `terminateService` → `settleRail` → `deleteDataSet`.
+
 **State cleared**: The `dataSetDeleted` callback removes `dataSetInfo`, `provingDeadlines`, `provenThisPeriod`, `provingActivationEpoch`, `railToDataSet[pdpRailId]`, the dataset's entry in `clientDataSets[payer]`, and all `dataSetMetadata` entries. `clientNonces[payer][nonce]` is **not** cleared. It is retained to prevent replay of authorization signatures.
 
 **CDN rails are not checked**: The settled-up-to requirement above and the `pdpEndEpoch` checks in the timing list both apply to the PDP rail only. FWSS does not verify CDN rail termination or settlement before allowing dataset deletion, because it does not track the CDN rails' `endEpoch` (there is no validator callback to set it). In the normal flow this is safe: CDN rails are terminated as part of the `dataSetDeleted` callback itself.

--- a/SPEC.md
+++ b/SPEC.md
@@ -233,7 +233,7 @@ require(settledUpTo >= endEpoch, RailNotFullySettled)
 - Dataset deletion timing is controlled by proving period deadlines, not just the lockup period
 
 **Timing**: To delete a dataset after termination:
-1. Wait for `block.number > pdpEndEpoch` (lockup period elapsed)
+1. Wait for `block.number >= pdpEndEpoch` (lockup period elapsed)
 2. Wait for all proving period deadlines within the lockup to pass
 3. Call `settleRail()` to complete settlement (rail may auto-finalize)
 4. Call `deleteDataSet()` to remove the dataset

--- a/service_contracts/abi/Errors.abi.json
+++ b/service_contracts/abi/Errors.abi.json
@@ -97,6 +97,27 @@
   },
   {
     "type": "error",
+    "name": "CallerNotServiceProvider",
+    "inputs": [
+      {
+        "name": "dataSetId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "expectedServiceProvider",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "caller",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
     "name": "ChallengeWindowTooEarly",
     "inputs": [
       {

--- a/service_contracts/abi/FilecoinWarmStorageService.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageService.abi.json
@@ -1417,6 +1417,27 @@
   },
   {
     "type": "error",
+    "name": "CallerNotServiceProvider",
+    "inputs": [
+      {
+        "name": "dataSetId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "expectedServiceProvider",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "caller",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
     "name": "ChallengeWindowTooEarly",
     "inputs": [
       {

--- a/service_contracts/src/Errors.sol
+++ b/service_contracts/src/Errors.sol
@@ -185,6 +185,12 @@ library Errors {
     /// @param caller The actual caller
     error CallerNotPayer(uint256 dataSetId, address expectedPayer, address caller);
 
+    /// @notice Only the service provider can perform this action
+    /// @param dataSetId The data set ID
+    /// @param expectedServiceProvider The service provider address
+    /// @param caller The actual caller
+    error CallerNotServiceProvider(uint256 dataSetId, address expectedServiceProvider, address caller);
+
     /// @notice Data set is beyond its payment end epoch
     /// @param dataSetId The data set ID
     /// @param pdpEndEpoch The payment end epoch for the data set

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -1006,6 +1006,7 @@ contract FilecoinWarmStorageService is
         require(info.pdpEndEpoch == 0, Errors.DataSetPaymentAlreadyTerminated(dataSetId));
 
         address approver;
+        bool immediate = false;
         if (extraData.length > 0) {
             require(
                 extraData.length <= MAX_TERMINATE_SERVICE_EXTRA_DATA_SIZE,
@@ -1014,7 +1015,7 @@ contract FilecoinWarmStorageService is
             bytes memory signature = abi.decode(extraData, (bytes));
             approver = _verifyTerminateServiceSignature(info.payer, dataSetId, signature);
             if (msg.sender == info.serviceProvider) {
-                // TODO termination can be immediate
+                immediate = true;
                 info.pendingOneTimePayments += uint96(TERMINATE_FEE);
             }
         } else {
@@ -1033,6 +1034,9 @@ contract FilecoinWarmStorageService is
             updatePaymentRates(dataSetId, info, leafCount, pending, info.lifecycleReserveBalance);
         }
 
+        if (immediate) {
+            payments.modifyRailLockup(info.pdpRailId, 0, 0);
+        }
         payments.terminateRail(info.pdpRailId);
 
         emit ServiceTerminated(approver, dataSetId, info.pdpRailId, info.cacheMissRailId, info.cdnRailId);

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -655,7 +655,7 @@ contract FilecoinWarmStorageService is
         } else {
             // Normal path: terminateService was already called.
             // Verify the payment window has elapsed and the rail is fully settled.
-            require(block.number > info.pdpEndEpoch, Errors.PaymentRailsNotFinalized(dataSetId, info.pdpEndEpoch));
+            require(block.number >= info.pdpEndEpoch, Errors.PaymentRailsNotFinalized(dataSetId, info.pdpEndEpoch));
             try payments.getRail(info.pdpRailId) returns (FilecoinPayV1.RailView memory rail) {
                 require(
                     rail.settledUpTo >= rail.endEpoch,

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -841,7 +841,7 @@ contract FilecoinWarmStorageService is
 
         uint96 newPending = info.pendingOneTimePayments + uint96(SCHEDULE_PIECE_REMOVALS_FEE);
         info.lifecycleReserveBalance = FilecoinPayV1(paymentsContractAddress).replenishReserveIfNeeded(
-            info.pdpRailId, info.pdpEndEpoch, info.lifecycleReserveBalance, newPending, false
+            info.pdpRailId, info.pdpEndEpoch, info.lifecycleReserveBalance, newPending
         );
         info.pendingOneTimePayments = newPending;
 

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -774,7 +774,7 @@ contract FilecoinWarmStorageService is
 
         // Validate lockup for the new data set size (fail-fast if client has insufficient funds)
         uint256 currentLeafCount = IPDPVerifier(pdpVerifierAddress).getDataSetLeafCount(dataSetId);
-        updatePaymentRates(dataSetId, info, currentLeafCount, pending, reserveBalance);
+        updatePaymentRates(dataSetId, info, currentLeafCount, pending, reserveBalance, false);
 
         // Store metadata for each new piece
         for (uint256 i = 0; i < pieceData.length; i++) {
@@ -841,7 +841,7 @@ contract FilecoinWarmStorageService is
 
         uint96 newPending = info.pendingOneTimePayments + uint96(SCHEDULE_PIECE_REMOVALS_FEE);
         info.lifecycleReserveBalance = FilecoinPayV1(paymentsContractAddress).replenishReserveIfNeeded(
-            info.pdpRailId, info.pdpEndEpoch, info.lifecycleReserveBalance, newPending
+            info.pdpRailId, info.pdpEndEpoch, info.lifecycleReserveBalance, newPending, false
         );
         info.pendingOneTimePayments = newPending;
 
@@ -922,7 +922,7 @@ contract FilecoinWarmStorageService is
 
             // Rate was already set in piecesAdded; only update if pieces were removed or fees are pending
             if (processScheduledPieceMetadataRemovals(dataSetId) || pending > 0) {
-                updatePaymentRates(dataSetId, info, leafCount, pending, reserveBalance);
+                updatePaymentRates(dataSetId, info, leafCount, pending, reserveBalance, false);
             }
 
             return;
@@ -972,7 +972,7 @@ contract FilecoinWarmStorageService is
         // Additions update rate immediately in piecesAdded; update here if pieces were removed or fees are pending
         bool hadRemovals = processScheduledPieceMetadataRemovals(dataSetId);
         if (hadRemovals || pending > 0) {
-            updatePaymentRates(dataSetId, info, leafCount, pending, reserveBalance);
+            updatePaymentRates(dataSetId, info, leafCount, pending, reserveBalance, false);
         }
     }
 
@@ -1006,7 +1006,7 @@ contract FilecoinWarmStorageService is
         require(info.pdpEndEpoch == 0, Errors.DataSetPaymentAlreadyTerminated(dataSetId));
 
         address approver;
-        bool immediate = false;
+        bool immediateTermination = false;
         if (extraData.length > 0) {
             require(
                 extraData.length <= MAX_TERMINATE_SERVICE_EXTRA_DATA_SIZE,
@@ -1015,7 +1015,7 @@ contract FilecoinWarmStorageService is
             bytes memory signature = abi.decode(extraData, (bytes));
             approver = _verifyTerminateServiceSignature(info.payer, dataSetId, signature);
             if (msg.sender == info.serviceProvider) {
-                immediate = true;
+                immediateTermination = true;
                 info.pendingOneTimePayments += uint96(TERMINATE_FEE);
             }
         } else {
@@ -1031,12 +1031,9 @@ contract FilecoinWarmStorageService is
         uint96 pending = info.pendingOneTimePayments;
         if (pending > 0) {
             uint256 leafCount = IPDPVerifier(pdpVerifierAddress).getDataSetLeafCount(dataSetId);
-            updatePaymentRates(dataSetId, info, leafCount, pending, info.lifecycleReserveBalance);
+            updatePaymentRates(dataSetId, info, leafCount, pending, info.lifecycleReserveBalance, immediateTermination);
         }
 
-        if (immediate) {
-            payments.modifyRailLockup(info.pdpRailId, 0, 0);
-        }
         payments.terminateRail(info.pdpRailId);
 
         emit ServiceTerminated(approver, dataSetId, info.pdpRailId, info.cacheMissRailId, info.cdnRailId);
@@ -1159,13 +1156,14 @@ contract FilecoinWarmStorageService is
         DataSetInfo storage info,
         uint256 leafCount,
         uint96 pending,
-        uint96 reserveBalance
+        uint96 reserveBalance,
+        bool immediateTermination
     ) internal {
         uint256 pdpRailId = info.pdpRailId;
         require(pdpRailId != 0, Errors.NoPDPPaymentRail(dataSetId));
 
         info.lifecycleReserveBalance = FilecoinPayV1(paymentsContractAddress).updateStorageRates(
-            dataSetId, pdpRailId, leafCount, pending, reserveBalance, info.pdpEndEpoch
+            dataSetId, pdpRailId, leafCount, pending, reserveBalance, info.pdpEndEpoch, immediateTermination
         );
         info.pendingOneTimePayments = 0;
     }

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -1009,15 +1009,17 @@ contract FilecoinWarmStorageService is
         bool immediateTermination = false;
         if (extraData.length > 0) {
             require(
+                msg.sender == info.serviceProvider,
+                Errors.CallerNotServiceProvider(dataSetId, info.serviceProvider, msg.sender)
+            );
+            require(
                 extraData.length <= MAX_TERMINATE_SERVICE_EXTRA_DATA_SIZE,
                 Errors.ExtraDataTooLarge(extraData.length, MAX_TERMINATE_SERVICE_EXTRA_DATA_SIZE)
             );
             bytes memory signature = abi.decode(extraData, (bytes));
             approver = _verifyTerminateServiceSignature(info.payer, dataSetId, signature);
-            if (msg.sender == info.serviceProvider) {
-                immediateTermination = true;
-                info.pendingOneTimePayments += uint96(TERMINATE_FEE);
-            }
+            immediateTermination = true;
+            info.pendingOneTimePayments += uint96(TERMINATE_FEE);
         } else {
             require(
                 msg.sender == info.payer || msg.sender == info.serviceProvider,

--- a/service_contracts/src/lib/Rails.sol
+++ b/service_contracts/src/lib/Rails.sol
@@ -260,13 +260,8 @@ library Rails {
         uint256 pdpRailId,
         uint256 pdpEndEpoch,
         uint96 reserveBalance,
-        uint96 pending,
-        bool immediateTermination
+        uint96 pending
     ) internal returns (uint96) {
-        if (immediateTermination) {
-            payments.modifyRailLockup(pdpRailId, 0, pending);
-            return pending;
-        }
         if (pdpEndEpoch == 0 && reserveBalance < pending + uint96(REPLENISH_THRESHOLD)) {
             uint96 newLockup = uint96(LIFECYCLE_RESERVE_TARGET) + pending;
             payments.modifyRailLockup(pdpRailId, DEFAULT_LOCKUP_PERIOD, newLockup);
@@ -286,9 +281,13 @@ library Rails {
         bool immediateTermination
     ) public returns (uint96 newReserveBalance) {
         uint256 newStorageRatePerEpoch = calculateStorageRate(leafCount);
-        newReserveBalance = replenishReserveIfNeeded(
-            payments, pdpRailId, pdpEndEpoch, reserveBalance, pending, immediateTermination
-        ) - pending;
+        if (immediateTermination) {
+            payments.modifyRailLockup(pdpRailId, 0, pending);
+            newReserveBalance = 0;
+        } else {
+            newReserveBalance =
+                replenishReserveIfNeeded(payments, pdpRailId, pdpEndEpoch, reserveBalance, pending) - pending;
+        }
         payments.modifyRailPayment(pdpRailId, newStorageRatePerEpoch, pending);
         emit RailRateUpdated(dataSetId, pdpRailId, newStorageRatePerEpoch);
     }

--- a/service_contracts/src/lib/Rails.sol
+++ b/service_contracts/src/lib/Rails.sol
@@ -260,8 +260,13 @@ library Rails {
         uint256 pdpRailId,
         uint256 pdpEndEpoch,
         uint96 reserveBalance,
-        uint96 pending
+        uint96 pending,
+        bool immediateTermination
     ) internal returns (uint96) {
+        if (immediateTermination) {
+            payments.modifyRailLockup(pdpRailId, 0, pending);
+            return pending;
+        }
         if (pdpEndEpoch == 0 && reserveBalance < pending + uint96(REPLENISH_THRESHOLD)) {
             uint96 newLockup = uint96(LIFECYCLE_RESERVE_TARGET) + pending;
             payments.modifyRailLockup(pdpRailId, DEFAULT_LOCKUP_PERIOD, newLockup);
@@ -277,11 +282,13 @@ library Rails {
         uint256 leafCount,
         uint96 pending,
         uint96 reserveBalance,
-        uint256 pdpEndEpoch
+        uint256 pdpEndEpoch,
+        bool immediateTermination
     ) public returns (uint96 newReserveBalance) {
         uint256 newStorageRatePerEpoch = calculateStorageRate(leafCount);
-        newReserveBalance =
-            replenishReserveIfNeeded(payments, pdpRailId, pdpEndEpoch, reserveBalance, pending) - pending;
+        newReserveBalance = replenishReserveIfNeeded(
+            payments, pdpRailId, pdpEndEpoch, reserveBalance, pending, immediateTermination
+        ) - pending;
         payments.modifyRailPayment(pdpRailId, newStorageRatePerEpoch, pending);
         emit RailRateUpdated(dataSetId, pdpRailId, newStorageRatePerEpoch);
     }

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -2617,6 +2617,18 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         assertEq(viewContract.getDataSet(dataSetId).pdpRailId, 0, "dataset should be deleted");
     }
 
+    function testTerminateService_extraData_callerNotServiceProvider() public {
+        (string[] memory keys, string[] memory values) = _getSingleMetadataKV("label", "caller not sp test");
+        uint256 dataSetId = createDataSetForClient(serviceProvider, client, keys, values);
+
+        bytes memory sig = abi.encode(FAKE_SIGNATURE);
+        vm.prank(client);
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.CallerNotServiceProvider.selector, dataSetId, serviceProvider, client)
+        );
+        pdpServiceWithPayments.terminateService(dataSetId, sig);
+    }
+
     function testTerminateService_directPayer_emitsApprover() public {
         (string[] memory keys, string[] memory values) = _getSingleMetadataKV("label", "test");
         uint256 dataSetId = createDataSetForClient(serviceProvider, client, keys, values);

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -2606,6 +2606,9 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         pdpServiceWithPayments.terminateService(dataSetId, sig);
 
         assertTrue(viewContract.getDataSet(dataSetId).pdpEndEpoch > 0, "dataset should be terminated");
+        FilecoinPayV1.RailView memory pdpRail = payments.getRail(info.pdpRailId);
+        assertEq(pdpRail.lockupPeriod, 0, "lockup period should be 0 for immediate termination");
+        assertEq(pdpRail.lockupFixed, 0, "lockup fixed should be 0 for immediate termination");
     }
 
     function testTerminateService_directPayer_emitsApprover() public {
@@ -2628,6 +2631,13 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         emit FilecoinWarmStorageService.ServiceTerminated(serviceProvider, dataSetId, info.pdpRailId, 0, 0);
         vm.prank(serviceProvider);
         pdpServiceWithPayments.terminateService(dataSetId);
+
+        FilecoinPayV1.RailView memory pdpRail = payments.getRail(info.pdpRailId);
+        assertEq(
+            pdpRail.lockupPeriod,
+            DEFAULT_LOCKUP_PERIOD,
+            "lockup period should remain DEFAULT_LOCKUP_PERIOD for non-consensual termination"
+        );
     }
 
     function testTerminateService_sessionKey() public {

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -2609,6 +2609,12 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         FilecoinPayV1.RailView memory pdpRail = payments.getRail(info.pdpRailId);
         assertEq(pdpRail.lockupPeriod, 0, "lockup period should be 0 for immediate termination");
         assertEq(pdpRail.lockupFixed, 0, "lockup fixed should be 0 for immediate termination");
+
+        // With lockupPeriod = 0, endEpoch = block.number — no need to advance blocks
+        payments.settleRail(info.pdpRailId, pdpRail.endEpoch);
+        vm.prank(serviceProvider);
+        mockPDPVerifier.deleteDataSet(pdpServiceWithPayments, dataSetId, "");
+        assertEq(viewContract.getDataSet(dataSetId).pdpRailId, 0, "dataset should be deleted");
     }
 
     function testTerminateService_directPayer_emitsApprover() public {

--- a/service_contracts/test/OpFees.t.sol
+++ b/service_contracts/test/OpFees.t.sol
@@ -202,6 +202,8 @@ contract OpFeesTest is FilecoinWarmStorageServiceTest {
         uint96 reserveBefore = info.lifecycleReserveBalance;
         assertEq(info.pendingOneTimePayments, 0);
 
+        (, uint256 spFundsBefore,,) = payments.getAccountInfoIfSettled(mockUSDFC, sp1);
+
         // Consent case: payer signs off-chain, SP submits with signature in extraData
         makeSignaturePass(client);
         vm.prank(sp1);
@@ -209,8 +211,15 @@ contract OpFeesTest is FilecoinWarmStorageServiceTest {
 
         info = viewContract.getDataSet(dataSetId);
         assertEq(info.pendingOneTimePayments, 0, "fee flushed at termination");
-        assertEq(info.lifecycleReserveBalance, reserveBefore - TERMINATE_FEE, "reserve decreased by fee");
-        assertEq(payments.getRail(pdpRailId).lockupFixed, info.lifecycleReserveBalance, "lockupFixed mirrors reserve");
+        assertEq(info.lifecycleReserveBalance, 0, "reserve fully released on immediate termination");
+        assertEq(payments.getRail(pdpRailId).lockupFixed, 0, "lockupFixed zeroed after fee deducted");
+
+        uint256 networkFee = (TERMINATE_FEE * payments.NETWORK_FEE_NUMERATOR() + payments.NETWORK_FEE_DENOMINATOR() - 1)
+            / payments.NETWORK_FEE_DENOMINATOR();
+        (, uint256 spFundsAfter,,) = payments.getAccountInfoIfSettled(mockUSDFC, sp1);
+        assertEq(
+            spFundsAfter - spFundsBefore, TERMINATE_FEE - networkFee, "SP received terminate fee net of network fee"
+        );
     }
 
     function test_terminateFee_notChargedOnPayerDirectCall() public {
@@ -331,6 +340,8 @@ contract OpFeesTest is FilecoinWarmStorageServiceTest {
         FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
         uint96 reserveAfterAdd = info.lifecycleReserveBalance;
 
+        (, uint256 spFundsBefore,,) = payments.getAccountInfoIfSettled(mockUSDFC, sp1);
+
         // Consent case: payer signs off-chain, SP submits; no removals scheduled
         makeSignaturePass(client);
         vm.prank(sp1);
@@ -338,10 +349,16 @@ contract OpFeesTest is FilecoinWarmStorageServiceTest {
 
         info = viewContract.getDataSet(dataSetId);
         assertEq(info.pendingOneTimePayments, 0, "TERMINATE_FEE flushed at termination");
-        assertEq(info.lifecycleReserveBalance, reserveAfterAdd - TERMINATE_FEE, "reserve decreased by fee");
+        assertEq(info.lifecycleReserveBalance, 0, "reserve fully released on immediate termination");
 
-        FilecoinPayV1.RailView memory rail = payments.getRail(pdpRailId);
-        assertEq(rail.lockupFixed, info.lifecycleReserveBalance, "lockupFixed mirrors reserve");
+        assertEq(payments.getRail(pdpRailId).lockupFixed, 0, "lockupFixed zeroed after fee deducted");
+
+        uint256 networkFee = (TERMINATE_FEE * payments.NETWORK_FEE_NUMERATOR() + payments.NETWORK_FEE_DENOMINATOR() - 1)
+            / payments.NETWORK_FEE_DENOMINATOR();
+        (, uint256 spFundsAfter,,) = payments.getAccountInfoIfSettled(mockUSDFC, sp1);
+        assertEq(
+            spFundsAfter - spFundsBefore, TERMINATE_FEE - networkFee, "SP received terminate fee net of network fee"
+        );
     }
 
     // CREATE_DATA_SET_FEE must be collected even when the dataset is terminated before any proving.

--- a/service_contracts/test/OpFees.t.sol
+++ b/service_contracts/test/OpFees.t.sol
@@ -200,6 +200,10 @@ contract OpFeesTest is FilecoinWarmStorageServiceTest {
 
         FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
         uint96 reserveBefore = info.lifecycleReserveBalance;
+        assertEq(
+            reserveBefore,
+            LIFECYCLE_RESERVE_TARGET - CREATE_DATA_SET_FEE - ADD_PIECES_BASE_FEE - ADD_PIECES_PER_PIECE_FEE
+        );
         assertEq(info.pendingOneTimePayments, 0);
 
         (, uint256 spFundsBefore,,) = payments.getAccountInfoIfSettled(mockUSDFC, sp1);
@@ -339,6 +343,10 @@ contract OpFeesTest is FilecoinWarmStorageServiceTest {
 
         FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
         uint96 reserveAfterAdd = info.lifecycleReserveBalance;
+        assertEq(
+            reserveAfterAdd,
+            LIFECYCLE_RESERVE_TARGET - CREATE_DATA_SET_FEE - ADD_PIECES_BASE_FEE - ADD_PIECES_PER_PIECE_FEE
+        );
 
         (, uint256 spFundsBefore,,) = payments.getAccountInfoIfSettled(mockUSDFC, sp1);
 


### PR DESCRIPTION

Reviewers @zenground0 @rvagg
If both the SP and the client agree, termination is immediate.
The final lockup period is 0, and deletion and cleanup can proceed.
Perhaps we should also `settleRail` in this case, but I don't currently think that's beneficial because of the case where the rail is far behind.
I pass the flag down to the Rails library to ensure that we only `modifyRailLockup` once.
#### Changes
* implement immediate termination
* update doc and tests