### PR TITLE
feat: FWSS v1.3.0 version bump

### DIFF
--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -78,7 +78,7 @@ contract FilecoinWarmStorageService is
     EIP712Upgradeable
 {
     // Version tracking
-    string public constant VERSION = "1.2.0";
+    string public constant VERSION = "1.3.0";
 
     using Rails for FilecoinPayV1;
 

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -5554,7 +5554,7 @@ contract FilecoinWarmStorageServiceUpgradeTest is Test {
             if (logs[i].topics[0] == expectedTopic) {
                 // Decode and verify the event data
                 (string memory version, address implementation) = abi.decode(logs[i].data, (string, address));
-                assertEq(version, "1.2.0", "Version should be 1.2.0");
+                assertEq(version, "1.3.0", "Version should be 1.3.0");
                 assertTrue(implementation != address(0), "Implementation address should not be zero");
                 foundEvent = true;
                 break;


### PR DESCRIPTION
## Summary
- bump `FilecoinWarmStorageService.VERSION()` to `1.3.0`
- update the FWSS upgrade test expectation to match the new release version

## Validation
- `cd service_contracts && forge test --match-contract FilecoinWarmStorageServiceUpgradeTest`
- `cd service_contracts && forge inspect src/FilecoinWarmStorageService.sol:FilecoinWarmStorageService storageLayout --extra-output storageLayout`

## Notes
- This PR intentionally avoids deployment address, release branch, tag, or changelog changes. Those are tracked separately in the FWSS v1.3.0 release issue.
- While working through the checklist, the storage-layout command was updated in #508/#509 to include `--extra-output storageLayout` so it works from a clean artifact state.

Tracks checklist work in https://github.com/FilOzone/filecoin-services/issues/509
