### PR TITLE
fix(abandonment): unblock finalize settle past open proving period

### DIFF
--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -651,12 +651,10 @@ contract FilecoinWarmStorageService is
             // Abandonment path: rail was never terminated via terminateService.
             // SP forfeits pending op-fees; lifecycle reserve returns to the payer.
             _verifyInactivity(dataSetId);
-            payments.settleAbandonedRail(info.pdpRailId);
-            // Wipe activation so validatePayment short-circuits the finalize settle past the
-            // still-open final proving period. The trailing cleanup re-deletes this slot
-            // harmlessly. No new state.
-            delete provingActivationEpoch[dataSetId];
-            payments.finalizeAbandonedRails(dataSetId, info.pdpRailId, info.cacheMissRailId, info.cdnRailId);
+            // abandonRails also terminates CDN rails and clears the proving activation epoch
+            payments.abandonRails(
+                provingActivationEpoch, dataSetId, info.pdpRailId, info.cacheMissRailId, info.cdnRailId
+            );
         } else {
             // Normal path: terminateService was already called.
             // Verify the payment window has elapsed and the rail is fully settled.
@@ -669,11 +667,11 @@ contract FilecoinWarmStorageService is
             } catch {
                 // Rail is finalized (zeroed out), meaning it was already fully settled
             }
-        }
-
-        // Terminate CDN rails if configured, giving FilBeam a graceful settle window
-        if (info.cdnRailId != 0) {
-            _terminateCDNRails(dataSetId, info, payments);
+            // Terminate CDN rails if configured, giving FilBeam a graceful settle window
+            if (info.cdnRailId != 0) {
+                _terminateCDNRails(dataSetId, info, payments);
+            }
+            delete provingActivationEpoch[dataSetId];
         }
 
         // NOTE keep clientNonces[payer][clientDataSetId] to prevent replay
@@ -692,7 +690,6 @@ contract FilecoinWarmStorageService is
         // Clean up proving-related state
         delete provingDeadlines[dataSetId];
         delete provenThisPeriod[dataSetId];
-        delete provingActivationEpoch[dataSetId];
 
         // Clean up rail mappings
         delete railToDataSet[info.pdpRailId];
@@ -1482,7 +1479,7 @@ contract FilecoinWarmStorageService is
 
         // No proving activity: pay nothing, advance settleUpto = toEpoch so settleRail can
         // discharge lockup. Hit by never-activated data sets and by the finalize leg of
-        // abandonment (which wipes activationEpoch between settles to unblock the open period).
+        // abandonment (which wipes activationEpoch between settles to unblock the open period)
         uint256 activationEpoch = provingActivationEpoch[dataSetId];
         if (activationEpoch == 0) {
             return ValidationResult({modifiedAmount: 0, settleUpto: toEpoch, note: "No proving activity"});

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -651,7 +651,12 @@ contract FilecoinWarmStorageService is
             // Abandonment path: rail was never terminated via terminateService.
             // SP forfeits pending op-fees; lifecycle reserve returns to the payer.
             _verifyInactivity(dataSetId);
-            payments.abandonRails(dataSetId, info.pdpRailId, info.cacheMissRailId, info.cdnRailId);
+            payments.settleAbandonedRail(info.pdpRailId);
+            // Short-circuit validatePayment for the finalize settle: without this, the open
+            // final proving period reverts settlement with NoProgressInSettlement. Relocates
+            // the cleanup below; no new state.
+            delete provingActivationEpoch[dataSetId];
+            payments.finalizeAbandonedRails(dataSetId, info.pdpRailId, info.cacheMissRailId, info.cdnRailId);
         } else {
             // Normal path: terminateService was already called.
             // Verify the payment window has elapsed and the rail is fully settled.
@@ -1475,16 +1480,12 @@ contract FilecoinWarmStorageService is
         uint256 totalEpochsRequested = toEpoch - fromEpoch;
         require(totalEpochsRequested > 0, Errors.InvalidEpochRange(fromEpoch, toEpoch));
 
-        // Proving never activated: no payment due, but settleUpto = toEpoch (not fromEpoch) lets
-        // settleRail advance and discharge lockup. Without this, settleRail reverts with
-        // NoProgressInSettlement, which blocks the abandonment teardown path.
+        // No proving activity: pay nothing, advance settleUpto = toEpoch so settleRail can
+        // discharge lockup. Hit by never-activated data sets and by the finalize leg of
+        // abandonment (which wipes activationEpoch between settles to unblock the open period).
         uint256 activationEpoch = provingActivationEpoch[dataSetId];
         if (activationEpoch == 0) {
-            return ValidationResult({
-                modifiedAmount: 0,
-                settleUpto: toEpoch,
-                note: "Proving never activated for this data set"
-            });
+            return ValidationResult({modifiedAmount: 0, settleUpto: toEpoch, note: "No proving activity"});
         }
 
         // Count proven epochs up to toEpoch, possibly stopping earlier if unresolved

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -652,9 +652,9 @@ contract FilecoinWarmStorageService is
             // SP forfeits pending op-fees; lifecycle reserve returns to the payer.
             _verifyInactivity(dataSetId);
             payments.settleAbandonedRail(info.pdpRailId);
-            // Short-circuit validatePayment for the finalize settle: without this, the open
-            // final proving period reverts settlement with NoProgressInSettlement. Relocates
-            // the cleanup below; no new state.
+            // Wipe activation so validatePayment short-circuits the finalize settle past the
+            // still-open final proving period. The trailing cleanup re-deletes this slot
+            // harmlessly. No new state.
             delete provingActivationEpoch[dataSetId];
             payments.finalizeAbandonedRails(dataSetId, info.pdpRailId, info.cacheMissRailId, info.cdnRailId);
         } else {

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -647,6 +647,9 @@ contract FilecoinWarmStorageService is
         address payer = info.payer;
         FilecoinPayV1 payments = FilecoinPayV1(paymentsContractAddress);
 
+        // Cache before either branch clears it — needed to bound the provenPeriods loop below.
+        uint256 activation = provingActivationEpoch[dataSetId];
+
         if (info.pdpEndEpoch == 0) {
             // Abandonment path: rail was never terminated via terminateService.
             // SP forfeits pending op-fees; lifecycle reserve returns to the payer.
@@ -690,6 +693,13 @@ contract FilecoinWarmStorageService is
         // Clean up proving-related state
         delete provingDeadlines[dataSetId];
         delete provenThisPeriod[dataSetId];
+        if (activation != 0) {
+            uint256 lastPeriod = _provingPeriodForEpoch(activation, block.number, maxProvingPeriod);
+            uint256 lastSlot = lastPeriod >> 8;
+            for (uint256 slot = 0; slot <= lastSlot; slot++) {
+                delete provenPeriods[dataSetId][slot];
+            }
+        }
 
         // Clean up rail mappings
         delete railToDataSet[info.pdpRailId];

--- a/service_contracts/src/lib/Rails.sol
+++ b/service_contracts/src/lib/Rails.sol
@@ -166,30 +166,32 @@ library Rails {
         emit CDNServiceTerminated(msg.sender, dataSetId, cacheMissRailId, cdnRailId);
     }
 
-    /// @notice Abandonment teardown, leg 1: pays proven epochs, releases reserve + buffer to payer.
-    /// @dev Pairs with `finalizeAbandonedRails`. Caller wipes `provingActivationEpoch` between
-    ///      legs so the finalize settle can advance past the open proving period.
-    function settleAbandonedRail(FilecoinPayV1 payments, uint256 pdpRailId) public {
-        payments.settleRail(pdpRailId, block.number);
-        payments.modifyRailLockup(pdpRailId, 0, 0);
-    }
-
-    /// @notice Abandonment teardown, leg 2: tears down CDN rails, terminates and finalises PDP rail.
-    /// @dev Requires the validator to have cleared activation for this data set so the
-    ///      post-terminate settle advances past the open proving period. CDN teardown is
-    ///      best-effort; rails may already be terminated externally.
-    function finalizeAbandonedRails(
+    /// @notice Tears down all rails for an abandoned data set.
+    /// @dev SP forfeits pending op-fees; lifecycle reserve and streaming buffer return to the
+    ///      payer. Intentional: abandonment means the SP walked away.
+    ///      PDP rail flow: settle to pay any proven epochs and advance settledUpTo; zero the
+    ///      lockup to release buffer+reserve to the payer; terminate (endEpoch = block.number
+    ///      since period is 0); settle again so settledUpTo >= endEpoch finalises the rail.
+    ///      CDN rails are best-effort, may have been terminated externally.
+    function abandonRails(
         FilecoinPayV1 payments,
+        mapping(uint256 dataSetId => uint256 activationEpoch) storage provingActivationEpoch,
         uint256 dataSetId,
         uint256 pdpRailId,
         uint256 cacheMissRailId,
         uint256 cdnRailId
     ) public {
+        payments.settleRail(pdpRailId, block.number);
+        payments.modifyRailLockup(pdpRailId, 0, 0);
+
         if (cdnRailId != 0) {
             _teardownCDNRail(payments, cacheMissRailId);
             _teardownCDNRail(payments, cdnRailId);
             emit CDNServiceTerminated(msg.sender, dataSetId, cacheMissRailId, cdnRailId);
         }
+
+        // clearing this allows settling up to block.number
+        delete provingActivationEpoch[dataSetId];
 
         payments.terminateRail(pdpRailId);
         payments.settleRail(pdpRailId, block.number);

--- a/service_contracts/src/lib/Rails.sol
+++ b/service_contracts/src/lib/Rails.sol
@@ -166,23 +166,25 @@ library Rails {
         emit CDNServiceTerminated(msg.sender, dataSetId, cacheMissRailId, cdnRailId);
     }
 
-    /// @notice Tears down all rails for an abandoned data set.
-    /// @dev SP forfeits pending op-fees; lifecycle reserve and streaming buffer return to the
-    ///      payer. Intentional: abandonment means the SP walked away.
-    ///      PDP rail flow: settle to pay any proven epochs and advance settledUpTo; zero the
-    ///      lockup to release buffer+reserve to the payer; terminate (endEpoch = block.number
-    ///      since period is 0); settle again so settledUpTo >= endEpoch finalises the rail.
-    ///      CDN rails are best-effort, may have been terminated externally.
-    function abandonRails(
+    /// @notice Abandonment teardown, leg 1: pays proven epochs, releases reserve + buffer to payer.
+    /// @dev Pairs with `finalizeAbandonedRails`. Caller wipes `provingActivationEpoch` between
+    ///      legs so the finalize settle can advance past the open proving period.
+    function settleAbandonedRail(FilecoinPayV1 payments, uint256 pdpRailId) public {
+        payments.settleRail(pdpRailId, block.number);
+        payments.modifyRailLockup(pdpRailId, 0, 0);
+    }
+
+    /// @notice Abandonment teardown, leg 2: tears down CDN rails, terminates and finalises PDP rail.
+    /// @dev Requires the validator to have cleared activation for this data set so the
+    ///      post-terminate settle advances past the open proving period. CDN teardown is
+    ///      best-effort; rails may already be terminated externally.
+    function finalizeAbandonedRails(
         FilecoinPayV1 payments,
         uint256 dataSetId,
         uint256 pdpRailId,
         uint256 cacheMissRailId,
         uint256 cdnRailId
     ) public {
-        payments.settleRail(pdpRailId, block.number);
-        payments.modifyRailLockup(pdpRailId, 0, 0);
-
         if (cdnRailId != 0) {
             _teardownCDNRail(payments, cacheMissRailId);
             _teardownCDNRail(payments, cdnRailId);

--- a/service_contracts/test/Abandonment.t.sol
+++ b/service_contracts/test/Abandonment.t.sol
@@ -138,6 +138,9 @@ contract AbandonmentTest is MockFVMTest {
         assertEq(info.commissionBps, 0, "commissionBps");
         assertEq(info.pdpEndEpoch, 0, "pdpEndEpoch");
         assertEq(info.providerId, 0, "providerId");
+        assertEq(info.clientDataSetId, 0, "clientDataSetId");
+        assertEq(info.pendingOneTimePayments, 0, "pendingOneTimePayments");
+        assertEq(info.lifecycleReserveBalance, 0, "lifecycleReserveBalance");
 
         (string[] memory keys,) = viewContract.getAllDataSetMetadata(dataSetId);
         assertEq(keys.length, 0, "metadata keys");

--- a/service_contracts/test/Abandonment.t.sol
+++ b/service_contracts/test/Abandonment.t.sol
@@ -128,6 +128,10 @@ contract AbandonmentTest is MockFVMTest {
         bytes32 provenThisPeriodSlot = keccak256(abi.encode(dataSetId, uint256(PROVEN_THIS_PERIOD_SLOT)));
         assertEq(uint256(vm.load(address(fwss), provenThisPeriodSlot)), 0, "provenThisPeriod");
 
+        bytes32 provenPeriodsInner = keccak256(abi.encode(dataSetId, uint256(PROVEN_PERIODS_SLOT)));
+        bytes32 provenPeriodsBitmap0 = keccak256(abi.encode(uint256(0), provenPeriodsInner));
+        assertEq(uint256(vm.load(address(fwss), provenPeriodsBitmap0)), 0, "provenPeriods[0]");
+
         FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
         assertEq(info.pdpRailId, 0, "pdpRailId");
         assertEq(info.cacheMissRailId, 0, "cacheMissRailId");

--- a/service_contracts/test/Abandonment.t.sol
+++ b/service_contracts/test/Abandonment.t.sol
@@ -10,7 +10,12 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import {FilecoinWarmStorageService, PDP_INACTIVITY_WINDOW} from "../src/FilecoinWarmStorageService.sol";
 import {FilecoinWarmStorageServiceStateView} from "../src/FilecoinWarmStorageServiceStateView.sol";
-import {PROVEN_PERIODS_SLOT, PROVING_ACTIVATION_EPOCH_SLOT} from "../src/lib/FilecoinWarmStorageServiceLayout.sol";
+import {
+    PROVEN_PERIODS_SLOT,
+    PROVING_ACTIVATION_EPOCH_SLOT,
+    PROVING_DEADLINES_SLOT,
+    PROVEN_THIS_PERIOD_SLOT
+} from "../src/lib/FilecoinWarmStorageServiceLayout.sol";
 import {FilecoinPayV1} from "@fws-payments/FilecoinPayV1.sol";
 import {Errors} from "../src/Errors.sol";
 import {MockERC20} from "./mocks/SharedMocks.sol";
@@ -113,6 +118,15 @@ contract AbandonmentTest is MockFVMTest {
 
     // Assert that all storage-backed fields of a deleted dataset are zero and metadata is empty.
     function _assertDataSetCleared(uint256 dataSetId) internal view {
+        bytes32 activationSlot = keccak256(abi.encode(dataSetId, uint256(PROVING_ACTIVATION_EPOCH_SLOT)));
+        assertEq(uint256(vm.load(address(fwss), activationSlot)), 0, "provingActivationEpoch");
+
+        bytes32 deadlineSlot = keccak256(abi.encode(dataSetId, uint256(PROVING_DEADLINES_SLOT)));
+        assertEq(uint256(vm.load(address(fwss), deadlineSlot)), 0, "provingDeadlines");
+
+        bytes32 provenThisPeriodSlot = keccak256(abi.encode(dataSetId, uint256(PROVEN_THIS_PERIOD_SLOT)));
+        assertEq(uint256(vm.load(address(fwss), provenThisPeriodSlot)), 0, "provenThisPeriod");
+
         FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
         assertEq(info.pdpRailId, 0, "pdpRailId");
         assertEq(info.cacheMissRailId, 0, "cacheMissRailId");

--- a/service_contracts/test/Abandonment.t.sol
+++ b/service_contracts/test/Abandonment.t.sol
@@ -17,6 +17,7 @@ import {
     PROVEN_THIS_PERIOD_SLOT
 } from "../src/lib/FilecoinWarmStorageServiceLayout.sol";
 import {FilecoinPayV1} from "@fws-payments/FilecoinPayV1.sol";
+import {EPOCHS_PER_DAY} from "../src/lib/PriceListUSDFC.sol";
 import {Errors} from "../src/Errors.sol";
 import {MockERC20} from "./mocks/SharedMocks.sol";
 import {CDNServiceTerminated, DataSetAbandoned} from "../src/lib/Rails.sol";
@@ -371,6 +372,44 @@ contract AbandonmentTest is MockFVMTest {
 
         vm.expectRevert();
         payments.getRail(before.pdpRailId);
+    }
+
+    // CDN rails + activated proving + all periods faulted. Exercises CDN teardown and the
+    // activation-epoch wipe in the same abandonRails call.
+    function testAbandonmentClearsCDNActivatedFaultedDataSet() public {
+        uint256 dataSetId = _createDataSet(true);
+        _addSinglePiece(dataSetId);
+
+        FilecoinWarmStorageService.DataSetInfoView memory before = viewContract.getDataSet(dataSetId);
+        assertGt(before.pdpRailId, 0, "pdpRailId should be set");
+        assertGt(before.cacheMissRailId, 0, "cacheMissRailId should be set");
+        assertGt(before.cdnRailId, 0, "cdnRailId should be set");
+
+        uint256 challengeEpoch = block.number + EPOCHS_PER_DAY - 5;
+        vm.prank(sp);
+        pdpVerifier.nextProvingPeriod(dataSetId, challengeEpoch, "");
+
+        uint256 lastActivity = pdpVerifier.getDataSetLastProvenEpoch(dataSetId);
+        vm.roll(lastActivity + pdpVerifier.INACTIVITY_WINDOW() + EPOCHS_PER_DAY * 3 + 1);
+
+        vm.expectEmit(true, true, false, true, address(fwss));
+        emit CDNServiceTerminated(address(pdpVerifier), dataSetId, before.cacheMissRailId, before.cdnRailId);
+
+        vm.expectEmit(true, false, false, false, address(fwss));
+        emit DataSetAbandoned(dataSetId, before.pdpRailId, before.cacheMissRailId, before.cdnRailId);
+
+        vm.prank(keeper);
+        pdpVerifier.deleteDataSet(dataSetId, "");
+
+        _assertDataSetCleared(dataSetId);
+        assertEq(viewContract.clientDataSets(client).length, 0, "client dataset list should be empty");
+
+        vm.expectRevert();
+        payments.getRail(before.pdpRailId);
+        vm.expectRevert();
+        payments.getRail(before.cacheMissRailId);
+        vm.expectRevert();
+        payments.getRail(before.cdnRailId);
     }
 
     // CDN rails are finalized before abandonment fires (modifyRailLockup and settleRail both fail).

--- a/service_contracts/test/Abandonment.t.sol
+++ b/service_contracts/test/Abandonment.t.sol
@@ -4,12 +4,13 @@ pragma solidity ^0.8.13;
 import {MockFVMTest} from "@fvm-solidity/mocks/MockFVMTest.sol";
 import {MyERC1967Proxy} from "@pdp/ERC1967Proxy.sol";
 import {PDPVerifier} from "@pdp/PDPVerifier.sol";
+import {Cids} from "@pdp/Cids.sol";
 import {SessionKeyRegistry} from "@session-key-registry/SessionKeyRegistry.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import {FilecoinWarmStorageService, PDP_INACTIVITY_WINDOW} from "../src/FilecoinWarmStorageService.sol";
 import {FilecoinWarmStorageServiceStateView} from "../src/FilecoinWarmStorageServiceStateView.sol";
-import {PROVING_ACTIVATION_EPOCH_SLOT} from "../src/lib/FilecoinWarmStorageServiceLayout.sol";
+import {PROVEN_PERIODS_SLOT, PROVING_ACTIVATION_EPOCH_SLOT} from "../src/lib/FilecoinWarmStorageServiceLayout.sol";
 import {FilecoinPayV1} from "@fws-payments/FilecoinPayV1.sol";
 import {Errors} from "../src/Errors.sol";
 import {MockERC20} from "./mocks/SharedMocks.sol";
@@ -266,6 +267,96 @@ contract AbandonmentTest is MockFVMTest {
 
         _assertDataSetCleared(dataSetId);
         assertEq(viewContract.clientDataSets(client).length, 0, "client dataset list should be empty");
+    }
+
+    function _addSinglePiece(uint256 dataSetId) internal {
+        Cids.Cid[] memory pieces = new Cids.Cid[](1);
+        pieces[0] = Cids.CommPv2FromDigest(0, 4, keccak256("abandonment-piece"));
+
+        string[][] memory metadataKeys = new string[][](1);
+        string[][] memory metadataValues = new string[][](1);
+        metadataKeys[0] = new string[](0);
+        metadataValues[0] = new string[](0);
+        bytes memory addPayload = abi.encode(uint256(1), metadataKeys, metadataValues, FAKE_SIG);
+
+        _makeSignaturePass(client);
+        vm.prank(sp);
+        pdpVerifier.addPieces(dataSetId, address(0), pieces, addPayload);
+    }
+
+    // Activated, all periods faulted, final period open. Without the activation-epoch wipe
+    // between settles, the finalize settle reverts NoProgressInSettlement against the open
+    // final period.
+    function testAbandonmentClearsActivatedFaultedDataSet() public {
+        uint256 dataSetId = _createDataSet(false);
+        _addSinglePiece(dataSetId);
+
+        FilecoinWarmStorageService.DataSetInfoView memory before = viewContract.getDataSet(dataSetId);
+
+        uint256 challengeEpoch = block.number + 2880 - 5;
+        vm.prank(sp);
+        pdpVerifier.nextProvingPeriod(dataSetId, challengeEpoch, "");
+
+        uint256 lastActivity = pdpVerifier.getDataSetLastProvenEpoch(dataSetId);
+        vm.roll(lastActivity + pdpVerifier.INACTIVITY_WINDOW() + 2880 * 3 + 1);
+
+        vm.expectEmit(true, false, false, false, address(fwss));
+        emit DataSetAbandoned(dataSetId, before.pdpRailId, 0, 0);
+
+        vm.prank(keeper);
+        pdpVerifier.deleteDataSet(dataSetId, "");
+
+        _assertDataSetCleared(dataSetId);
+        assertEq(viewContract.clientDataSets(client).length, 0, "client dataset list should be empty");
+
+        vm.expectRevert();
+        payments.getRail(before.pdpRailId);
+    }
+
+    // Mark periods [0..periodCount) proven via direct write to the FWSS bitmap. periodCount <= 256.
+    function _markPeriodsProven(uint256 dataSetId, uint256 periodCount) internal {
+        require(periodCount <= 256, "single-word helper");
+        bytes32 outerSlot = keccak256(abi.encode(dataSetId, uint256(PROVEN_PERIODS_SLOT)));
+        bytes32 innerSlot = keccak256(abi.encode(uint256(0), outerSlot));
+        uint256 mask = periodCount == 256 ? type(uint256).max : (uint256(1) << periodCount) - 1;
+        vm.store(address(fwss), innerSlot, bytes32(mask));
+    }
+
+    function _payeeFunds() internal view returns (uint256) {
+        (, uint256 funds,,) = payments.getAccountInfoIfSettled(usdfc, sp);
+        return funds;
+    }
+
+    // Activated, proven, then SP walks away. First settle pays proven epochs; finalize settle
+    // still needs the activation wipe to advance past the open final period.
+    function testAbandonmentClearsActivatedProvenThenFaultedDataSet() public {
+        uint256 dataSetId = _createDataSet(false);
+        _addSinglePiece(dataSetId);
+
+        FilecoinWarmStorageService.DataSetInfoView memory before = viewContract.getDataSet(dataSetId);
+        uint256 payeeFundsBefore = _payeeFunds();
+
+        uint256 challengeEpoch = block.number + 2880 - 5;
+        vm.prank(sp);
+        pdpVerifier.nextProvingPeriod(dataSetId, challengeEpoch, "");
+
+        _markPeriodsProven(dataSetId, 3);
+
+        uint256 lastActivity = pdpVerifier.getDataSetLastProvenEpoch(dataSetId);
+        vm.roll(lastActivity + pdpVerifier.INACTIVITY_WINDOW() + 2880 * 3 + 1);
+
+        vm.expectEmit(true, false, false, false, address(fwss));
+        emit DataSetAbandoned(dataSetId, before.pdpRailId, 0, 0);
+
+        vm.prank(keeper);
+        pdpVerifier.deleteDataSet(dataSetId, "");
+
+        _assertDataSetCleared(dataSetId);
+        assertEq(viewContract.clientDataSets(client).length, 0, "client dataset list should be empty");
+        assertGt(_payeeFunds(), payeeFundsBefore, "payee should have received payment for proven periods");
+
+        vm.expectRevert();
+        payments.getRail(before.pdpRailId);
     }
 
     // CDN rails are finalized before abandonment fires (modifyRailLockup and settleRail both fail).

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -5894,7 +5894,7 @@ contract ValidatePaymentTest is FilecoinWarmStorageServiceTest {
 
         assertEq(result.modifiedAmount, 0, "Should pay nothing");
         assertEq(result.settleUpto, toEpoch, "Should advance settlement at zero cost");
-        assertEq(result.note, "Proving never activated for this data set");
+        assertEq(result.note, "No proving activity");
     }
 
     /**


### PR DESCRIPTION
Split Rails.abandonRails so FWSS clears provingActivationEpoch between the settle and finalise legs, short-circuiting validatePayment past the open final period. The SSTORE is one the cleanup already did; no new state.

---

Abandonment via `PDPVerifier.deleteDataSet` tears down the PDP rail with settle -> release reserve -> terminate -> settle. When proving was ever activated, that second settle reverts `NoProgressInSettlement`: `_findProvenEpochs` won't advance `settleUpto` through the still-open current period (a late proof could arrive), so the post-terminate settle has nowhere to go.

The fix here is to split `Rails.abandonRails` into a settle leg and a finalize leg, and `delete provingActivationEpoch[dataSetId]` between them. `validatePayment`'s existing `activationEpoch == 0` short-circuit then lets the finalise settle advance past the open period. The `delete` is the same one `dataSetDeleted` already does at the end of the function, just relocated; no new state (new state is an alternative fix but it would just be needed during the call).