### PR TITLE
docs: clean up README for GA, link SPEC to pricing source

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,6 @@
 
 Building Filecoin onchain programmable services that integrate with the Filecoin network for decentralized storage.
 
-## ⚠️ IMPORTANT DISCLAIMER
-
-**🚨 THE WARM STORAGE CONTRACT IS CURRENTLY UNDER ACTIVE DEVELOPMENT AND IS NOT READY FOR PRODUCTION USE 🚨**
-
-**DO NOT USE IN PRODUCTION ENVIRONMENTS**
-
-This software is provided for development, testing, and research purposes only. The smart contracts have not undergone comprehensive security audits and may contain bugs, vulnerabilities, or other issues that could result in loss of funds or data.
-
-**Use at your own risk. The developers and contributors are not responsible for any losses or damages.**
-
 ## Overview
 
 This repository contains smart contracts and services for the Filecoin ecosystem, featuring:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The complete on-chain price catalogue is exposed via `FilecoinWarmStorageService
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/your-org/filecoin-services.git
+git clone https://github.com/FilOzone/filecoin-services.git
 cd filecoin-services/service_contracts
 ```
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -6,6 +6,8 @@
 
 FilecoinWarmStorageService uses **static global pricing**. All payment rails use the same price regardless of which provider stores the data. The default storage price is 2.5 USDFC per TiB/month.
 
+All pricing constants (rates, fees, and lockup amounts) are defined in [`service_contracts/src/lib/PriceListUSDFC.sol`](service_contracts/src/lib/PriceListUSDFC.sol). The on-chain entry point is [`getPriceList()`](service_contracts/src/lib/FilecoinWarmStorageServiceStateLibrary.sol) which assembles them into the `PriceList` struct.
+
 Providers may advertise their own prices in the ServiceProviderRegistry, but these are informational for other services, and does not affect actual payments in FilecoinWarmStorageService.
 
 ### Rate Calculation
@@ -82,7 +84,7 @@ struct PriceList {
 }
 ```
 
-This is the canonical price discovery API for SDKs and dashboards.
+This is the canonical price discovery API for SDKs and dashboards. The struct is defined in [`service_contracts/src/lib/PriceList.sol`](service_contracts/src/lib/PriceList.sol) and populated from the constants in [`PriceListUSDFC.sol`](service_contracts/src/lib/PriceListUSDFC.sol).
 
 ### Pricing Updates
 


### PR DESCRIPTION
## Summary
- Remove the "not ready for production use" disclaimer block from README.md (contract is on mainnet, GA next week)
- Fix clone URL placeholder (`your-org` → `FilOzone`)
- Add source-of-truth links in SPEC.md pointing to `PriceListUSDFC.sol` (constants) and `PriceList.sol` (struct), establishing the chain README → SPEC → source

## Test plan
- [ ] Verify README and SPEC.md render correctly on GitHub
- [ ] Confirm relative links to .sol files resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)