### PR TITLE
ci: make Synapse SDK sync manual

### DIFF
--- a/.github/workflows/notify-synapse-sdk.yml
+++ b/.github/workflows/notify-synapse-sdk.yml
@@ -1,11 +1,6 @@
 name: Update Synapse SDK
 
 on:
-  release:
-    types: [published]
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
       tag:
@@ -20,6 +15,10 @@ on:
 # Required repository secret:
 #   SYNAPSE_SDK_DISPATCH_TOKEN - Token allowed to push branches and create PRs in FilOzone/synapse-sdk.
 #   Current PAT was created using the FilOzzy account on 2026-05-12.
+#
+# This workflow is intentionally manual. FWSS release tags and GitHub pre-releases
+# may be created before live implementation addresses are known, but Synapse SDK
+# should only be updated once the operator has chosen the correct release/address ref.
 
 permissions:
   contents: read

--- a/service_contracts/tools/UPGRADE-CHECKLIST.md
+++ b/service_contracts/tools/UPGRADE-CHECKLIST.md
@@ -309,6 +309,7 @@ echo "nextUpgrade(): $NEXT_UPGRADE (expected zero address and 0)"
 - [ ] Finalize and merge changelog/deployments PR(s)
 - [ ] Tag release: `git tag {{RELEASE_VERSION}} && git push origin {{RELEASE_VERSION}}`
 - [ ] Create GitHub Release with changelog
+- [ ] Run the [Update Synapse SDK](https://github.com/FilOzone/filecoin-services/actions/workflows/notify-synapse-sdk.yml) workflow manually with the release tag and the approved source ref/SHA after the intended deployment address state is available
 - [ ] Merge auto-generated PRs in [filecoin-cloud](https://github.com/FilOzone/filecoin-cloud/pulls)
 - [ ] Create "Upgrade Synapse to use newest contracts" issue
 - [ ] Capture lessons learned from this rollout and update [`service_contracts/tools/UPGRADE-CHECKLIST.md`]({{CHECKLIST_LINK}}) if the process should change


### PR DESCRIPTION
## Summary

- Make the Update Synapse SDK workflow manual-only so creating or moving a release tag does not immediately attempt downstream SDK sync.
- Document the manual Synapse SDK sync checkpoint in the FWSS upgrade checklist.

## Why

For tag-first FWSS releases, the release tag can exist before live implementation addresses and the final address source ref are ready. The downstream SDK sync should happen only after the operator chooses the correct release/address ref.

Fixes #511.