### PR TITLE
fix: publish FWSS library ABIs

### DIFF
--- a/service_contracts/Makefile
+++ b/service_contracts/Makefile
@@ -135,7 +135,7 @@ check-layout:
 
 # ABI Management
 
-# Core contracts we publish ABIs for
+# Core contracts and externally consumed libraries we publish ABIs for.
 ABI_CONTRACTS := \
 	FilecoinWarmStorageService \
 	FilecoinWarmStorageServiceStateLibrary \
@@ -148,25 +148,10 @@ ABI_CONTRACTS := \
 	SessionKeyRegistry \
 	Errors
 
-# Generate ABI file targets
-ABI_FILES := $(addprefix abi/,$(addsuffix .abi.json,$(ABI_CONTRACTS)))
-
-# Define a template for ABI extraction; we use a template approach instead of
-# defining a global pattern rule because patterns for files that don't exist
-# at parse-time will be rejected by make, so we'll be explicit instead.
-define ABI_RULE
-abi/$(1).abi.json: out/$(1).sol/$(1).json | abi
-	@echo "Extracting ABI for $(1)..."
-	@jq '.abi' $$< > $$@
-
-# Mark JSON as coming from build (unless it's the library which has its own rule)
-ifneq ($(1),FilecoinWarmStorageServiceStateLibrary)
-out/$(1).sol/$(1).json: | build
-endif
-endef
-
-# Generate rules for each contract using the template above
-$(foreach contract,$(ABI_CONTRACTS),$(eval $(call ABI_RULE,$(contract))))
+# Contract ABIs that should include event fragments emitted from first-party
+# libraries. Library events are logged from the calling contract/proxy address.
+ABI_CONTRACTS_WITH_LIBRARY_EVENTS := FilecoinWarmStorageService
+FIRST_PARTY_LIBRARY_SOURCE_PREFIX := src/lib/
 
 # Directory for ABIs
 abi:
@@ -174,7 +159,26 @@ abi:
 
 # Update ABIs
 .PHONY: update-abi
-update-abi: $(ABI_FILES)
+update-abi: | abi
+	forge clean
+	forge build --via-ir
+	@rm -f abi/*.abi.json
+	@set -e; for contract in $(ABI_CONTRACTS); do \
+		artifact="out/$$contract.sol/$$contract.json"; \
+		echo "Extracting ABI for $$contract..."; \
+		jq '.abi' "$$artifact" > "abi/$$contract.abi.json"; \
+	done
+	@jq -s --arg source_prefix "$(FIRST_PARTY_LIBRARY_SOURCE_PREFIX)" \
+		'def solc_metadata: if (.metadata | type) == "string" then (.metadata | try fromjson catch {}) else (.metadata // {}) end; def abi_key: (.type // "") + ":" + (.name // "") + ":" + ([.inputs[]? | (.type // "")] | join(",")); reduce ([.[] | select((((solc_metadata.settings.compilationTarget // {}) | to_entries[0]? | .key // "") | startswith($$source_prefix))) | (.abi // [])[] | select(.type == "event")][]) as $$event ([]; if any(.[]; abi_key == ($$event | abi_key)) then . else . + [$$event] end)' \
+		out/*.sol/*.json > abi/.library-events.abi.json
+	@set -e; for contract in $(ABI_CONTRACTS_WITH_LIBRARY_EVENTS); do \
+		echo "Merging first-party library events into $$contract ABI..."; \
+		jq -s \
+			'def abi_key: (.type // "") + ":" + (.name // "") + ":" + ([.inputs[]? | (.type // "")] | join(",")); .[0] as $$contract_abi | .[1] as $$library_events | reduce $$library_events[] as $$event ($$contract_abi; if any(.[]; abi_key == ($$event | abi_key)) then . else . + [$$event] end)' \
+			"abi/$$contract.abi.json" abi/.library-events.abi.json > "abi/$$contract.abi.json.tmp"; \
+		mv "abi/$$contract.abi.json.tmp" "abi/$$contract.abi.json"; \
+	done
+	@rm -f abi/.library-events.abi.json
 
 # Clean just the ABIs
 .PHONY: clean-abi
@@ -206,7 +210,7 @@ help:
 	@echo "  help       - Show this help message"
 	@echo ""
 	@echo "ABI management targets:"
-	@echo "  update-abi - Update checked-in ABIs in abi/ directory (incremental)"
+	@echo "  update-abi - Update checked-in ABIs in abi/ directory from a clean build"
 	@echo "  clean-abi  - Remove all ABI files"
 	@echo ""
 	@echo "Full cleanup:"

--- a/service_contracts/Makefile
+++ b/service_contracts/Makefile
@@ -135,7 +135,7 @@ check-layout:
 
 # ABI Management
 
-# Core contracts and externally consumed libraries we publish ABIs for.
+# Core contracts we publish ABIs for.
 ABI_CONTRACTS := \
 	FilecoinWarmStorageService \
 	FilecoinWarmStorageServiceStateLibrary \
@@ -151,6 +151,7 @@ ABI_CONTRACTS := \
 # Contract ABIs that should include event fragments emitted from first-party
 # libraries. Library events are logged from the calling contract/proxy address.
 ABI_CONTRACTS_WITH_LIBRARY_EVENTS := FilecoinWarmStorageService
+ABI_CONTRACTS_SIMPLE := $(filter-out $(ABI_CONTRACTS_WITH_LIBRARY_EVENTS),$(ABI_CONTRACTS))
 FIRST_PARTY_LIBRARY_SOURCE_PREFIX := src/lib/
 
 # Directory for ABIs
@@ -160,10 +161,8 @@ abi:
 # Update ABIs
 .PHONY: update-abi
 update-abi: | abi
-	forge clean
 	forge build --via-ir
-	@rm -f abi/*.abi.json
-	@set -e; for contract in $(ABI_CONTRACTS); do \
+	@set -e; for contract in $(ABI_CONTRACTS_SIMPLE); do \
 		artifact="out/$$contract.sol/$$contract.json"; \
 		echo "Extracting ABI for $$contract..."; \
 		jq '.abi' "$$artifact" > "abi/$$contract.abi.json"; \
@@ -172,10 +171,11 @@ update-abi: | abi
 		'def solc_metadata: if (.metadata | type) == "string" then (.metadata | try fromjson catch {}) else (.metadata // {}) end; def abi_key: (.type // "") + ":" + (.name // "") + ":" + ([.inputs[]? | (.type // "")] | join(",")); reduce ([.[] | select((((solc_metadata.settings.compilationTarget // {}) | to_entries[0]? | .key // "") | startswith($$source_prefix))) | (.abi // [])[] | select(.type == "event")][]) as $$event ([]; if any(.[]; abi_key == ($$event | abi_key)) then . else . + [$$event] end)' \
 		out/*.sol/*.json > abi/.library-events.abi.json
 	@set -e; for contract in $(ABI_CONTRACTS_WITH_LIBRARY_EVENTS); do \
-		echo "Merging first-party library events into $$contract ABI..."; \
+		artifact="out/$$contract.sol/$$contract.json"; \
+		echo "Extracting ABI for $$contract with first-party library events..."; \
 		jq -s \
-			'def abi_key: (.type // "") + ":" + (.name // "") + ":" + ([.inputs[]? | (.type // "")] | join(",")); .[0] as $$contract_abi | .[1] as $$library_events | reduce $$library_events[] as $$event ($$contract_abi; if any(.[]; abi_key == ($$event | abi_key)) then . else . + [$$event] end)' \
-			"abi/$$contract.abi.json" abi/.library-events.abi.json > "abi/$$contract.abi.json.tmp"; \
+			'def abi_key: (.type // "") + ":" + (.name // "") + ":" + ([.inputs[]? | (.type // "")] | join(",")); .[0].abi as $$contract_abi | .[1] as $$library_events | reduce $$library_events[] as $$event ($$contract_abi; if any(.[]; abi_key == ($$event | abi_key)) then . else . + [$$event] end)' \
+			"$$artifact" abi/.library-events.abi.json > "abi/$$contract.abi.json.tmp"; \
 		mv "abi/$$contract.abi.json.tmp" "abi/$$contract.abi.json"; \
 	done
 	@rm -f abi/.library-events.abi.json
@@ -183,7 +183,7 @@ update-abi: | abi
 # Clean just the ABIs
 .PHONY: clean-abi
 clean-abi:
-	@rm -rf abi
+	@rm -f abi/*.abi.json
 
 # Help target
 .PHONY: help
@@ -210,7 +210,7 @@ help:
 	@echo "  help       - Show this help message"
 	@echo ""
 	@echo "ABI management targets:"
-	@echo "  update-abi - Update checked-in ABIs in abi/ directory from a clean build"
+	@echo "  update-abi - Update checked-in ABIs in abi/ directory from an incremental build"
 	@echo "  clean-abi  - Remove all ABI files"
 	@echo ""
 	@echo "Full cleanup:"

--- a/service_contracts/README.md
+++ b/service_contracts/README.md
@@ -163,15 +163,13 @@ The project maintains checked-in ABI files in the `abi/` directory for use by sc
 make update-abi
 ```
 
-This extracts the ABIs from the compiled contracts and saves them as JSON files:
+This extracts the checked-in ABIs, including:
 - `abi/FilecoinWarmStorageService.abi.json` - Main service contract ABI
+- `abi/FilecoinWarmStorageServiceStateLibrary.abi.json` - State library ABI used by generated view helpers
 - `abi/FilecoinWarmStorageServiceStateView.abi.json` - View contract ABI
 
 These ABIs are used by the code generation scripts in the `gen` target and should be updated whenever contract interfaces change.
-
-Note: `SignatureVerificationLib.sol` is an external library (public functions); if you rely on its ABI for external tooling or verification,
-you may also extract the library ABI via `make update-abi` after compilation. The primary consumer is the service implementation which
-is linked at deploy time by the scripts in `tools/`.
+`FilecoinWarmStorageService.abi.json` also includes first-party library event fragments emitted by the FWSS proxy at runtime.
 
 ### Dependencies
 

--- a/service_contracts/abi/FilecoinWarmStorageService.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageService.abi.json
@@ -2091,5 +2091,129 @@
         "internalType": "enum Errors.AddressField"
       }
     ]
+  },
+  {
+    "type": "event",
+    "name": "CDNPaymentRailsToppedUp",
+    "inputs": [
+      {
+        "name": "dataSetId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "cdnAmountAdded",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "totalCdnLockup",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "cacheMissAmountAdded",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "totalCacheMissLockup",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "CDNServiceTerminated",
+    "inputs": [
+      {
+        "name": "caller",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "dataSetId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "cacheMissRailId",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "cdnRailId",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DataSetAbandoned",
+    "inputs": [
+      {
+        "name": "dataSetId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "pdpRailId",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "cacheMissRailId",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "cdnRailId",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RailRateUpdated",
+    "inputs": [
+      {
+        "name": "dataSetId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "railId",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newRate",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
   }
 ]


### PR DESCRIPTION
Rails library in particular has event signatures, and I've just discovered that we don't have these published ABI artifacts. I guess we've missed the 1.3.0 boat but we should remember for next time - any non-empty library we extract should have ABI artifcats included.