### PR TITLE
docs(changelog): finalize FWSS v1.3.0 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Fixed a lifecycle reserve underflow in `Rails.updateStorageRates()` that could cause `nextProvingPeriod` to fail ([#521](https://github.com/FilOzone/filecoin-services/pull/521)).
 
-## [1.3.0] - 2026-06-12 - FWSS Upgrade
+## [1.3.0] - FWSS Upgrade
 
 This FWSS contract upgrade coincides with Filecoin Onchain Cloud's General Availability. It includes breaking changes for integrations that depend on the old pricing model, removed pricing helpers or events, or updated termination behavior.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
-## [1.3.0] - FWSS Upgrade
+## [Unreleased]
+
+### Fixed
+- Fixed a lifecycle reserve underflow in `Rails.updateStorageRates()` that could cause `nextProvingPeriod` to fail ([#521](https://github.com/FilOzone/filecoin-services/pull/521)).
+
+## [1.3.0] - 2026-06-12 - FWSS Upgrade
 
 This FWSS contract upgrade coincides with Filecoin Onchain Cloud's General Availability. It includes breaking changes for integrations that depend on the old pricing model, removed pricing helpers or events, or updated termination behavior.
 
 ### Deployment / Rollout Status
 
-See the [v1.3.0 GitHub Release](https://github.com/FilOzone/filecoin-services/releases/tag/v1.3.0) for rollout status, implementation addresses, epochs, and transaction links. The FWSS proxy addresses remain unchanged.
+The Calibnet and Mainnet rollout is complete. See the [v1.3.0 GitHub Release](https://github.com/FilOzone/filecoin-services/releases/tag/v1.3.0) for final implementation addresses, StateView addresses, epochs, transaction links, and validation evidence. The FWSS proxy addresses remain unchanged.
 
 ### Breaking Changes
 - Removed `calculateRatePerEpoch()`, `updatePricing()`, and `updateServiceCommission()` from the FWSS ABI. Integrations must stop calling those methods; use `FilecoinWarmStorageServiceStateView.getPriceList()` for price discovery. Pricing changes are now delivered by contract upgrade instead of owner calls ([#478](https://github.com/FilOzone/filecoin-services/pull/478), [#488](https://github.com/FilOzone/filecoin-services/pull/488), [#501](https://github.com/FilOzone/filecoin-services/pull/501)).


### PR DESCRIPTION
## Summary
- add an Unreleased entry for the post-v1.3.0 lifecycle reserve underflow fix from #521
- finalize the v1.3.0 changelog heading with the release date
- update rollout wording to point readers to the GitHub Release for final addresses, txs, and validation evidence

## Notes
This intentionally keeps #521 under Unreleased because it landed after the frozen/deployed `v1.3.0` tag commit. Final rollout details remain on the GitHub Release page and in `service_contracts/deployments.json`.