### PR TITLE
feat: UpgradeHardening

### DIFF
--- a/service_contracts/abi/FilecoinWarmStorageService.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageService.abi.json
@@ -86,7 +86,7 @@
       {
         "name": "plannedUpgrade",
         "type": "tuple",
-        "internalType": "struct FilecoinWarmStorageService.PlannedUpgrade",
+        "internalType": "struct UpgradeHardening.PlannedUpgrade",
         "components": [
           {
             "name": "nextImplementation",
@@ -95,6 +95,31 @@
           },
           {
             "name": "afterEpoch",
+            "type": "uint96",
+            "internalType": "uint96"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "announceUpgradePlan",
+    "inputs": [
+      {
+        "name": "upgradePlan",
+        "type": "tuple",
+        "internalType": "struct UpgradeHardening.UpgradePlan",
+        "components": [
+          {
+            "name": "nextImplementation",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "delay",
             "type": "uint96",
             "internalType": "uint96"
           }
@@ -817,6 +842,25 @@
   },
   {
     "type": "function",
+    "name": "upgradeEpoch",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "upgradeToAndCall",
     "inputs": [
       {
@@ -1298,7 +1342,7 @@
         "name": "plannedUpgrade",
         "type": "tuple",
         "indexed": false,
-        "internalType": "struct FilecoinWarmStorageService.PlannedUpgrade",
+        "internalType": "struct UpgradeHardening.PlannedUpgrade",
         "components": [
           {
             "name": "nextImplementation",

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -201,6 +201,11 @@ contract FilecoinWarmStorageService is
         uint256 datasetFeePerMonth; // Per-dataset additive monthly fee (0.024 USDFC)
     }
 
+    struct UpgradePlan {
+        address nextImplementation;
+        uint96 delay;
+    }
+
     // Used for announcing upgrades, packed into one slot
     struct PlannedUpgrade {
         // Address of the new implementation contract
@@ -302,6 +307,8 @@ contract FilecoinWarmStorageService is
 
     // Piece IDs awaiting metadata cleanup; cleared each nextProvingPeriod call
     mapping(uint256 dataSetId => uint256[] pieceIds) internal scheduledPieceMetadataRemovals;
+
+    mapping(string version => uint256 epoch) public upgradeEpoch;
 
     event UpgradeAnnounced(PlannedUpgrade plannedUpgrade);
 
@@ -405,7 +412,18 @@ contract FilecoinWarmStorageService is
         challengeWindowSize = _challengeWindowSize;
     }
 
-    function announcePlannedUpgrade(PlannedUpgrade calldata plannedUpgrade) external onlyOwner {
+    function announceUpgradePlan(UpgradePlan calldata upgradePlan) external {
+        PlannedUpgrade memory plannedUpgrade =
+            PlannedUpgrade(upgradePlan.nextImplementation, uint96(block.number) + upgradePlan.delay);
+        _announcePlannedUpgrade(plannedUpgrade);
+    }
+
+    // deprecated
+    function announcePlannedUpgrade(PlannedUpgrade calldata plannedUpgrade) external {
+        _announcePlannedUpgrade(plannedUpgrade);
+    }
+
+    function _announcePlannedUpgrade(PlannedUpgrade memory plannedUpgrade) internal onlyOwner {
         require(plannedUpgrade.nextImplementation.code.length > 3000);
         require(plannedUpgrade.afterEpoch > block.number);
         nextUpgrade = plannedUpgrade;
@@ -448,6 +466,7 @@ contract FilecoinWarmStorageService is
             emit ViewContractSet(_viewContract);
         }
 
+        upgradeEpoch[VERSION] = block.number;
         emit ContractUpgraded(VERSION, ERC1967Utils.getImplementation());
     }
 

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -6,14 +6,12 @@ import {IPDPVerifier} from "@pdp/interfaces/IPDPVerifier.sol";
 import {Cids} from "@pdp/Cids.sol";
 import {SessionKeyRegistry} from "@session-key-registry/SessionKeyRegistry.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {EIP712Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import {EIP712Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
-import {ERC1967Utils} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
 import {FilecoinPayV1, IValidator} from "@fws-payments/FilecoinPayV1.sol";
 import {Errors} from "./Errors.sol";
+import {UpgradeHardening} from "./UpgradeHardening.sol";
 
 import {ServiceProviderRegistry} from "./ServiceProviderRegistry.sol";
 
@@ -72,8 +70,7 @@ contract FilecoinWarmStorageService is
     PDPListener,
     IValidator,
     Initializable,
-    UUPSUpgradeable,
-    OwnableUpgradeable,
+    UpgradeHardening,
     Extsload,
     EIP712Upgradeable
 {
@@ -84,7 +81,6 @@ contract FilecoinWarmStorageService is
 
     // Events
 
-    event ContractUpgraded(string version, address implementation);
     event FilecoinServiceDeployed(string name, string description);
     event DataSetServiceProviderChanged(
         uint256 indexed dataSetId, address indexed oldServiceProvider, address indexed newServiceProvider
@@ -201,19 +197,6 @@ contract FilecoinWarmStorageService is
         uint256 datasetFeePerMonth; // Per-dataset additive monthly fee (0.024 USDFC)
     }
 
-    struct UpgradePlan {
-        address nextImplementation;
-        uint96 delay;
-    }
-
-    // Used for announcing upgrades, packed into one slot
-    struct PlannedUpgrade {
-        // Address of the new implementation contract
-        address nextImplementation;
-        // Upgrade will not occur until at least this epoch
-        uint96 afterEpoch;
-    }
-
     // Constants
 
     uint256 private constant NO_CHALLENGE_SCHEDULED = 0;
@@ -299,6 +282,7 @@ contract FilecoinWarmStorageService is
     // The address allowed to terminate CDN services
     address private filBeamControllerAddress;
 
+    // Pending upgrade announcement
     PlannedUpgrade private nextUpgrade;
 
     // Pricing rates (mutable for future adjustments)
@@ -308,9 +292,8 @@ contract FilecoinWarmStorageService is
     // Piece IDs awaiting metadata cleanup; cleared each nextProvingPeriod call
     mapping(uint256 dataSetId => uint256[] pieceIds) internal scheduledPieceMetadataRemovals;
 
-    mapping(string version => uint256 epoch) public upgradeEpoch;
-
-    event UpgradeAnnounced(PlannedUpgrade plannedUpgrade);
+    // Epoch at which each contract version was deployed
+    mapping(string version => uint256 epoch) private _upgradeEpoch;
 
     // =========================================================================
 
@@ -412,29 +395,16 @@ contract FilecoinWarmStorageService is
         challengeWindowSize = _challengeWindowSize;
     }
 
-    function announceUpgradePlan(UpgradePlan calldata upgradePlan) external {
-        PlannedUpgrade memory plannedUpgrade =
-            PlannedUpgrade(upgradePlan.nextImplementation, uint96(block.number) + upgradePlan.delay);
-        _announcePlannedUpgrade(plannedUpgrade);
+    function _currentVersion() internal pure override returns (string memory) {
+        return VERSION;
     }
 
-    // deprecated
-    function announcePlannedUpgrade(PlannedUpgrade calldata plannedUpgrade) external {
-        _announcePlannedUpgrade(plannedUpgrade);
+    function _nextUpgradeStorage() internal view override returns (PlannedUpgrade storage) {
+        return nextUpgrade;
     }
 
-    function _announcePlannedUpgrade(PlannedUpgrade memory plannedUpgrade) internal onlyOwner {
-        require(plannedUpgrade.nextImplementation.code.length > 3000);
-        require(plannedUpgrade.afterEpoch > block.number);
-        nextUpgrade = plannedUpgrade;
-        emit UpgradeAnnounced(plannedUpgrade);
-    }
-
-    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {
-        // zero address already checked by ERC1967Utils._setImplementation
-        require(newImplementation == nextUpgrade.nextImplementation);
-        require(block.number >= nextUpgrade.afterEpoch);
-        delete nextUpgrade;
+    function _upgradeEpochStorage() internal view override returns (mapping(string => uint256) storage) {
+        return _upgradeEpoch;
     }
 
     /**
@@ -466,8 +436,7 @@ contract FilecoinWarmStorageService is
             emit ViewContractSet(_viewContract);
         }
 
-        upgradeEpoch[VERSION] = block.number;
-        emit ContractUpgraded(VERSION, ERC1967Utils.getImplementation());
+        _recordUpgrade(VERSION);
     }
 
     /**

--- a/service_contracts/src/UpgradeHardening.sol
+++ b/service_contracts/src/UpgradeHardening.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+pragma solidity ^0.8.20;
+
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {ERC1967Utils} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
+
+/// @notice Abstract base that enforces a time-hardened minimum delay before upgrades can execute.
+abstract contract UpgradeHardening is UUPSUpgradeable, OwnableUpgradeable {
+    struct UpgradePlan {
+        address nextImplementation;
+        uint96 delay;
+    }
+
+    // Used for announcing upgrades, packed into one slot
+    struct PlannedUpgrade {
+        // Address of the new implementation contract
+        address nextImplementation;
+        // Upgrade will not occur until at least this epoch
+        uint96 afterEpoch;
+    }
+
+    // Minimum delay grows cubically from MIN to MAX over RAMP epochs since last upgrade
+    uint256 internal constant MIN_UPGRADE_DELAY = 10; // 5 min
+    uint256 internal constant MAX_UPGRADE_DELAY = 40_320; // 2 weeks
+    uint256 internal constant UPGRADE_HARDENING_RAMP = 161_280; // 8 weeks
+
+    event UpgradeAnnounced(PlannedUpgrade plannedUpgrade);
+    event ContractUpgraded(string version, address implementation);
+
+    /// @dev Returns a storage reference to the pending upgrade slot. Subclass provides the location.
+    function _nextUpgradeStorage() internal view virtual returns (PlannedUpgrade storage);
+
+    /// @dev Returns a storage reference to the upgrade-epoch mapping. Subclass provides the location.
+    function _upgradeEpochStorage() internal view virtual returns (mapping(string => uint256) storage);
+
+    function _currentVersion() internal view virtual returns (string memory);
+
+    function upgradeEpoch(string calldata version) external view returns (uint256) {
+        return _upgradeEpochStorage()[version];
+    }
+
+    function announceUpgradePlan(UpgradePlan calldata upgradePlan) external {
+        uint256 minDelay = _hardenedMinDelay();
+        uint96 delay = upgradePlan.delay >= minDelay ? upgradePlan.delay : uint96(minDelay);
+        PlannedUpgrade memory plannedUpgrade =
+            PlannedUpgrade(upgradePlan.nextImplementation, uint96(block.number) + delay);
+        _announcePlannedUpgrade(plannedUpgrade);
+    }
+
+    // deprecated
+    function announcePlannedUpgrade(PlannedUpgrade calldata plannedUpgrade) external {
+        _announcePlannedUpgrade(plannedUpgrade);
+    }
+
+    function _announcePlannedUpgrade(PlannedUpgrade memory plannedUpgrade) internal onlyOwner {
+        require(plannedUpgrade.nextImplementation.code.length > 3000);
+        require(plannedUpgrade.afterEpoch > block.number);
+        PlannedUpgrade storage $ = _nextUpgradeStorage();
+        $.nextImplementation = plannedUpgrade.nextImplementation;
+        $.afterEpoch = plannedUpgrade.afterEpoch;
+        emit UpgradeAnnounced(plannedUpgrade);
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {
+        PlannedUpgrade storage $ = _nextUpgradeStorage();
+        require(newImplementation == $.nextImplementation);
+        require(block.number >= $.afterEpoch);
+        $.nextImplementation = address(0);
+        $.afterEpoch = 0;
+    }
+
+    function _hardenedMinDelay() internal view returns (uint256) {
+        uint256 lastUpgrade = _upgradeEpochStorage()[_currentVersion()];
+        if (lastUpgrade == 0) return MIN_UPGRADE_DELAY;
+        uint256 age = block.number - lastUpgrade;
+        uint256 t = age < UPGRADE_HARDENING_RAMP ? age : UPGRADE_HARDENING_RAMP;
+        uint256 ramp = UPGRADE_HARDENING_RAMP;
+        return MIN_UPGRADE_DELAY + (MAX_UPGRADE_DELAY - MIN_UPGRADE_DELAY) * t * t * t / (ramp * ramp * ramp);
+    }
+
+    function _recordUpgrade(string memory version) internal {
+        _upgradeEpochStorage()[version] = block.number;
+        emit ContractUpgraded(version, ERC1967Utils.getImplementation());
+    }
+}

--- a/service_contracts/src/UpgradeHardening.sol
+++ b/service_contracts/src/UpgradeHardening.sol
@@ -41,10 +41,8 @@ abstract contract UpgradeHardening is UUPSUpgradeable, OwnableUpgradeable {
     }
 
     function announceUpgradePlan(UpgradePlan calldata upgradePlan) external {
-        uint256 minDelay = _hardenedMinDelay();
-        uint96 delay = upgradePlan.delay >= minDelay ? upgradePlan.delay : uint96(minDelay);
         PlannedUpgrade memory plannedUpgrade =
-            PlannedUpgrade(upgradePlan.nextImplementation, uint96(block.number) + delay);
+            PlannedUpgrade(upgradePlan.nextImplementation, uint96(block.number) + upgradePlan.delay);
         _announcePlannedUpgrade(plannedUpgrade);
     }
 
@@ -55,7 +53,10 @@ abstract contract UpgradeHardening is UUPSUpgradeable, OwnableUpgradeable {
 
     function _announcePlannedUpgrade(PlannedUpgrade memory plannedUpgrade) internal onlyOwner {
         require(plannedUpgrade.nextImplementation.code.length > 3000);
-        require(plannedUpgrade.afterEpoch > block.number);
+        uint256 minAfterEpoch = block.number + _hardenedMinDelay();
+        if (plannedUpgrade.afterEpoch < minAfterEpoch) {
+            plannedUpgrade.afterEpoch = uint96(minAfterEpoch);
+        }
         PlannedUpgrade storage $ = _nextUpgradeStorage();
         $.nextImplementation = plannedUpgrade.nextImplementation;
         $.afterEpoch = plannedUpgrade.afterEpoch;

--- a/service_contracts/src/UpgradeHardening.sol
+++ b/service_contracts/src/UpgradeHardening.sol
@@ -5,6 +5,11 @@ import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/U
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {ERC1967Utils} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
 
+// Minimum delay grows cubically from MIN to MAX over RAMP epochs since last upgrade
+uint256 constant MIN_UPGRADE_DELAY = 10; // 5 min
+uint256 constant MAX_UPGRADE_DELAY = 40_320; // 2 weeks
+uint256 constant UPGRADE_HARDENING_RAMP = 161_280; // 8 weeks
+
 /// @notice Abstract base that enforces a time-hardened minimum delay before upgrades can execute.
 abstract contract UpgradeHardening is UUPSUpgradeable, OwnableUpgradeable {
     struct UpgradePlan {
@@ -19,11 +24,6 @@ abstract contract UpgradeHardening is UUPSUpgradeable, OwnableUpgradeable {
         // Upgrade will not occur until at least this epoch
         uint96 afterEpoch;
     }
-
-    // Minimum delay grows cubically from MIN to MAX over RAMP epochs since last upgrade
-    uint256 internal constant MIN_UPGRADE_DELAY = 10; // 5 min
-    uint256 internal constant MAX_UPGRADE_DELAY = 40_320; // 2 weeks
-    uint256 internal constant UPGRADE_HARDENING_RAMP = 161_280; // 8 weeks
 
     event UpgradeAnnounced(PlannedUpgrade plannedUpgrade);
     event ContractUpgraded(string version, address implementation);

--- a/service_contracts/src/UpgradeHardening.sol
+++ b/service_contracts/src/UpgradeHardening.sol
@@ -48,7 +48,7 @@ abstract contract UpgradeHardening is UUPSUpgradeable, OwnableUpgradeable {
         _announcePlannedUpgrade(plannedUpgrade);
     }
 
-    // deprecated
+    /// @custom:deprecated Use announceUpgradePlan instead
     function announcePlannedUpgrade(PlannedUpgrade calldata plannedUpgrade) external {
         _announcePlannedUpgrade(plannedUpgrade);
     }

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceLayout.json
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceLayout.json
@@ -544,9 +544,9 @@
     "label": "nextUpgrade",
     "slot": "19",
     "offset": 0,
-    "type": "struct FilecoinWarmStorageService.PlannedUpgrade",
+    "type": "struct UpgradeHardening.PlannedUpgrade",
     "typeDetails": {
-      "label": "struct FilecoinWarmStorageService.PlannedUpgrade",
+      "label": "struct UpgradeHardening.PlannedUpgrade",
       "encoding": "inplace",
       "numberOfBytes": "32",
       "members": [
@@ -618,6 +618,27 @@
           "encoding": "inplace",
           "numberOfBytes": "32"
         }
+      }
+    }
+  },
+  {
+    "label": "_upgradeEpoch",
+    "slot": "23",
+    "offset": 0,
+    "type": "mapping(string => uint256)",
+    "typeDetails": {
+      "label": "mapping(string => uint256)",
+      "encoding": "mapping",
+      "numberOfBytes": "32",
+      "key": {
+        "label": "string",
+        "encoding": "bytes",
+        "numberOfBytes": "32"
+      },
+      "value": {
+        "label": "uint256",
+        "encoding": "inplace",
+        "numberOfBytes": "32"
       }
     }
   }

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceLayout.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceLayout.sol
@@ -28,3 +28,4 @@ bytes32 constant NEXT_UPGRADE_SLOT = bytes32(uint256(19));
 bytes32 constant DEPRECATED_STORAGE_PRICE_PER_TIB_PER_MONTH_SLOT = bytes32(uint256(20));
 bytes32 constant DEPRECATED_MINIMUM_STORAGE_RATE_PER_MONTH_SLOT = bytes32(uint256(21));
 bytes32 constant SCHEDULED_PIECE_METADATA_REMOVALS_SLOT = bytes32(uint256(22));
+bytes32 constant UPGRADE_EPOCH_SLOT = bytes32(uint256(23));

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -10,7 +10,9 @@ import {MyERC1967Proxy} from "@pdp/ERC1967Proxy.sol";
 import {SessionKeyRegistry} from "@session-key-registry/SessionKeyRegistry.sol";
 
 import {CHALLENGES_PER_PROOF, FilecoinWarmStorageService} from "../src/FilecoinWarmStorageService.sol";
-import {UpgradeHardening} from "../src/UpgradeHardening.sol";
+import {
+    UpgradeHardening, MIN_UPGRADE_DELAY, MAX_UPGRADE_DELAY, UPGRADE_HARDENING_RAMP
+} from "../src/UpgradeHardening.sol";
 import {FilecoinWarmStorageServiceStateView} from "../src/FilecoinWarmStorageServiceStateView.sol";
 import {SignatureVerificationLib} from "../src/lib/SignatureVerificationLib.sol";
 import {FilecoinWarmStorageServiceStateLibrary} from "../src/lib/FilecoinWarmStorageServiceStateLibrary.sol";
@@ -515,6 +517,74 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         vm.expectEmit(false, false, false, true, address(service));
         emit UpgradeHardening.ContractUpgraded(newServiceImpl.VERSION(), plan.nextImplementation);
         service.upgradeToAndCall(plan.nextImplementation, migrateData);
+    }
+
+    function _newFWSSImpl() internal returns (FilecoinWarmStorageService) {
+        return new FilecoinWarmStorageService(
+            address(mockPDPVerifier),
+            address(payments),
+            mockUSDFC,
+            filBeamBeneficiary,
+            serviceProviderRegistry,
+            sessionKeyRegistry,
+            4
+        );
+    }
+
+    function testAnnounceUpgradePlan_clampsToMinDelay() public {
+        // upgradeEpoch[VERSION] == 0, so min delay is MIN_UPGRADE_DELAY
+        FilecoinWarmStorageService newImpl = _newFWSSImpl();
+        UpgradeHardening.UpgradePlan memory plan =
+            UpgradeHardening.UpgradePlan({nextImplementation: address(newImpl), delay: 0});
+        pdpServiceWithPayments.announceUpgradePlan(plan);
+
+        (, uint96 afterEpoch) = viewContract.nextUpgrade();
+        assertEq(afterEpoch, vm.getBlockNumber() + MIN_UPGRADE_DELAY);
+    }
+
+    function testAnnounceUpgradePlan_respectsHigherUserDelay() public {
+        FilecoinWarmStorageService newImpl = _newFWSSImpl();
+        uint96 userDelay = 1000;
+        UpgradeHardening.UpgradePlan memory plan =
+            UpgradeHardening.UpgradePlan({nextImplementation: address(newImpl), delay: userDelay});
+        pdpServiceWithPayments.announceUpgradePlan(plan);
+
+        (, uint96 afterEpoch) = viewContract.nextUpgrade();
+        assertEq(afterEpoch, vm.getBlockNumber() + userDelay);
+    }
+
+    function testAnnounceUpgradePlan_maxDelayAtFullRamp() public {
+        pdpServiceWithPayments.migrate(address(0));
+        uint256 migrateBlock = vm.getBlockNumber();
+
+        vm.roll(migrateBlock + UPGRADE_HARDENING_RAMP);
+
+        FilecoinWarmStorageService newImpl = _newFWSSImpl();
+        UpgradeHardening.UpgradePlan memory plan =
+            UpgradeHardening.UpgradePlan({nextImplementation: address(newImpl), delay: 0});
+        pdpServiceWithPayments.announceUpgradePlan(plan);
+
+        (, uint96 afterEpoch) = viewContract.nextUpgrade();
+        assertEq(afterEpoch, vm.getBlockNumber() + MAX_UPGRADE_DELAY);
+    }
+
+    function testAnnounceUpgradePlan_cubicInterpolationAtHalfRamp() public {
+        pdpServiceWithPayments.migrate(address(0));
+        uint256 migrateBlock = vm.getBlockNumber();
+
+        uint256 t = UPGRADE_HARDENING_RAMP / 2;
+        vm.roll(migrateBlock + t);
+
+        FilecoinWarmStorageService newImpl = _newFWSSImpl();
+        UpgradeHardening.UpgradePlan memory plan =
+            UpgradeHardening.UpgradePlan({nextImplementation: address(newImpl), delay: 0});
+        pdpServiceWithPayments.announceUpgradePlan(plan);
+
+        uint256 ramp = UPGRADE_HARDENING_RAMP;
+        uint256 expectedDelay =
+            MIN_UPGRADE_DELAY + (MAX_UPGRADE_DELAY - MIN_UPGRADE_DELAY) * t * t * t / (ramp * ramp * ramp);
+        (, uint96 afterEpoch) = viewContract.nextUpgrade();
+        assertEq(afterEpoch, vm.getBlockNumber() + expectedDelay);
     }
 
     function _getSingleMetadataKV(string memory key, string memory value)

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -10,6 +10,7 @@ import {MyERC1967Proxy} from "@pdp/ERC1967Proxy.sol";
 import {SessionKeyRegistry} from "@session-key-registry/SessionKeyRegistry.sol";
 
 import {CHALLENGES_PER_PROOF, FilecoinWarmStorageService} from "../src/FilecoinWarmStorageService.sol";
+import {UpgradeHardening} from "../src/UpgradeHardening.sol";
 import {FilecoinWarmStorageServiceStateView} from "../src/FilecoinWarmStorageServiceStateView.sol";
 import {SignatureVerificationLib} from "../src/lib/SignatureVerificationLib.sol";
 import {FilecoinWarmStorageServiceStateLibrary} from "../src/lib/FilecoinWarmStorageServiceStateLibrary.sol";
@@ -512,7 +513,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
 
         vm.roll(plan.afterEpoch);
         vm.expectEmit(false, false, false, true, address(service));
-        emit FilecoinWarmStorageService.ContractUpgraded(newServiceImpl.VERSION(), plan.nextImplementation);
+        emit UpgradeHardening.ContractUpgraded(newServiceImpl.VERSION(), plan.nextImplementation);
         service.upgradeToAndCall(plan.nextImplementation, migrateData);
     }
 

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import {MockFVMTest} from "@fvm-solidity/mocks/MockFVMTest.sol";
 import {console, Test, Vm} from "forge-std/Test.sol";
+import {stdError} from "forge-std/StdError.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {Cids} from "@pdp/Cids.sol";
@@ -585,6 +586,25 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
             MIN_UPGRADE_DELAY + (MAX_UPGRADE_DELAY - MIN_UPGRADE_DELAY) * t * t * t / (ramp * ramp * ramp);
         (, uint96 afterEpoch) = viewContract.nextUpgrade();
         assertEq(afterEpoch, vm.getBlockNumber() + expectedDelay);
+    }
+
+    function testAnnounceUpgradePlan_overflowingDelayReverts() public {
+        FilecoinWarmStorageService newImpl = _newFWSSImpl();
+        // type(uint96).max overflows uint96(block.number) + delay; Solidity 0.8 reverts rather than wrapping
+        UpgradeHardening.UpgradePlan memory plan =
+            UpgradeHardening.UpgradePlan({nextImplementation: address(newImpl), delay: type(uint96).max});
+        vm.expectRevert(stdError.arithmeticError);
+        pdpServiceWithPayments.announceUpgradePlan(plan);
+    }
+
+    function testAnnouncePlannedUpgrade_pastEpochClampsToMinDelay() public {
+        FilecoinWarmStorageService newImpl = _newFWSSImpl();
+        UpgradeHardening.PlannedUpgrade memory plan =
+            UpgradeHardening.PlannedUpgrade({nextImplementation: address(newImpl), afterEpoch: 0});
+        pdpServiceWithPayments.announcePlannedUpgrade(plan);
+
+        (, uint96 afterEpoch) = viewContract.nextUpgrade();
+        assertGe(afterEpoch, vm.getBlockNumber() + MIN_UPGRADE_DELAY);
     }
 
     function _getSingleMetadataKV(string memory key, string memory value)

--- a/service_contracts/tools/check_storage_layout.sh
+++ b/service_contracts/tools/check_storage_layout.sh
@@ -75,7 +75,6 @@ typedetails_compatible() {
             elif (($base | type) == "object") and (($new | type) == "object") then
                 if (($base | has("encoding")) and $base.encoding == "inplace" and ($base | has("members"))) and
                    (($new  | has("encoding")) and $new.encoding  == "inplace" and ($new  | has("members"))) then
-                    ($base.label == $new.label) and
                     (($new.members | length) >= ($base.members | length)) and
                     ($base.members == ($new.members[0:($base.members | length)]))
                 else


### PR DESCRIPTION

Closes https://github.com/FilOzone/filecoin-services/issues/505
Reviewer @ZenGround0
CC @rjan90
This is a draft because if we agree on this approach, I also want to do it for PDPVerifier, and so it should become a separate module instead of merging as-is. 
#### Overview
This introduces an UpgradeHardening superclass to implement upgrade hardening and encapsulate the two step upgrade process.
The upgrade plan epoch changes into a delay mechanism with a minimum enforced by `_hardenedMinDelay` in a non-reverting way.

The previous method that specifies the plan by epoch is deprecated in favor of the new method.
We can remove it after all of the tooling and runbooks are updated, which should only happen after the new method is deployed.
#### Context
We want multisig upgrade coordination to be less-likely to result in a revert.
Also, two customers have requested a minimum delay between the announcement and the upgrade.
We want to track upgradeEpoch in order to implement a gradual hardening, but also it can help with certain kinds of potential future rollback operations.
I do not use ERC 7201 because we already have a slot assigned for the upgrade plan information and because it is not supported by `forge inspect storageLayout`.
#### Changes
* add upgradeEpoch mapping to track upgrade activation information
* pull two step upgrade logic into UpgradeHardening superclass
* test hardening