### PR TITLE
fix: non-reverting upgrade announcement

### DIFF
--- a/service_contracts/abi/FilecoinWarmStorageService.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageService.abi.json
@@ -114,7 +114,7 @@
         "internalType": "address"
       },
       {
-        "name": "delay",
+        "name": "delayEpochs",
         "type": "uint96",
         "internalType": "uint96"
       }

--- a/service_contracts/abi/FilecoinWarmStorageService.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageService.abi.json
@@ -106,6 +106,24 @@
   },
   {
     "type": "function",
+    "name": "announceUpgradePlan",
+    "inputs": [
+      {
+        "name": "nextImplementation",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "delay",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "configureProvingPeriod",
     "inputs": [
       {

--- a/service_contracts/abi/ServiceProviderRegistry.abi.json
+++ b/service_contracts/abi/ServiceProviderRegistry.abi.json
@@ -189,6 +189,24 @@
   },
   {
     "type": "function",
+    "name": "announceUpgradePlan",
+    "inputs": [
+      {
+        "name": "nextImplementation",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "delay",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "eip712Domain",
     "inputs": [],
     "outputs": [

--- a/service_contracts/abi/ServiceProviderRegistry.abi.json
+++ b/service_contracts/abi/ServiceProviderRegistry.abi.json
@@ -197,7 +197,7 @@
         "internalType": "address"
       },
       {
-        "name": "delay",
+        "name": "delayEpochs",
         "type": "uint96",
         "internalType": "uint96"
       }

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -294,6 +294,7 @@ contract FilecoinWarmStorageService is
     // The address allowed to terminate CDN services
     address private filBeamControllerAddress;
 
+    // Pending upgrade announcement
     PlannedUpgrade private nextUpgrade;
 
     // Pricing rates (mutable for future adjustments)
@@ -405,11 +406,27 @@ contract FilecoinWarmStorageService is
         challengeWindowSize = _challengeWindowSize;
     }
 
-    function announcePlannedUpgrade(PlannedUpgrade calldata plannedUpgrade) external onlyOwner {
-        require(plannedUpgrade.nextImplementation.code.length > 3000);
-        require(plannedUpgrade.afterEpoch > block.number);
-        nextUpgrade = plannedUpgrade;
-        emit UpgradeAnnounced(plannedUpgrade);
+    function announceUpgradePlan(address nextImplementation, uint96 delay) external {
+        if (delay == 0) {
+            delay = 1;
+        }
+        _announcePlannedUpgrade(nextImplementation, uint96(block.number) + delay);
+    }
+
+    /// @custom:deprecated Use announceUpgradePlan instead
+    function announcePlannedUpgrade(PlannedUpgrade calldata plannedUpgrade) external {
+        uint96 minAfterEpoch = uint96(block.number + 1);
+        _announcePlannedUpgrade(
+            plannedUpgrade.nextImplementation,
+            plannedUpgrade.afterEpoch < minAfterEpoch ? minAfterEpoch : plannedUpgrade.afterEpoch
+        );
+    }
+
+    function _announcePlannedUpgrade(address nextImplementation, uint96 afterEpoch) internal onlyOwner {
+        require(nextImplementation.code.length > 3000);
+        nextUpgrade.nextImplementation = nextImplementation;
+        nextUpgrade.afterEpoch = afterEpoch;
+        emit UpgradeAnnounced(nextUpgrade);
     }
 
     function _authorizeUpgrade(address newImplementation) internal override onlyOwner {

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -406,11 +406,11 @@ contract FilecoinWarmStorageService is
         challengeWindowSize = _challengeWindowSize;
     }
 
-    function announceUpgradePlan(address nextImplementation, uint96 delay) external {
-        if (delay == 0) {
-            delay = 1;
+    function announceUpgradePlan(address nextImplementation, uint96 delayEpochs) external {
+        if (delayEpochs == 0) {
+            delayEpochs = 1;
         }
-        _announcePlannedUpgrade(nextImplementation, uint96(block.number) + delay);
+        _announcePlannedUpgrade(nextImplementation, uint96(block.number) + delayEpochs);
     }
 
     /// @custom:deprecated Use announceUpgradePlan instead

--- a/service_contracts/src/ServiceProviderRegistry.sol
+++ b/service_contracts/src/ServiceProviderRegistry.sol
@@ -772,12 +772,12 @@ contract ServiceProviderRegistry is
     /// @notice Announce a planned upgrade
     /// @dev Can only be called by the contract owner
     /// @param nextImplementation Address of the new implementation contract
-    /// @param delay Number of epochs from now before the upgrade may occur
-    function announceUpgradePlan(address nextImplementation, uint96 delay) external {
-        if (delay == 0) {
-            delay = 1;
+    /// @param delayEpochs Number of epochs from now before the upgrade may occur
+    function announceUpgradePlan(address nextImplementation, uint96 delayEpochs) external {
+        if (delayEpochs == 0) {
+            delayEpochs = 1;
         }
-        _announcePlannedUpgrade(nextImplementation, uint96(block.number) + delay);
+        _announcePlannedUpgrade(nextImplementation, uint96(block.number) + delayEpochs);
     }
 
     /// @notice Announce a planned upgrade

--- a/service_contracts/src/ServiceProviderRegistry.sol
+++ b/service_contracts/src/ServiceProviderRegistry.sol
@@ -113,6 +113,7 @@ contract ServiceProviderRegistry is
         uint96 afterEpoch;
     }
 
+    // Pending upgrade announcement
     PlannedUpgrade public nextUpgrade;
 
     event UpgradeAnnounced(PlannedUpgrade plannedUpgrade);
@@ -770,12 +771,32 @@ contract ServiceProviderRegistry is
 
     /// @notice Announce a planned upgrade
     /// @dev Can only be called by the contract owner
+    /// @param nextImplementation Address of the new implementation contract
+    /// @param delay Number of epochs from now before the upgrade may occur
+    function announceUpgradePlan(address nextImplementation, uint96 delay) external {
+        if (delay == 0) {
+            delay = 1;
+        }
+        _announcePlannedUpgrade(nextImplementation, uint96(block.number) + delay);
+    }
+
+    /// @notice Announce a planned upgrade
+    /// @dev Can only be called by the contract owner
     /// @param plannedUpgrade The planned upgrade details
-    function announcePlannedUpgrade(PlannedUpgrade calldata plannedUpgrade) external onlyOwner {
-        require(plannedUpgrade.nextImplementation.code.length > 3000);
-        require(plannedUpgrade.afterEpoch > block.number);
-        nextUpgrade = plannedUpgrade;
-        emit UpgradeAnnounced(plannedUpgrade);
+    /// @custom:deprecated Use announceUpgradePlan instead
+    function announcePlannedUpgrade(PlannedUpgrade calldata plannedUpgrade) external {
+        uint96 minAfterEpoch = uint96(block.number + 1);
+        _announcePlannedUpgrade(
+            plannedUpgrade.nextImplementation,
+            plannedUpgrade.afterEpoch < minAfterEpoch ? minAfterEpoch : plannedUpgrade.afterEpoch
+        );
+    }
+
+    function _announcePlannedUpgrade(address nextImplementation, uint96 afterEpoch) internal onlyOwner {
+        require(nextImplementation.code.length > 3000);
+        nextUpgrade.nextImplementation = nextImplementation;
+        nextUpgrade.afterEpoch = afterEpoch;
+        emit UpgradeAnnounced(nextUpgrade);
     }
 
     /// @notice Authorizes an upgrade to a new implementation

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import {MockFVMTest} from "@fvm-solidity/mocks/MockFVMTest.sol";
+import {stdError} from "forge-std/StdError.sol";
 import {console, Test, Vm} from "forge-std/Test.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
@@ -446,7 +447,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         new MyERC1967Proxy(address(serviceImpl4), initDataLongDesc);
     }
 
-    function testUpgrade() public {
+    function testUpgrade(bool useDeprecatedMethod) public {
         FilecoinWarmStorageService firstServiceImpl = new FilecoinWarmStorageService(
             address(mockPDPVerifier),
             address(payments),
@@ -477,6 +478,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
 
         bytes memory migrateData = abi.encodeWithSelector(FilecoinWarmStorageService.migrate.selector, viewContract);
 
+        // Upgrade plan should be cleared
         (address nextImplementation, uint96 afterEpoch) = viewContract.nextUpgrade();
         assertEq(nextImplementation, address(0));
         assertEq(afterEpoch, uint96(0));
@@ -495,12 +497,20 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
             4
         );
 
+        // Another successful announcement
+        nextImplementation = address(newServiceImpl);
+        uint96 delay = 2000;
+        afterEpoch = uint96(vm.getBlockNumber()) + delay;
         FilecoinWarmStorageService.PlannedUpgrade memory plan;
-        plan.nextImplementation = address(newServiceImpl);
-        plan.afterEpoch = uint96(vm.getBlockNumber()) + 2000;
-        service.announcePlannedUpgrade(plan);
 
-        (nextImplementation, afterEpoch) = viewContract.nextUpgrade();
+        if (useDeprecatedMethod) {
+            plan.nextImplementation = nextImplementation;
+            plan.afterEpoch = afterEpoch;
+            service.announcePlannedUpgrade(plan);
+        } else {
+            service.announceUpgradePlan(nextImplementation, delay);
+        }
+        (plan.nextImplementation, plan.afterEpoch) = viewContract.nextUpgrade();
         assertEq(nextImplementation, plan.nextImplementation);
         assertEq(afterEpoch, plan.afterEpoch);
 
@@ -509,12 +519,33 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         service.upgradeToAndCall(nextImplementation, migrateData);
         vm.roll(plan.afterEpoch - 1);
         vm.expectRevert();
-        service.upgradeToAndCall(plan.nextImplementation, migrateData);
+        service.upgradeToAndCall(nextImplementation, migrateData);
 
         vm.roll(plan.afterEpoch);
         vm.expectEmit(false, false, false, true, address(service));
-        emit FilecoinWarmStorageService.ContractUpgraded(newServiceImpl.VERSION(), plan.nextImplementation);
-        service.upgradeToAndCall(plan.nextImplementation, migrateData);
+        emit FilecoinWarmStorageService.ContractUpgraded(newServiceImpl.VERSION(), nextImplementation);
+        service.upgradeToAndCall(nextImplementation, migrateData);
+
+        // Plan should be cleared
+        (plan.nextImplementation, plan.afterEpoch) = viewContract.nextUpgrade();
+        assertEq(address(0), plan.nextImplementation);
+        assertEq(0, plan.afterEpoch);
+
+        // Check behavior of minimum delay
+        if (useDeprecatedMethod) {
+            plan.nextImplementation = nextImplementation;
+            plan.afterEpoch = 0;
+            service.announcePlannedUpgrade(plan);
+        } else {
+            // prevent overflow
+            vm.expectRevert(stdError.arithmeticError);
+            service.announceUpgradePlan(nextImplementation, type(uint96).max);
+
+            service.announceUpgradePlan(nextImplementation, 0);
+        }
+        (plan.nextImplementation, plan.afterEpoch) = viewContract.nextUpgrade();
+        assertEq(plan.nextImplementation, nextImplementation);
+        assertEq(plan.afterEpoch, vm.getBlockNumber() + 1);
     }
 
     function _getSingleMetadataKV(string memory key, string memory value)

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -448,7 +448,15 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         new MyERC1967Proxy(address(serviceImpl4), initDataLongDesc);
     }
 
-    function testUpgrade(bool useDeprecatedMethod) public {
+    function testAnnouncePlannedUpgrade() public {
+        _testUpgrade(true);
+    }
+
+    function testAnnounceUpgradePlan() public {
+        _testUpgrade(false);
+    }
+
+    function _testUpgrade(bool useDeprecatedMethod) internal {
         FilecoinWarmStorageService firstServiceImpl = new FilecoinWarmStorageService(
             address(mockPDPVerifier),
             address(payments),
@@ -549,7 +557,15 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         assertEq(plan.afterEpoch, vm.getBlockNumber() + 1);
     }
 
-    function testAnnouncePlannedUpgradeOnlyOwner(bool useDeprecatedMethod) public {
+    function testAnnouncePlannedUpgradeOnlyOwner() public {
+        _testAnnouncePlannedUpgradeOnlyOwner(true);
+    }
+
+    function testAnnounceUpgradePlanOnlyOwner() public {
+        _testAnnouncePlannedUpgradeOnlyOwner(false);
+    }
+
+    function _testAnnouncePlannedUpgradeOnlyOwner(bool useDeprecatedMethod) internal {
         FilecoinWarmStorageService newServiceImpl = new FilecoinWarmStorageService(
             address(mockPDPVerifier),
             address(payments),

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -9,6 +9,7 @@ import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {Cids} from "@pdp/Cids.sol";
 import {MyERC1967Proxy} from "@pdp/ERC1967Proxy.sol";
 import {SessionKeyRegistry} from "@session-key-registry/SessionKeyRegistry.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 import {CHALLENGES_PER_PROOF, FilecoinWarmStorageService} from "../src/FilecoinWarmStorageService.sol";
 import {FilecoinWarmStorageServiceStateView} from "../src/FilecoinWarmStorageServiceStateView.sol";
@@ -546,6 +547,29 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         (plan.nextImplementation, plan.afterEpoch) = viewContract.nextUpgrade();
         assertEq(plan.nextImplementation, nextImplementation);
         assertEq(plan.afterEpoch, vm.getBlockNumber() + 1);
+    }
+
+    function testAnnouncePlannedUpgradeOnlyOwner(bool useDeprecatedMethod) public {
+        FilecoinWarmStorageService newServiceImpl = new FilecoinWarmStorageService(
+            address(mockPDPVerifier),
+            address(payments),
+            mockUSDFC,
+            filBeamBeneficiary,
+            serviceProviderRegistry,
+            sessionKeyRegistry,
+            4
+        );
+
+        vm.prank(client);
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, client));
+        if (useDeprecatedMethod) {
+            FilecoinWarmStorageService.PlannedUpgrade memory plan;
+            plan.nextImplementation = address(newServiceImpl);
+            plan.afterEpoch = uint96(vm.getBlockNumber()) + 2000;
+            pdpServiceWithPayments.announcePlannedUpgrade(plan);
+        } else {
+            pdpServiceWithPayments.announceUpgradePlan(address(newServiceImpl), 2000);
+        }
     }
 
     function _getSingleMetadataKV(string memory key, string memory value)

--- a/service_contracts/test/ServiceProviderRegistry.t.sol
+++ b/service_contracts/test/ServiceProviderRegistry.t.sol
@@ -53,7 +53,7 @@ contract ServiceProviderRegistryTest is MockFVMTest {
         registry.initialize();
     }
 
-    function testAnnouncePlannedUpgrade() public {
+    function testAnnouncePlannedUpgrade(bool useDeprecatedMethod) public {
         // Initially, no upgrade is planned
         (address nextImplementation, uint96 afterEpoch) = registry.nextUpgrade();
         assertEq(nextImplementation, address(0));
@@ -63,13 +63,20 @@ contract ServiceProviderRegistryTest is MockFVMTest {
         ServiceProviderRegistry newImplementation = new ServiceProviderRegistry(2);
 
         // Announce upgrade
+        nextImplementation = address(newImplementation);
+        uint96 delay = 2000;
+        afterEpoch = uint96(vm.getBlockNumber()) + delay;
         ServiceProviderRegistry.PlannedUpgrade memory plan;
-        plan.nextImplementation = address(newImplementation);
-        plan.afterEpoch = uint96(vm.getBlockNumber()) + 2000;
+        plan.nextImplementation = nextImplementation;
+        plan.afterEpoch = afterEpoch;
 
         vm.expectEmit(false, false, false, true);
         emit ServiceProviderRegistry.UpgradeAnnounced(plan);
-        registry.announcePlannedUpgrade(plan);
+        if (useDeprecatedMethod) {
+            registry.announcePlannedUpgrade(plan);
+        } else {
+            registry.announceUpgradePlan(nextImplementation, delay);
+        }
 
         // Verify upgrade plan is stored
         (nextImplementation, afterEpoch) = registry.nextUpgrade();
@@ -115,35 +122,51 @@ contract ServiceProviderRegistryTest is MockFVMTest {
         assertEq(afterEpoch, uint96(0));
     }
 
-    function testAnnouncePlannedUpgradeOnlyOwner() public {
+    function testAnnouncePlannedUpgradeOnlyOwner(bool useDeprecatedMethod) public {
         ServiceProviderRegistry newImplementation = new ServiceProviderRegistry(2);
-        ServiceProviderRegistry.PlannedUpgrade memory plan;
-        plan.nextImplementation = address(newImplementation);
-        plan.afterEpoch = uint96(vm.getBlockNumber()) + 2000;
 
         // Non-owner cannot announce upgrade
         vm.prank(user1);
         vm.expectRevert();
-        registry.announcePlannedUpgrade(plan);
+        if (useDeprecatedMethod) {
+            ServiceProviderRegistry.PlannedUpgrade memory plan;
+            plan.nextImplementation = address(newImplementation);
+            plan.afterEpoch = uint96(vm.getBlockNumber()) + 2000;
+            registry.announcePlannedUpgrade(plan);
+        } else {
+            registry.announceUpgradePlan(address(newImplementation), 2000);
+        }
     }
 
-    function testAnnouncePlannedUpgradeInvalidImplementation() public {
-        ServiceProviderRegistry.PlannedUpgrade memory plan;
-        plan.nextImplementation = address(0x123); // Invalid address with no code
-        plan.afterEpoch = uint96(vm.getBlockNumber()) + 2000;
-
-        vm.expectRevert();
-        registry.announcePlannedUpgrade(plan);
+    function testAnnouncePlannedUpgradeInvalidImplementation(bool useDeprecatedMethod) public {
+        if (useDeprecatedMethod) {
+            ServiceProviderRegistry.PlannedUpgrade memory plan;
+            plan.nextImplementation = address(0x123); // Invalid address with no code
+            plan.afterEpoch = uint96(vm.getBlockNumber()) + 2000;
+            vm.expectRevert();
+            registry.announcePlannedUpgrade(plan);
+        } else {
+            vm.expectRevert();
+            registry.announceUpgradePlan(address(0x123), 2000); // Invalid address with no code
+        }
     }
 
-    function testAnnouncePlannedUpgradeInvalidEpoch() public {
+    // A low or past afterEpoch/delay is clamped up to the minimum rather than reverting
+    function testAnnouncePlannedUpgradeMinimumDelay(bool useDeprecatedMethod) public {
         ServiceProviderRegistry newImplementation = new ServiceProviderRegistry(2);
-        ServiceProviderRegistry.PlannedUpgrade memory plan;
-        plan.nextImplementation = address(newImplementation);
-        plan.afterEpoch = uint96(vm.getBlockNumber()); // Must be in the future
 
-        vm.expectRevert();
-        registry.announcePlannedUpgrade(plan);
+        if (useDeprecatedMethod) {
+            ServiceProviderRegistry.PlannedUpgrade memory plan;
+            plan.nextImplementation = address(newImplementation);
+            plan.afterEpoch = 0;
+            registry.announcePlannedUpgrade(plan);
+        } else {
+            registry.announceUpgradePlan(address(newImplementation), 0);
+        }
+
+        (address nextImplementation, uint96 afterEpoch) = registry.nextUpgrade();
+        assertEq(nextImplementation, address(newImplementation));
+        assertEq(afterEpoch, vm.getBlockNumber() + 1);
     }
 
     function testIsRegisteredProviderReturnsFalse() public view {

--- a/service_contracts/test/ServiceProviderRegistry.t.sol
+++ b/service_contracts/test/ServiceProviderRegistry.t.sol
@@ -53,7 +53,15 @@ contract ServiceProviderRegistryTest is MockFVMTest {
         registry.initialize();
     }
 
-    function testAnnouncePlannedUpgrade(bool useDeprecatedMethod) public {
+    function testAnnouncePlannedUpgrade() public {
+        _testAnnouncePlannedUpgrade(true);
+    }
+
+    function testAnnounceUpgradePlan() public {
+        _testAnnouncePlannedUpgrade(false);
+    }
+
+    function _testAnnouncePlannedUpgrade(bool useDeprecatedMethod) internal {
         // Initially, no upgrade is planned
         (address nextImplementation, uint96 afterEpoch) = registry.nextUpgrade();
         assertEq(nextImplementation, address(0));
@@ -122,7 +130,15 @@ contract ServiceProviderRegistryTest is MockFVMTest {
         assertEq(afterEpoch, uint96(0));
     }
 
-    function testAnnouncePlannedUpgradeOnlyOwner(bool useDeprecatedMethod) public {
+    function testAnnouncePlannedUpgradeOnlyOwner() public {
+        _testAnnouncePlannedUpgradeOnlyOwner(true);
+    }
+
+    function testAnnounceUpgradePlanOnlyOwner() public {
+        _testAnnouncePlannedUpgradeOnlyOwner(false);
+    }
+
+    function _testAnnouncePlannedUpgradeOnlyOwner(bool useDeprecatedMethod) internal {
         ServiceProviderRegistry newImplementation = new ServiceProviderRegistry(2);
 
         // Non-owner cannot announce upgrade
@@ -138,7 +154,15 @@ contract ServiceProviderRegistryTest is MockFVMTest {
         }
     }
 
-    function testAnnouncePlannedUpgradeInvalidImplementation(bool useDeprecatedMethod) public {
+    function testAnnouncePlannedUpgradeInvalidImplementation() public {
+        _testAnnouncePlannedUpgradeInvalidImplementation(true);
+    }
+
+    function testAnnounceUpgradePlanInvalidImplementation() public {
+        _testAnnouncePlannedUpgradeInvalidImplementation(false);
+    }
+
+    function _testAnnouncePlannedUpgradeInvalidImplementation(bool useDeprecatedMethod) internal {
         if (useDeprecatedMethod) {
             ServiceProviderRegistry.PlannedUpgrade memory plan;
             plan.nextImplementation = address(0x123); // Invalid address with no code
@@ -152,7 +176,15 @@ contract ServiceProviderRegistryTest is MockFVMTest {
     }
 
     // A low or past afterEpoch/delay is clamped up to the minimum rather than reverting
-    function testAnnouncePlannedUpgradeMinimumDelay(bool useDeprecatedMethod) public {
+    function testAnnouncePlannedUpgradeMinimumDelay() public {
+        _testAnnouncePlannedUpgradeMinimumDelay(true);
+    }
+
+    function testAnnounceUpgradePlanMinimumDelay() public {
+        _testAnnouncePlannedUpgradeMinimumDelay(false);
+    }
+
+    function _testAnnouncePlannedUpgradeMinimumDelay(bool useDeprecatedMethod) internal {
         ServiceProviderRegistry newImplementation = new ServiceProviderRegistry(2);
 
         if (useDeprecatedMethod) {

--- a/service_contracts/tools/README.md
+++ b/service_contracts/tools/README.md
@@ -206,7 +206,7 @@ The FilecoinWarmStorageService and ServiceProviderRegistry contracts use a **two
 2. **Observe**: Read `nextUpgrade()` after the announcement lands and record its exact `afterEpoch`
 3. **Execute**: After the observed epoch, call `upgradeToAndCall()` to complete the upgrade
 
-The delay is measured from the block in which the announcement executes, so Safe signing time does not consume the requested notice window. ServiceProviderRegistry continues to use `announcePlannedUpgrade()` with an absolute epoch.
+The delay is measured from the block in which the announcement executes, so Safe signing time does not consume the requested notice window.
 
 **For complete FWSS upgrade documentation**, including:
 - Step-by-step upgrade workflows

--- a/service_contracts/tools/README.md
+++ b/service_contracts/tools/README.md
@@ -75,7 +75,7 @@ The `check-gen` CI job ([`.github/workflows/check.yml`](../../.github/workflows/
 
 # Upgrade existing deployment (see UPGRADE-CHECKLIST.md for the full runbook)
 ./tools/warm-storage-announce-upgrade.sh    # Step 1: Announce
-./tools/warm-storage-execute-upgrade.sh     # Step 2: Execute (after AFTER_EPOCH)
+./tools/warm-storage-execute-upgrade.sh     # Step 2: Execute (after the observed afterEpoch)
 ```
 
 ## Deployment Parameters
@@ -200,12 +200,13 @@ See [UPGRADE-CHECKLIST.md](./UPGRADE-CHECKLIST.md) for the complete two-step FWS
 
 ## Contract Upgrade Process
 
-The FilecoinWarmStorageService and ServiceProviderRegistry contracts use a **two-step upgrade process** for security:
+The FilecoinWarmStorageService and ServiceProviderRegistry contracts use a **two-step upgrade process** for security. The normal FWSS flow is:
 
-1. **Announce**: Call `announcePlannedUpgrade()` with the new implementation address and a future epoch
-2. **Execute**: After the announced epoch, call `upgradeToAndCall()` to complete the upgrade
+1. **Announce**: Call `announceUpgradePlan()` with the new implementation address and a relative delay
+2. **Observe**: Read `nextUpgrade()` after the announcement lands and record its exact `afterEpoch`
+3. **Execute**: After the observed epoch, call `upgradeToAndCall()` to complete the upgrade
 
-This gives stakeholders time to review changes before execution.
+The delay is measured from the block in which the announcement executes, so Safe signing time does not consume the requested notice window. ServiceProviderRegistry continues to use `announcePlannedUpgrade()` with an absolute epoch.
 
 **For complete FWSS upgrade documentation**, including:
 - Step-by-step upgrade workflows
@@ -257,11 +258,26 @@ The following scripts support `CALLDATA_ONLY=true`:
 export ETH_RPC_URL="https://api.node.glif.io/rpc/v1"
 export FWSS_PROXY_ADDRESS="0x8408502033C418E1bbC97cE9ac48E5528F371A9f"
 export NEW_FWSS_IMPLEMENTATION_ADDRESS="0x..."
-export AFTER_EPOCH="123456"
+export UPGRADE_DELAY_EPOCHS="2880"
+unset ANNOUNCEMENT_MODE AFTER_EPOCH
 CALLDATA_ONLY=true ./warm-storage-announce-upgrade.sh
 ```
 
 This prints a formatted transaction block with the target address, function signature, and calldata to paste into the Safe UI transaction builder.
+
+The FWSS v1.3.0 contracts currently deployed on Calibnet and Mainnet do not expose `announceUpgradePlan()`. Their upgrade to v1.3.1 must therefore use the old interface:
+
+```bash
+export ANNOUNCEMENT_MODE=legacy
+export LEGACY_NOTICE_EPOCHS=2880
+export SAFE_SIGNING_BUFFER_EPOCHS=2880
+CURRENT_EPOCH=$(cast block-number --rpc-url "$ETH_RPC_URL")
+export AFTER_EPOCH=$((CURRENT_EPOCH + SAFE_SIGNING_BUFFER_EPOCHS + LEGACY_NOTICE_EPOCHS))
+unset UPGRADE_DELAY_EPOCHS
+CALLDATA_ONLY=true ./warm-storage-announce-upgrade.sh
+```
+
+Treat this bootstrap-only mode as deprecated after FWSS v1.3.1 is live on both Calibnet and Mainnet. Remove it once rollback to v1.3.0 is no longer supported; until then it remains available only for that rollback path.
 
 ## Testing
 

--- a/service_contracts/tools/README.md
+++ b/service_contracts/tools/README.md
@@ -259,7 +259,8 @@ export ETH_RPC_URL="https://api.node.glif.io/rpc/v1"
 export FWSS_PROXY_ADDRESS="0x8408502033C418E1bbC97cE9ac48E5528F371A9f"
 export NEW_FWSS_IMPLEMENTATION_ADDRESS="0x..."
 export UPGRADE_DELAY_EPOCHS="2880"
-unset ANNOUNCEMENT_MODE AFTER_EPOCH
+export ANNOUNCEMENT_MODE=delay
+unset AFTER_EPOCH
 CALLDATA_ONLY=true ./warm-storage-announce-upgrade.sh
 ```
 

--- a/service_contracts/tools/UPGRADE-CHECKLIST.md
+++ b/service_contracts/tools/UPGRADE-CHECKLIST.md
@@ -49,7 +49,7 @@ Field ownership for duplicated rollout data:
 
 ### Upgrade Schedule
 
-| Network | Announcement mode (v1.3.1 bootstrap only) | Requested delay | Actual `AFTER_EPOCH` | Status |
+| Network | Announcement mode (v1.3.1 bootstrap only) | Requested delay epochs | Actual `AFTER_EPOCH` | Status |
 |---|---|---:|---:|---|
 | Calibnet | `TBD` | `TBD` | `TBD` | Pending |
 | Mainnet | `TBD` | `TBD` | `TBD` | Pending |
@@ -151,7 +151,13 @@ Record validation that proves the planned upgrade works against the full contrac
 | Routine | `2880` epochs (~24h) | 1-2 days |
 | Breaking change | `20160` epochs (~1 week) | 1-2 weeks |
 
-Calibnet can use a shorter window for rehearsal and validation, but use enough time for signers to coordinate. Select a positive operational delay; the contract's one-epoch floor is an emergency safety bound, not the routine notice policy.
+| Upgrade Type | Minimum Notice | Recommended |
+|---|---:|---|
+| Calibration | `240` epochs (~2h) | ~1 day |
+| Mainnet Routine | `2880` epochs (~24h) | 1-2 days |
+| Mainnet Breaking change | `20160` epochs (~1 week) | 1-2 weeks |
+
+Select a positive operational delay; the contract's one-epoch floor is an emergency safety bound, not the routine notice policy.
 
 ```bash
 export UPGRADE_DELAY_EPOCHS=2880 # use 240+ for Calibnet rehearsal, 20160 for breaking changes
@@ -379,7 +385,7 @@ In Safe Transaction Builder, set target to the printed FWSS proxy, value to `0`,
 **Announce**
 - [ ] Set the Calibnet requested delay and update the schedule table. **v1.3.1 bootstrap only:** record the announcement mode as `legacy`; upgrades from v1.3.1 onward always use `delay`.
 
-- [ ] Generate announce calldata and submit/sign/execute in Safe UI:
+- [ ] Generate announce calldata
 
 ```bash
 cd service_contracts/tools

--- a/service_contracts/tools/UPGRADE-CHECKLIST.md
+++ b/service_contracts/tools/UPGRADE-CHECKLIST.md
@@ -378,7 +378,7 @@ In Safe Transaction Builder, set target to the printed FWSS proxy, value to `0`,
 ### Phase 3: Calibnet Announce + Execute
 
 **Announce**
-- [ ] Set the Calibnet requested delay and update the schedule table. **v1.3.1 bootstrap only:** record the announcement mode as `legacy`; upgrades from v1.3.1 onward always use `delay`.
+- [ ] Update the Calibnet row in the upgrade schedule table with the requested delay. **v1.3.1 bootstrap only:** record the announcement mode as `legacy`; upgrades from v1.3.1 onward always use `delay`.
 
 - [ ] Generate announce calldata
 
@@ -546,7 +546,7 @@ The unique `smoke_run` metadata is required so this validates new Data Set creat
 - [ ] Technical owner records Mainnet go/no-go after reviewing Calibnet evidence, rollback status, dependency targets, and cross-repo status
 - [ ] Confirm required cross-repo changes are merged/released or explicitly waived by the technical owner
 - [ ] Notify stakeholders before announcing Mainnet, including FilB so they can propagate the upgrade notice
-- [ ] Set the Mainnet requested delay and update the schedule table. **v1.3.1 bootstrap only:** record the announcement mode as `legacy`; upgrades from v1.3.1 onward always use `delay`.
+- [ ] Update the Mainnet row in the upgrade schedule table with the requested delay. **v1.3.1 bootstrap only:** record the announcement mode as `legacy`; upgrades from v1.3.1 onward always use `delay`.
 
 - [ ] Generate announce calldata and submit/sign/execute in Safe UI:
 

--- a/service_contracts/tools/UPGRADE-CHECKLIST.md
+++ b/service_contracts/tools/UPGRADE-CHECKLIST.md
@@ -415,41 +415,11 @@ CALLDATA_ONLY=true ./warm-storage-announce-upgrade.sh
 ```
 
 - [ ] In Safe Transaction Builder, set target to the printed FWSS proxy, value to `0`, and data to the printed calldata
-- [ ] After the Safe transaction executes, verify and read back the pending plan:
+- [ ] After the Safe transaction executes, set the Calibnet verification inputs, then run the [shared pending-plan verification](#shared-pending-plan-verification):
 
 ```bash
 export ANNOUNCE_TX_HASH="0x..." # Safe execution transaction hash
-
-CURRENT_VIEW=$(cast call --rpc-url "$ETH_RPC_URL" \
-  "$FWSS_PROXY_ADDRESS" \
-  'viewContractAddress()(address)')
-
-UPGRADE_PLAN=($(cast call --rpc-url "$ETH_RPC_URL" \
-  "$CURRENT_VIEW" \
-  'nextUpgrade()(address,uint96)'))
-
-OBSERVED_IMPL=${UPGRADE_PLAN[0]}
-OBSERVED_AFTER_EPOCH=${UPGRADE_PLAN[1]}
-echo "Planned implementation: $OBSERVED_IMPL (expected $CALI_NEW_IMPL)"
-echo "Actual afterEpoch: $OBSERVED_AFTER_EPOCH"
-
-if [ "${ANNOUNCEMENT_MODE:-legacy}" = "legacy" ]; then
-  EXPECTED_AFTER_EPOCH=$AFTER_EPOCH
-else
-  ANNOUNCE_EPOCH=$(cast receipt --rpc-url "$ETH_RPC_URL" "$ANNOUNCE_TX_HASH" blockNumber)
-  EFFECTIVE_DELAY_EPOCHS=$UPGRADE_DELAY_EPOCHS
-  [ "$EFFECTIVE_DELAY_EPOCHS" -eq 0 ] && EFFECTIVE_DELAY_EPOCHS=1
-  EXPECTED_AFTER_EPOCH=$((ANNOUNCE_EPOCH + EFFECTIVE_DELAY_EPOCHS))
-fi
-
-if [ "$(printf '%s' "$OBSERVED_IMPL" | tr '[:upper:]' '[:lower:]')" != "$(printf '%s' "$CALI_NEW_IMPL" | tr '[:upper:]' '[:lower:]')" ]; then
-  echo "ERROR: announced implementation mismatch"
-  exit 1
-fi
-if [ "$OBSERVED_AFTER_EPOCH" -ne "$EXPECTED_AFTER_EPOCH" ]; then
-  echo "ERROR: afterEpoch mismatch ($OBSERVED_AFTER_EPOCH != $EXPECTED_AFTER_EPOCH)"
-  exit 1
-fi
+export EXPECTED_FWSS_IMPLEMENTATION_ADDRESS="$CALI_NEW_IMPL"
 ```
 
 - [ ] Record the Calibnet announce tx and observed `afterEpoch` in the schedule and Run Log
@@ -583,41 +553,11 @@ CALLDATA_ONLY=true ./warm-storage-announce-upgrade.sh
 ```
 
 - [ ] In Safe Transaction Builder, set target to the printed FWSS proxy, value to `0`, and data to the printed calldata
-- [ ] After the Safe transaction executes, verify and read back the pending plan:
+- [ ] After the Safe transaction executes, set the Mainnet verification inputs, then run the [shared pending-plan verification](#shared-pending-plan-verification):
 
 ```bash
 export ANNOUNCE_TX_HASH="0x..." # Safe execution transaction hash
-
-CURRENT_VIEW=$(cast call --rpc-url "$ETH_RPC_URL" \
-  "$FWSS_PROXY_ADDRESS" \
-  'viewContractAddress()(address)')
-
-UPGRADE_PLAN=($(cast call --rpc-url "$ETH_RPC_URL" \
-  "$CURRENT_VIEW" \
-  'nextUpgrade()(address,uint96)'))
-
-OBSERVED_IMPL=${UPGRADE_PLAN[0]}
-OBSERVED_AFTER_EPOCH=${UPGRADE_PLAN[1]}
-echo "Planned implementation: $OBSERVED_IMPL (expected $MAIN_NEW_IMPL)"
-echo "Actual afterEpoch: $OBSERVED_AFTER_EPOCH"
-
-if [ "${ANNOUNCEMENT_MODE:-legacy}" = "legacy" ]; then
-  EXPECTED_AFTER_EPOCH=$AFTER_EPOCH
-else
-  ANNOUNCE_EPOCH=$(cast receipt --rpc-url "$ETH_RPC_URL" "$ANNOUNCE_TX_HASH" blockNumber)
-  EFFECTIVE_DELAY_EPOCHS=$UPGRADE_DELAY_EPOCHS
-  [ "$EFFECTIVE_DELAY_EPOCHS" -eq 0 ] && EFFECTIVE_DELAY_EPOCHS=1
-  EXPECTED_AFTER_EPOCH=$((ANNOUNCE_EPOCH + EFFECTIVE_DELAY_EPOCHS))
-fi
-
-if [ "$(printf '%s' "$OBSERVED_IMPL" | tr '[:upper:]' '[:lower:]')" != "$(printf '%s' "$MAIN_NEW_IMPL" | tr '[:upper:]' '[:lower:]')" ]; then
-  echo "ERROR: announced implementation mismatch"
-  exit 1
-fi
-if [ "$OBSERVED_AFTER_EPOCH" -ne "$EXPECTED_AFTER_EPOCH" ]; then
-  echo "ERROR: afterEpoch mismatch ($OBSERVED_AFTER_EPOCH != $EXPECTED_AFTER_EPOCH)"
-  exit 1
-fi
+export EXPECTED_FWSS_IMPLEMENTATION_ADDRESS="$MAIN_NEW_IMPL"
 ```
 
 - [ ] Record the Mainnet announce tx and observed `afterEpoch` in the schedule and Run Log
@@ -705,6 +645,43 @@ The unique `smoke_run` metadata is required so this validates new Data Set creat
 
 - [ ] Verify the proxy on Blockscout
 - [ ] Update the GitHub pre-release Mainnet rollout status with execute tx, checks, and smoke/E2E evidence
+
+### Shared Pending-Plan Verification
+
+Run this after each Safe announcement transaction. Keep the network's `ETH_RPC_URL`, `FWSS_PROXY_ADDRESS`, `ANNOUNCEMENT_MODE`, and mode-specific `AFTER_EPOCH` or `UPGRADE_DELAY_EPOCHS` values in the environment, and set `ANNOUNCE_TX_HASH` and `EXPECTED_FWSS_IMPLEMENTATION_ADDRESS` in the relevant network phase above.
+
+```bash
+CURRENT_VIEW=$(cast call --rpc-url "$ETH_RPC_URL" \
+  "$FWSS_PROXY_ADDRESS" \
+  'viewContractAddress()(address)')
+
+UPGRADE_PLAN=($(cast call --rpc-url "$ETH_RPC_URL" \
+  "$CURRENT_VIEW" \
+  'nextUpgrade()(address,uint96)'))
+
+OBSERVED_IMPL=${UPGRADE_PLAN[0]}
+OBSERVED_AFTER_EPOCH=${UPGRADE_PLAN[1]}
+echo "Planned implementation: $OBSERVED_IMPL (expected $EXPECTED_FWSS_IMPLEMENTATION_ADDRESS)"
+echo "Actual afterEpoch: $OBSERVED_AFTER_EPOCH"
+
+if [ "${ANNOUNCEMENT_MODE:-legacy}" = "legacy" ]; then
+  EXPECTED_AFTER_EPOCH=$AFTER_EPOCH
+else
+  ANNOUNCE_EPOCH=$(cast receipt --rpc-url "$ETH_RPC_URL" "$ANNOUNCE_TX_HASH" blockNumber)
+  EFFECTIVE_DELAY_EPOCHS=$UPGRADE_DELAY_EPOCHS
+  [ "$EFFECTIVE_DELAY_EPOCHS" -eq 0 ] && EFFECTIVE_DELAY_EPOCHS=1
+  EXPECTED_AFTER_EPOCH=$((ANNOUNCE_EPOCH + EFFECTIVE_DELAY_EPOCHS))
+fi
+
+if [ "$(printf '%s' "$OBSERVED_IMPL" | tr '[:upper:]' '[:lower:]')" != "$(printf '%s' "$EXPECTED_FWSS_IMPLEMENTATION_ADDRESS" | tr '[:upper:]' '[:lower:]')" ]; then
+  echo "ERROR: announced implementation mismatch"
+  exit 1
+fi
+if [ "$OBSERVED_AFTER_EPOCH" -ne "$EXPECTED_AFTER_EPOCH" ]; then
+  echo "ERROR: afterEpoch mismatch ($OBSERVED_AFTER_EPOCH != $EXPECTED_AFTER_EPOCH)"
+  exit 1
+fi
+```
 
 ### Phase 5: Promote Release and Close Out
 - [ ] Confirm live Calibnet and Mainnet FWSS implementation slots match the new implementation addresses

--- a/service_contracts/tools/UPGRADE-CHECKLIST.md
+++ b/service_contracts/tools/UPGRADE-CHECKLIST.md
@@ -155,6 +155,7 @@ Calibnet can use a shorter window for rehearsal and validation, but use enough t
 
 ```bash
 export UPGRADE_DELAY_EPOCHS=2880 # use 240+ for Calibnet rehearsal, 20160 for breaking changes
+export ANNOUNCEMENT_MODE=delay
 echo "Requested upgrade delay: $UPGRADE_DELAY_EPOCHS epochs"
 ```
 
@@ -391,7 +392,8 @@ For the normal delay-based flow:
 
 ```bash
 export UPGRADE_DELAY_EPOCHS=240 # use a longer window if desired
-unset ANNOUNCEMENT_MODE AFTER_EPOCH
+export ANNOUNCEMENT_MODE=delay
+unset AFTER_EPOCH
 ```
 
 For the v1.3.0 -> v1.3.1 bootstrap rollout only, use this configuration instead:
@@ -430,7 +432,7 @@ OBSERVED_AFTER_EPOCH=${UPGRADE_PLAN[1]}
 echo "Planned implementation: $OBSERVED_IMPL (expected $CALI_NEW_IMPL)"
 echo "Actual afterEpoch: $OBSERVED_AFTER_EPOCH"
 
-if [ "${ANNOUNCEMENT_MODE:-delay}" = "legacy" ]; then
+if [ "${ANNOUNCEMENT_MODE:-legacy}" = "legacy" ]; then
   EXPECTED_AFTER_EPOCH=$AFTER_EPOCH
 else
   ANNOUNCE_EPOCH=$(cast receipt --rpc-url "$ETH_RPC_URL" "$ANNOUNCE_TX_HASH" blockNumber)
@@ -558,7 +560,8 @@ For the normal delay-based flow:
 
 ```bash
 export UPGRADE_DELAY_EPOCHS=2880 # use 20160 for breaking changes
-unset ANNOUNCEMENT_MODE AFTER_EPOCH
+export ANNOUNCEMENT_MODE=delay
+unset AFTER_EPOCH
 ```
 
 For the v1.3.0 -> v1.3.1 bootstrap rollout only, use this configuration instead:
@@ -597,7 +600,7 @@ OBSERVED_AFTER_EPOCH=${UPGRADE_PLAN[1]}
 echo "Planned implementation: $OBSERVED_IMPL (expected $MAIN_NEW_IMPL)"
 echo "Actual afterEpoch: $OBSERVED_AFTER_EPOCH"
 
-if [ "${ANNOUNCEMENT_MODE:-delay}" = "legacy" ]; then
+if [ "${ANNOUNCEMENT_MODE:-legacy}" = "legacy" ]; then
   EXPECTED_AFTER_EPOCH=$AFTER_EPOCH
 else
   ANNOUNCE_EPOCH=$(cast receipt --rpc-url "$ETH_RPC_URL" "$ANNOUNCE_TX_HASH" blockNumber)

--- a/service_contracts/tools/UPGRADE-CHECKLIST.md
+++ b/service_contracts/tools/UPGRADE-CHECKLIST.md
@@ -155,7 +155,7 @@ Record validation that proves the planned upgrade works against the full contrac
 Select a positive operational delay; the contract's one-epoch floor is an emergency safety bound, not the routine notice policy.
 
 ```bash
-export UPGRADE_DELAY_EPOCHS=2880 # use 240+ for Calibnet rehearsal, 20160 for breaking changes
+export UPGRADE_DELAY_EPOCHS="<ENTER_VALUE_FROM_TABLE_ABOVE>"
 export ANNOUNCEMENT_MODE=delay
 echo "Requested upgrade delay: $UPGRADE_DELAY_EPOCHS epochs"
 ```
@@ -392,7 +392,7 @@ export NEW_FWSS_IMPLEMENTATION_ADDRESS="$CALI_NEW_IMPL"
 For the normal delay-based flow:
 
 ```bash
-export UPGRADE_DELAY_EPOCHS=240 # use a longer window if desired
+export UPGRADE_DELAY_EPOCHS="<ENTER_VALUE_FROM_TABLE_ABOVE>"
 export ANNOUNCEMENT_MODE=delay
 unset AFTER_EPOCH
 ```
@@ -560,7 +560,7 @@ export NEW_FWSS_IMPLEMENTATION_ADDRESS="$MAIN_NEW_IMPL"
 For the normal delay-based flow:
 
 ```bash
-export UPGRADE_DELAY_EPOCHS=2880 # use 20160 for breaking changes
+export UPGRADE_DELAY_EPOCHS="<ENTER_VALUE_FROM_TABLE_ABOVE>"
 export ANNOUNCEMENT_MODE=delay
 unset AFTER_EPOCH
 ```

--- a/service_contracts/tools/UPGRADE-CHECKLIST.md
+++ b/service_contracts/tools/UPGRADE-CHECKLIST.md
@@ -49,10 +49,14 @@ Field ownership for duplicated rollout data:
 
 ### Upgrade Schedule
 
-| Network | AFTER_EPOCH | Status |
-|---|---:|---|
-| Calibnet | `TBD` | Pending |
-| Mainnet | `TBD` | Pending |
+| Network | Announcement mode (v1.3.1 bootstrap only) | Requested delay | Actual `AFTER_EPOCH` | Status |
+|---|---|---:|---:|---|
+| Calibnet | `TBD` | `TBD` | `TBD` | Pending |
+| Mainnet | `TBD` | `TBD` | `TBD` | Pending |
+
+Set the requested delay before proposing the Safe transaction. For the normal delay-based flow, fill in the actual `AFTER_EPOCH` from `nextUpgrade()` after the announcement executes. The observed value is the source of truth for the execute step and external communications.
+
+> **v1.3.1 bootstrap only:** The announcement-mode column is temporary. Record `legacy` for the v1.3.0 -> v1.3.1 rollout; upgrades from v1.3.1 onward use `delay`. Record the absolute target before Safe signing, include the notice duration and signing buffer in the requested-delay cell, and verify the same target on-chain after execution.
 
 ### Run Log
 
@@ -60,10 +64,10 @@ The Run Log is this release issue's operator journal for rollout facts discovere
 
 Keep this table current as values become known.
 
-| Network | New FWSS implementation | StateView / setView tx | Announce tx | Execute tx | Post-upgrade checks |
-|---|---|---|---|---|---|
-| Calibnet | `TBD` | `TBD` | `TBD` | `TBD` | Pending |
-| Mainnet | `TBD` | `TBD` | `TBD` | `TBD` | Pending |
+| Network | New FWSS implementation | StateView / setView tx | Announce tx | Actual `afterEpoch` | Execute tx | Post-upgrade checks |
+|---|---|---|---|---:|---|---|
+| Calibnet | `TBD` | `TBD` | `TBD` | `TBD` | `TBD` | Pending |
+| Mainnet | `TBD` | `TBD` | `TBD` | `TBD` | `TBD` | Pending |
 
 ### Scope
 - In scope: `FilecoinWarmStorageService` implementation upgrade behind the existing FWSS proxy.
@@ -137,7 +141,8 @@ Record validation that proves the planned upgrade works against the full contrac
 - Do not announce Mainnet until Calibnet execution, on-chain checks, explorer checks, smoke/E2E checks, and `filecoin-pin` Data Set creation validation are complete.
 - Do not announce Mainnet until required cross-repo changes are merged/released or explicitly waived by the technical owner.
 - `service_contracts/deployments.json` reflects what is live behind proxies and View contracts. Update it only after the relevant proxy switch and, if applicable, View switch are complete, normally through follow-up PR(s) to `main`, and record PR links in Release Tracking.
-- If an `AFTER_EPOCH` changes, submit a new `announcePlannedUpgrade()` transaction and record that it supersedes the previous announcement.
+- In the normal delay-based flow, the requested delay starts when the Safe announcement executes. After execution, verify both fields returned by `nextUpgrade()` and record its exact `afterEpoch` as the source of truth.
+- A later announcement replaces the pending plan. Record the replacement transaction and explicitly mark it as superseding the previous announcement.
 
 ### Notice Guidance
 
@@ -146,14 +151,28 @@ Record validation that proves the planned upgrade works against the full contrac
 | Routine | `2880` epochs (~24h) | 1-2 days |
 | Breaking change | `20160` epochs (~1 week) | 1-2 weeks |
 
-Calibnet can use a shorter window for rehearsal and validation, but use enough time for signers to coordinate.
+Calibnet can use a shorter window for rehearsal and validation, but use enough time for signers to coordinate. Select a positive operational delay; the contract's one-epoch floor is an emergency safety bound, not the routine notice policy.
 
 ```bash
-export UPGRADE_WAIT_DURATION_EPOCHS=2880 # use 240+ for Calibnet rehearsal, 20160 for breaking changes
-CURRENT_EPOCH=$(cast block-number --rpc-url "$ETH_RPC_URL")
-AFTER_EPOCH=$((CURRENT_EPOCH + UPGRADE_WAIT_DURATION_EPOCHS))
-echo "Current: $CURRENT_EPOCH, Upgrade after: $AFTER_EPOCH"
+export UPGRADE_DELAY_EPOCHS=2880 # use 240+ for Calibnet rehearsal, 20160 for breaking changes
+echo "Requested upgrade delay: $UPGRADE_DELAY_EPOCHS epochs"
 ```
+
+### Temporary Bootstrap Compatibility
+
+FWSS v1.3.0 is currently deployed on Calibnet and Mainnet and does not expose `announceUpgradePlan(address,uint96)`. The v1.3.0 -> v1.3.1 rollout must announce through `announcePlannedUpgrade((address,uint96))`. Use `ANNOUNCEMENT_MODE=legacy` with an absolute `AFTER_EPOCH` for both networks and include a conservative Safe-signing buffer so the proposal is still in the future when it executes.
+
+```bash
+export ANNOUNCEMENT_MODE=legacy
+export LEGACY_NOTICE_EPOCHS=2880
+export SAFE_SIGNING_BUFFER_EPOCHS=240
+CURRENT_EPOCH=$(cast block-number --rpc-url "$ETH_RPC_URL")
+export AFTER_EPOCH=$((CURRENT_EPOCH + SAFE_SIGNING_BUFFER_EPOCHS + LEGACY_NOTICE_EPOCHS))
+unset UPGRADE_DELAY_EPOCHS
+echo "Legacy target epoch: $AFTER_EPOCH"
+```
+
+This is a v1.3.1 bootstrap exception, not a second long-term workflow. Treat legacy mode as deprecated once v1.3.1 is live on both networks, then use the Phase 5 cleanup item to remove it when rollback to v1.3.0 is retired.
 
 ### Post-Upgrade Evidence Required
 
@@ -228,10 +247,10 @@ cat > /tmp/fwss-release-notes.md <<'EOF'
 
 ## Rollout Status
 
-| Network | FWSS Proxy | FWSS Implementation | StateView | Announce tx | Execute tx | Status |
-|---|---|---|---|---|---|---|
-| Calibnet | `0x02925630df557F957f70E112bA06e50965417CA0` | `TBD` | `TBD` | `TBD` | `TBD` | Pending |
-| Mainnet | `0x8408502033C418E1bbC97cE9ac48E5528F371A9f` | `TBD` | `TBD` | `TBD` | `TBD` | Pending |
+| Network | FWSS Proxy | FWSS Implementation | StateView | Announce tx | Actual `afterEpoch` | Execute tx | Status |
+|---|---|---|---|---|---:|---|---|
+| Calibnet | `0x02925630df557F957f70E112bA06e50965417CA0` | `TBD` | `TBD` | `TBD` | `TBD` | `TBD` | Pending |
+| Mainnet | `0x8408502033C418E1bbC97cE9ac48E5528F371A9f` | `TBD` | `TBD` | `TBD` | `TBD` | `TBD` | Pending |
 
 ## Action Required For Integrators
 - TBD
@@ -357,15 +376,7 @@ In Safe Transaction Builder, set target to the printed FWSS proxy, value to `0`,
 ### Phase 3: Calibnet Announce + Execute
 
 **Announce**
-- [ ] Compute Calibnet `AFTER_EPOCH` and update the schedule table
-
-```bash
-export ETH_RPC_URL="https://api.calibration.node.glif.io/rpc/v1"
-export UPGRADE_WAIT_DURATION_EPOCHS=240 # use a longer window if desired
-CURRENT_EPOCH=$(cast block-number --rpc-url "$ETH_RPC_URL")
-AFTER_EPOCH=$((CURRENT_EPOCH + UPGRADE_WAIT_DURATION_EPOCHS))
-echo "$CURRENT_EPOCH -> $AFTER_EPOCH"
-```
+- [ ] Set the Calibnet requested delay and update the schedule table. **v1.3.1 bootstrap only:** record the announcement mode as `legacy`; upgrades from v1.3.1 onward always use `delay`.
 
 - [ ] Generate announce calldata and submit/sign/execute in Safe UI:
 
@@ -374,17 +385,75 @@ cd service_contracts/tools
 export ETH_RPC_URL="https://api.calibration.node.glif.io/rpc/v1"
 export FWSS_PROXY_ADDRESS="0x02925630df557F957f70E112bA06e50965417CA0"
 export NEW_FWSS_IMPLEMENTATION_ADDRESS="$CALI_NEW_IMPL"
-export AFTER_EPOCH="$AFTER_EPOCH"
+```
 
+For the normal delay-based flow:
+
+```bash
+export UPGRADE_DELAY_EPOCHS=240 # use a longer window if desired
+unset ANNOUNCEMENT_MODE AFTER_EPOCH
+```
+
+For the v1.3.0 -> v1.3.1 bootstrap rollout only, use this configuration instead:
+
+```bash
+export ANNOUNCEMENT_MODE=legacy
+export LEGACY_NOTICE_EPOCHS=240
+export SAFE_SIGNING_BUFFER_EPOCHS=240
+CURRENT_EPOCH=$(cast block-number --rpc-url "$ETH_RPC_URL")
+export AFTER_EPOCH=$((CURRENT_EPOCH + SAFE_SIGNING_BUFFER_EPOCHS + LEGACY_NOTICE_EPOCHS))
+unset UPGRADE_DELAY_EPOCHS
+```
+
+Generate the transaction after selecting exactly one configuration above:
+
+```bash
 CALLDATA_ONLY=true ./warm-storage-announce-upgrade.sh
 ```
 
 - [ ] In Safe Transaction Builder, set target to the printed FWSS proxy, value to `0`, and data to the printed calldata
-- [ ] Record Calibnet announce tx link in the Run Log
-- [ ] Update the GitHub pre-release Calibnet rollout status with the announce tx and `AFTER_EPOCH`
+- [ ] After the Safe transaction executes, verify and read back the pending plan:
+
+```bash
+export ANNOUNCE_TX_HASH="0x..." # Safe execution transaction hash
+
+CURRENT_VIEW=$(cast call --rpc-url "$ETH_RPC_URL" \
+  "$FWSS_PROXY_ADDRESS" \
+  'viewContractAddress()(address)')
+
+UPGRADE_PLAN=($(cast call --rpc-url "$ETH_RPC_URL" \
+  "$CURRENT_VIEW" \
+  'nextUpgrade()(address,uint96)'))
+
+OBSERVED_IMPL=${UPGRADE_PLAN[0]}
+OBSERVED_AFTER_EPOCH=${UPGRADE_PLAN[1]}
+echo "Planned implementation: $OBSERVED_IMPL (expected $CALI_NEW_IMPL)"
+echo "Actual afterEpoch: $OBSERVED_AFTER_EPOCH"
+
+if [ "${ANNOUNCEMENT_MODE:-delay}" = "legacy" ]; then
+  EXPECTED_AFTER_EPOCH=$AFTER_EPOCH
+else
+  ANNOUNCE_EPOCH=$(cast receipt --rpc-url "$ETH_RPC_URL" "$ANNOUNCE_TX_HASH" blockNumber)
+  EFFECTIVE_DELAY_EPOCHS=$UPGRADE_DELAY_EPOCHS
+  [ "$EFFECTIVE_DELAY_EPOCHS" -eq 0 ] && EFFECTIVE_DELAY_EPOCHS=1
+  EXPECTED_AFTER_EPOCH=$((ANNOUNCE_EPOCH + EFFECTIVE_DELAY_EPOCHS))
+fi
+
+if [ "$(printf '%s' "$OBSERVED_IMPL" | tr '[:upper:]' '[:lower:]')" != "$(printf '%s' "$CALI_NEW_IMPL" | tr '[:upper:]' '[:lower:]')" ]; then
+  echo "ERROR: announced implementation mismatch"
+  exit 1
+fi
+if [ "$OBSERVED_AFTER_EPOCH" -ne "$EXPECTED_AFTER_EPOCH" ]; then
+  echo "ERROR: afterEpoch mismatch ($OBSERVED_AFTER_EPOCH != $EXPECTED_AFTER_EPOCH)"
+  exit 1
+fi
+```
+
+- [ ] Record the Calibnet announce tx and observed `afterEpoch` in the schedule and Run Log
+- [ ] Update the GitHub pre-release Calibnet rollout status with the announce tx and observed `afterEpoch`
 
 **Execute**
-- [ ] Wait for `AFTER_EPOCH`
+- [ ] Wait for the observed Calibnet `afterEpoch`
 - [ ] Generate execute calldata and submit/sign/execute in Safe UI:
 
 ```bash
@@ -474,15 +543,7 @@ The unique `smoke_run` metadata is required so this validates new Data Set creat
 - [ ] Technical owner records Mainnet go/no-go after reviewing Calibnet evidence, rollback status, dependency targets, and cross-repo status
 - [ ] Confirm required cross-repo changes are merged/released or explicitly waived by the technical owner
 - [ ] Notify stakeholders before announcing Mainnet, including FilB so they can propagate the upgrade notice
-- [ ] Compute Mainnet `AFTER_EPOCH` and update the schedule table
-
-```bash
-export ETH_RPC_URL="https://api.node.glif.io/rpc/v1"
-export UPGRADE_WAIT_DURATION_EPOCHS=2880 # use 20160 for breaking changes
-CURRENT_EPOCH=$(cast block-number --rpc-url "$ETH_RPC_URL")
-AFTER_EPOCH=$((CURRENT_EPOCH + UPGRADE_WAIT_DURATION_EPOCHS))
-echo "$CURRENT_EPOCH -> $AFTER_EPOCH"
-```
+- [ ] Set the Mainnet requested delay and update the schedule table. **v1.3.1 bootstrap only:** record the announcement mode as `legacy`; upgrades from v1.3.1 onward always use `delay`.
 
 - [ ] Generate announce calldata and submit/sign/execute in Safe UI:
 
@@ -491,17 +552,75 @@ cd service_contracts/tools
 export ETH_RPC_URL="https://api.node.glif.io/rpc/v1"
 export FWSS_PROXY_ADDRESS="0x8408502033C418E1bbC97cE9ac48E5528F371A9f"
 export NEW_FWSS_IMPLEMENTATION_ADDRESS="$MAIN_NEW_IMPL"
-export AFTER_EPOCH="$AFTER_EPOCH"
+```
 
+For the normal delay-based flow:
+
+```bash
+export UPGRADE_DELAY_EPOCHS=2880 # use 20160 for breaking changes
+unset ANNOUNCEMENT_MODE AFTER_EPOCH
+```
+
+For the v1.3.0 -> v1.3.1 bootstrap rollout only, use this configuration instead:
+
+```bash
+export ANNOUNCEMENT_MODE=legacy
+export LEGACY_NOTICE_EPOCHS=2880
+export SAFE_SIGNING_BUFFER_EPOCHS=2880
+CURRENT_EPOCH=$(cast block-number --rpc-url "$ETH_RPC_URL")
+export AFTER_EPOCH=$((CURRENT_EPOCH + SAFE_SIGNING_BUFFER_EPOCHS + LEGACY_NOTICE_EPOCHS))
+unset UPGRADE_DELAY_EPOCHS
+```
+
+Generate the transaction after selecting exactly one configuration above:
+
+```bash
 CALLDATA_ONLY=true ./warm-storage-announce-upgrade.sh
 ```
 
 - [ ] In Safe Transaction Builder, set target to the printed FWSS proxy, value to `0`, and data to the printed calldata
-- [ ] Record Mainnet announce tx link in the Run Log
-- [ ] Update the GitHub pre-release Mainnet rollout status with the announce tx and `AFTER_EPOCH`
+- [ ] After the Safe transaction executes, verify and read back the pending plan:
+
+```bash
+export ANNOUNCE_TX_HASH="0x..." # Safe execution transaction hash
+
+CURRENT_VIEW=$(cast call --rpc-url "$ETH_RPC_URL" \
+  "$FWSS_PROXY_ADDRESS" \
+  'viewContractAddress()(address)')
+
+UPGRADE_PLAN=($(cast call --rpc-url "$ETH_RPC_URL" \
+  "$CURRENT_VIEW" \
+  'nextUpgrade()(address,uint96)'))
+
+OBSERVED_IMPL=${UPGRADE_PLAN[0]}
+OBSERVED_AFTER_EPOCH=${UPGRADE_PLAN[1]}
+echo "Planned implementation: $OBSERVED_IMPL (expected $MAIN_NEW_IMPL)"
+echo "Actual afterEpoch: $OBSERVED_AFTER_EPOCH"
+
+if [ "${ANNOUNCEMENT_MODE:-delay}" = "legacy" ]; then
+  EXPECTED_AFTER_EPOCH=$AFTER_EPOCH
+else
+  ANNOUNCE_EPOCH=$(cast receipt --rpc-url "$ETH_RPC_URL" "$ANNOUNCE_TX_HASH" blockNumber)
+  EFFECTIVE_DELAY_EPOCHS=$UPGRADE_DELAY_EPOCHS
+  [ "$EFFECTIVE_DELAY_EPOCHS" -eq 0 ] && EFFECTIVE_DELAY_EPOCHS=1
+  EXPECTED_AFTER_EPOCH=$((ANNOUNCE_EPOCH + EFFECTIVE_DELAY_EPOCHS))
+fi
+
+if [ "$(printf '%s' "$OBSERVED_IMPL" | tr '[:upper:]' '[:lower:]')" != "$(printf '%s' "$MAIN_NEW_IMPL" | tr '[:upper:]' '[:lower:]')" ]; then
+  echo "ERROR: announced implementation mismatch"
+  exit 1
+fi
+if [ "$OBSERVED_AFTER_EPOCH" -ne "$EXPECTED_AFTER_EPOCH" ]; then
+  echo "ERROR: afterEpoch mismatch ($OBSERVED_AFTER_EPOCH != $EXPECTED_AFTER_EPOCH)"
+  exit 1
+fi
+```
+
+- [ ] Record the Mainnet announce tx and observed `afterEpoch` in the schedule and Run Log
+- [ ] Update the GitHub pre-release Mainnet rollout status with the announce tx and observed `afterEpoch`
 
 **Execute**
-- [ ] Wait for `AFTER_EPOCH`
+- [ ] Wait for the observed Mainnet `afterEpoch`
 - [ ] Generate execute calldata and submit/sign/execute in Safe UI:
 
 ```bash
@@ -585,6 +704,7 @@ The unique `smoke_run` metadata is required so this validates new Data Set creat
 
 ### Phase 5: Promote Release and Close Out
 - [ ] Confirm live Calibnet and Mainnet FWSS implementation slots match the new implementation addresses
+- [ ] After FWSS v1.3.1 is live on Calibnet and Mainnet, treat `ANNOUNCEMENT_MODE=legacy` as deprecated and decide whether rollback to v1.3.0 is still supported. Once that rollback path is retired, open and merge a follow-up PR that removes the legacy mode, its `AFTER_EPOCH` handling, the temporary announcement-mode schedule column and bootstrap clauses, the README bootstrap example, and the Temporary Bootstrap Compatibility instructions; record the cleanup PR link. If v1.3.0 rollback remains supported, retain legacy mode or document the exact v1.3.1-tagged helper that operators must use.
 - [ ] Confirm cross-repo follow-ups are complete or tracked with owners
 - [ ] Open or update follow-up PR(s) to `main` for `service_contracts/deployments.json` after the relevant Calibnet/Mainnet proxy switches and, if applicable, View switches are live. Include live implementation addresses, View addresses, deployment bytecode metadata, and `pdp_version` / `fwss_version` fields for each updated network.
 - [ ] Record the `service_contracts/deployments.json` PR link(s) in Release Tracking, then merge after checksum validation, bytecode metadata verification, and live-slot verification

--- a/service_contracts/tools/UPGRADE-CHECKLIST.md
+++ b/service_contracts/tools/UPGRADE-CHECKLIST.md
@@ -708,7 +708,7 @@ The unique `smoke_run` metadata is required so this validates new Data Set creat
 
 ### Phase 5: Promote Release and Close Out
 - [ ] Confirm live Calibnet and Mainnet FWSS implementation slots match the new implementation addresses
-- [ ] After FWSS v1.3.1 is live on Calibnet and Mainnet, treat `ANNOUNCEMENT_MODE=legacy` as deprecated and decide whether rollback to v1.3.0 is still supported. Once that rollback path is retired, open and merge a follow-up PR that removes the legacy mode, its `AFTER_EPOCH` handling, the temporary announcement-mode schedule column and bootstrap clauses, the README bootstrap example, and the Temporary Bootstrap Compatibility instructions; record the cleanup PR link. If v1.3.0 rollback remains supported, retain legacy mode or document the exact v1.3.1-tagged helper that operators must use.
+- [ ] Complete the post-v1.3.1 FWSS legacy-path cleanup tracked in [#554](https://github.com/FilOzone/filecoin-services/issues/554).
 - [ ] Confirm cross-repo follow-ups are complete or tracked with owners
 - [ ] Open or update follow-up PR(s) to `main` for `service_contracts/deployments.json` after the relevant Calibnet/Mainnet proxy switches and, if applicable, View switches are live. Include live implementation addresses, View addresses, deployment bytecode metadata, and `pdp_version` / `fwss_version` fields for each updated network.
 - [ ] Record the `service_contracts/deployments.json` PR link(s) in Release Tracking, then merge after checksum validation, bytecode metadata verification, and live-slot verification

--- a/service_contracts/tools/UPGRADE-CHECKLIST.md
+++ b/service_contracts/tools/UPGRADE-CHECKLIST.md
@@ -148,11 +148,6 @@ Record validation that proves the planned upgrade works against the full contrac
 
 | Upgrade Type | Minimum Notice | Recommended |
 |---|---:|---|
-| Routine | `2880` epochs (~24h) | 1-2 days |
-| Breaking change | `20160` epochs (~1 week) | 1-2 weeks |
-
-| Upgrade Type | Minimum Notice | Recommended |
-|---|---:|---|
 | Calibration | `240` epochs (~2h) | ~1 day |
 | Mainnet Routine | `2880` epochs (~24h) | 1-2 days |
 | Mainnet Breaking change | `20160` epochs (~1 week) | 1-2 weeks |

--- a/service_contracts/tools/warm-storage-announce-upgrade.sh
+++ b/service_contracts/tools/warm-storage-announce-upgrade.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 
+set -o pipefail
+
 # warm-storage-announce-upgrade.sh: Announces a planned FWSS upgrade
-# Required args: ETH_RPC_URL, FWSS_PROXY_ADDRESS, NEW_FWSS_IMPLEMENTATION_ADDRESS, AFTER_EPOCH
+# Required args: ETH_RPC_URL, FWSS_PROXY_ADDRESS, NEW_FWSS_IMPLEMENTATION_ADDRESS
+# Required in the default delay mode: UPGRADE_DELAY_EPOCHS
+# Required for the v1.3.0 -> v1.3.1 bootstrap: ANNOUNCEMENT_MODE=legacy, AFTER_EPOCH
 # Required for direct send (not CALLDATA_ONLY): ETH_KEYSTORE, PASSWORD
-# Optional: CALLDATA_ONLY=true to generate calldata for Safe multisig instead of sending
+# Optional: CALLDATA_ONLY=true to generate calldata for Safe multisig instead of sending;
+#           ANNOUNCEMENT_MODE=delay|legacy (default: delay)
 
 # Get script directory and source deployments.sh
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
@@ -11,6 +16,15 @@ source "$SCRIPT_DIR/deployments.sh"
 source "$SCRIPT_DIR/multisig.sh"
 
 CALLDATA_ONLY="${CALLDATA_ONLY:-false}"
+ANNOUNCEMENT_MODE="${ANNOUNCEMENT_MODE:-delay}"
+
+case "$CALLDATA_ONLY" in
+  true | false) ;;
+  *)
+    echo "Error: CALLDATA_ONLY must be 'true' or 'false'"
+    exit 1
+    ;;
+esac
 
 if [ -z "$ETH_RPC_URL" ]; then
   echo "Error: ETH_RPC_URL is not set"
@@ -30,7 +44,7 @@ if [ "$CALLDATA_ONLY" != "true" ]; then
 fi
 
 if [ -z "$CHAIN" ]; then
-  CHAIN=$(cast chain-id)
+  CHAIN=$(cast chain-id --rpc-url "$ETH_RPC_URL")
   if [ -z "$CHAIN" ]; then
     echo "Error: Failed to detect chain ID from RPC"
     exit 1
@@ -42,28 +56,103 @@ if [ -z "$NEW_FWSS_IMPLEMENTATION_ADDRESS" ]; then
   exit 1
 fi
 
-if [ -z "$AFTER_EPOCH" ]; then
-  echo "AFTER_EPOCH is not set"
-  exit 1
-fi
-
-CURRENT_EPOCH=$(cast block-number 2>/dev/null)
-
-if [ "$CURRENT_EPOCH" -gt "$AFTER_EPOCH" ]; then
-  echo "Already past AFTER_EPOCH ($CURRENT_EPOCH > $AFTER_EPOCH)"
-  exit 1
-else
-  echo "Announcing planned upgrade after $(($AFTER_EPOCH - $CURRENT_EPOCH)) epochs"
-fi
-
 if [ -z "$FWSS_PROXY_ADDRESS" ]; then
   echo "Error: FWSS_PROXY_ADDRESS is not set"
   exit 1
 fi
 
+is_non_negative_integer() {
+  [[ "$1" =~ ^(0|[1-9][0-9]*)$ ]]
+}
+
+CALL_SIGNATURE=""
+CALL_ARGS=()
+
+case "$ANNOUNCEMENT_MODE" in
+  delay)
+    if [ -z "$UPGRADE_DELAY_EPOCHS" ]; then
+      echo "Error: UPGRADE_DELAY_EPOCHS is not set"
+      exit 1
+    fi
+    if ! is_non_negative_integer "$UPGRADE_DELAY_EPOCHS"; then
+      echo "Error: UPGRADE_DELAY_EPOCHS must be a non-negative base-10 integer without leading zeros"
+      exit 1
+    fi
+    if [ -n "$AFTER_EPOCH" ]; then
+      echo "Error: AFTER_EPOCH is only valid with ANNOUNCEMENT_MODE=legacy"
+      exit 1
+    fi
+
+    CALL_SIGNATURE="announceUpgradePlan(address,uint96)"
+    CALL_ARGS=("$NEW_FWSS_IMPLEMENTATION_ADDRESS" "$UPGRADE_DELAY_EPOCHS")
+    echo "Announcing upgrade with a requested delay of $UPGRADE_DELAY_EPOCHS epochs"
+    echo "Delay mode requires the deployed FWSS implementation to expose announceUpgradePlan"
+    if [ "$UPGRADE_DELAY_EPOCHS" = "0" ]; then
+      echo "The contract will enforce a minimum delay of one epoch"
+    fi
+    ;;
+  legacy)
+    # Bootstrap only: FWSS v1.3.0 predates announceUpgradePlan, so the v1.3.1
+    # rollout cannot use delay mode. Deprecate this branch after v1.3.1 is live on
+    # both networks; remove it once rollback to v1.3.0 is retired (checklist Phase 5).
+    if [ -z "$AFTER_EPOCH" ]; then
+      echo "Error: AFTER_EPOCH is not set for ANNOUNCEMENT_MODE=legacy"
+      exit 1
+    fi
+    if ! is_non_negative_integer "$AFTER_EPOCH"; then
+      echo "Error: AFTER_EPOCH must be a non-negative base-10 integer without leading zeros"
+      exit 1
+    fi
+    if [ -n "$UPGRADE_DELAY_EPOCHS" ]; then
+      echo "Error: UPGRADE_DELAY_EPOCHS is not valid with ANNOUNCEMENT_MODE=legacy"
+      exit 1
+    fi
+
+    CURRENT_EPOCH=$(cast block-number --rpc-url "$ETH_RPC_URL" 2>/dev/null)
+    if ! is_non_negative_integer "$CURRENT_EPOCH"; then
+      echo "Error: Failed to read the current epoch"
+      exit 1
+    fi
+    if [ "$CURRENT_EPOCH" -ge "$AFTER_EPOCH" ]; then
+      echo "Error: legacy AFTER_EPOCH must be in the future ($CURRENT_EPOCH >= $AFTER_EPOCH)"
+      exit 1
+    fi
+
+    CALL_SIGNATURE="announcePlannedUpgrade((address,uint96))"
+    CALL_ARGS=("($NEW_FWSS_IMPLEMENTATION_ADDRESS,$AFTER_EPOCH)")
+    echo "Using v1.3.0 bootstrap legacy mode; announcing upgrade after $((AFTER_EPOCH - CURRENT_EPOCH)) epochs"
+    echo "Ensure AFTER_EPOCH includes enough Safe-signing buffer; legacy calldata can expire before execution"
+    ;;
+  *)
+    echo "Error: ANNOUNCEMENT_MODE must be 'delay' or 'legacy'"
+    exit 1
+    ;;
+esac
+
+ZERO_ADDRESS="0x0000000000000000000000000000000000000000"
+if ! PROXY_OWNER=$(cast call --rpc-url "$ETH_RPC_URL" --from "$ZERO_ADDRESS" \
+  "$FWSS_PROXY_ADDRESS" "owner()(address)" 2>/dev/null); then
+  echo "Error: Failed to read the FWSS proxy owner"
+  exit 1
+fi
+
+# Simulate from the owner before producing calldata. This catches unsupported
+# announcement modes, invalid implementation addresses, and delay overflow.
+if ! cast call --rpc-url "$ETH_RPC_URL" --from "$PROXY_OWNER" \
+  "$FWSS_PROXY_ADDRESS" "$CALL_SIGNATURE" "${CALL_ARGS[@]}" >/dev/null; then
+  echo "Error: $CALL_SIGNATURE would revert against the current FWSS proxy"
+  if [ "$ANNOUNCEMENT_MODE" = "delay" ]; then
+    echo "For the FWSS v1.3.0 -> v1.3.1 bootstrap, rerun with ANNOUNCEMENT_MODE=legacy"
+  fi
+  exit 1
+fi
+
 if [ "$CALLDATA_ONLY" = "true" ]; then
-  CALLDATA=$(cast calldata "announcePlannedUpgrade((address,uint96))" "($NEW_FWSS_IMPLEMENTATION_ADDRESS,$AFTER_EPOCH)")
-  print_safe_transaction "$FWSS_PROXY_ADDRESS" "announcePlannedUpgrade((address,uint96))" "$CALLDATA"
+  if ! CALLDATA=$(cast calldata "$CALL_SIGNATURE" "${CALL_ARGS[@]}"); then
+    echo "Error: Failed to encode $CALL_SIGNATURE calldata"
+    exit 1
+  fi
+  print_safe_transaction "$FWSS_PROXY_ADDRESS" "$CALL_SIGNATURE" "$CALLDATA"
   exit 0
 fi
 
@@ -73,20 +162,17 @@ echo "Sending announcement from owner address: $ADDR"
 # Get current nonce
 NONCE=$(cast nonce "$ADDR")
 
-PROXY_OWNER=$(cast call -f 0x0000000000000000000000000000000000000000 "$FWSS_PROXY_ADDRESS" "owner()(address)" 2>/dev/null)
 if [ "$PROXY_OWNER" != "$ADDR" ]; then
   echo "Supplied ETH_KEYSTORE ($ADDR) is not the proxy owner ($PROXY_OWNER)."
   exit 1
 fi
 
-TX_HASH=$(cast send "$FWSS_PROXY_ADDRESS" "announcePlannedUpgrade((address,uint96))" "($NEW_FWSS_IMPLEMENTATION_ADDRESS,$AFTER_EPOCH)" \
+if ! TX_HASH=$(cast send "$FWSS_PROXY_ADDRESS" "$CALL_SIGNATURE" "${CALL_ARGS[@]}" \
   --password "$PASSWORD" \
   --nonce "$NONCE" \
-  --json | jq -r '.transactionHash')
-
-if [ -z "$TX_HASH" ]; then
-  echo "Error: Failed to send announcePlannedUpgrade transaction"
+  --json | jq -er '.transactionHash | select(type == "string" and length > 0)'); then
+  echo "Error: Failed to send $CALL_SIGNATURE transaction"
   exit 1
 fi
 
-echo "announcePlannedUpgrade transaction sent: $TX_HASH"
+echo "$CALL_SIGNATURE transaction sent: $TX_HASH"

--- a/service_contracts/tools/warm-storage-announce-upgrade.sh
+++ b/service_contracts/tools/warm-storage-announce-upgrade.sh
@@ -8,7 +8,7 @@ set -o pipefail
 # Required for the v1.3.0 -> v1.3.1 bootstrap: ANNOUNCEMENT_MODE=legacy, AFTER_EPOCH
 # Required for direct send (not CALLDATA_ONLY): ETH_KEYSTORE, PASSWORD
 # Optional: CALLDATA_ONLY=true to generate calldata for Safe multisig instead of sending;
-#           ANNOUNCEMENT_MODE=delay|legacy (default: delay)
+#           ANNOUNCEMENT_MODE=delay|legacy (default: legacy)
 
 # Get script directory and source deployments.sh
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
@@ -16,7 +16,7 @@ source "$SCRIPT_DIR/deployments.sh"
 source "$SCRIPT_DIR/multisig.sh"
 
 CALLDATA_ONLY="${CALLDATA_ONLY:-false}"
-ANNOUNCEMENT_MODE="${ANNOUNCEMENT_MODE:-delay}"
+ANNOUNCEMENT_MODE="${ANNOUNCEMENT_MODE:-legacy}"
 
 case "$CALLDATA_ONLY" in
   true | false) ;;


### PR DESCRIPTION

Supercedes #533 (no minimum delay)
Toward #505
Reviewer @ZenGround0
CC @rjan90
#### Changes
* do not revert if upgrade plan has low block number
* deprecate previous method specifying block number in favor of new method specifying delay
* test both methods using (bool) param