### PR TITLE
fix: align FWSS upgrade tooling with delay plans

### DIFF
--- a/service_contracts/abi/FilecoinWarmStorageService.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageService.abi.json
@@ -106,6 +106,24 @@
   },
   {
     "type": "function",
+    "name": "announceUpgradePlan",
+    "inputs": [
+      {
+        "name": "nextImplementation",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "delay",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "configureProvingPeriod",
     "inputs": [
       {

--- a/service_contracts/tools/README.md
+++ b/service_contracts/tools/README.md
@@ -265,7 +265,7 @@ CALLDATA_ONLY=true ./warm-storage-announce-upgrade.sh
 
 This prints a formatted transaction block with the target address, function signature, and calldata to paste into the Safe UI transaction builder.
 
-The first rollout that installs `announceUpgradePlan()` must use the old interface exposed by the currently deployed proxy:
+The FWSS v1.3.0 contracts currently deployed on Calibnet and Mainnet do not expose `announceUpgradePlan()`. Their upgrade to v1.3.1 must therefore use the old interface:
 
 ```bash
 export ANNOUNCEMENT_MODE=legacy
@@ -277,7 +277,7 @@ unset UPGRADE_DELAY_EPOCHS
 CALLDATA_ONLY=true ./warm-storage-announce-upgrade.sh
 ```
 
-This bootstrap-only mode is tracked for removal in the upgrade checklist after both Calibnet and Mainnet run the delay-aware implementation and any rollback path that still needs the old selector is retired.
+Treat this bootstrap-only mode as deprecated after FWSS v1.3.1 is live on both Calibnet and Mainnet. Remove it once rollback to v1.3.0 is no longer supported; until then it remains available only for that rollback path.
 
 ## Testing
 

--- a/service_contracts/tools/README.md
+++ b/service_contracts/tools/README.md
@@ -75,7 +75,7 @@ The `check-gen` CI job ([`.github/workflows/check.yml`](../../.github/workflows/
 
 # Upgrade existing deployment (see UPGRADE-CHECKLIST.md for the full runbook)
 ./tools/warm-storage-announce-upgrade.sh    # Step 1: Announce
-./tools/warm-storage-execute-upgrade.sh     # Step 2: Execute (after AFTER_EPOCH)
+./tools/warm-storage-execute-upgrade.sh     # Step 2: Execute (after the observed afterEpoch)
 ```
 
 ## Deployment Parameters
@@ -200,12 +200,13 @@ See [UPGRADE-CHECKLIST.md](./UPGRADE-CHECKLIST.md) for the complete two-step FWS
 
 ## Contract Upgrade Process
 
-The FilecoinWarmStorageService and ServiceProviderRegistry contracts use a **two-step upgrade process** for security:
+The FilecoinWarmStorageService and ServiceProviderRegistry contracts use a **two-step upgrade process** for security. The normal FWSS flow is:
 
-1. **Announce**: Call `announcePlannedUpgrade()` with the new implementation address and a future epoch
-2. **Execute**: After the announced epoch, call `upgradeToAndCall()` to complete the upgrade
+1. **Announce**: Call `announceUpgradePlan()` with the new implementation address and a relative delay
+2. **Observe**: Read `nextUpgrade()` after the announcement lands and record its exact `afterEpoch`
+3. **Execute**: After the observed epoch, call `upgradeToAndCall()` to complete the upgrade
 
-This gives stakeholders time to review changes before execution.
+The delay is measured from the block in which the announcement executes, so Safe signing time does not consume the requested notice window. ServiceProviderRegistry continues to use `announcePlannedUpgrade()` with an absolute epoch.
 
 **For complete FWSS upgrade documentation**, including:
 - Step-by-step upgrade workflows
@@ -257,11 +258,26 @@ The following scripts support `CALLDATA_ONLY=true`:
 export ETH_RPC_URL="https://api.node.glif.io/rpc/v1"
 export FWSS_PROXY_ADDRESS="0x8408502033C418E1bbC97cE9ac48E5528F371A9f"
 export NEW_FWSS_IMPLEMENTATION_ADDRESS="0x..."
-export AFTER_EPOCH="123456"
+export UPGRADE_DELAY_EPOCHS="2880"
+unset ANNOUNCEMENT_MODE AFTER_EPOCH
 CALLDATA_ONLY=true ./warm-storage-announce-upgrade.sh
 ```
 
 This prints a formatted transaction block with the target address, function signature, and calldata to paste into the Safe UI transaction builder.
+
+The first rollout that installs `announceUpgradePlan()` must use the old interface exposed by the currently deployed proxy:
+
+```bash
+export ANNOUNCEMENT_MODE=legacy
+export LEGACY_NOTICE_EPOCHS=2880
+export SAFE_SIGNING_BUFFER_EPOCHS=2880
+CURRENT_EPOCH=$(cast block-number --rpc-url "$ETH_RPC_URL")
+export AFTER_EPOCH=$((CURRENT_EPOCH + SAFE_SIGNING_BUFFER_EPOCHS + LEGACY_NOTICE_EPOCHS))
+unset UPGRADE_DELAY_EPOCHS
+CALLDATA_ONLY=true ./warm-storage-announce-upgrade.sh
+```
+
+This bootstrap-only mode is tracked for removal in the upgrade checklist after both Calibnet and Mainnet run the delay-aware implementation and any rollback path that still needs the old selector is retired.
 
 ## Testing
 

--- a/service_contracts/tools/UPGRADE-CHECKLIST.md
+++ b/service_contracts/tools/UPGRADE-CHECKLIST.md
@@ -49,12 +49,14 @@ Field ownership for duplicated rollout data:
 
 ### Upgrade Schedule
 
-| Network | Announcement mode | Requested delay | Actual `AFTER_EPOCH` | Status |
+| Network | Announcement mode (v1.3.1 bootstrap only) | Requested delay | Actual `AFTER_EPOCH` | Status |
 |---|---|---:|---:|---|
 | Calibnet | `TBD` | `TBD` | `TBD` | Pending |
 | Mainnet | `TBD` | `TBD` | `TBD` | Pending |
 
-Choose the announcement mode and requested delay before proposing the Safe transaction. In delay mode, fill in the actual `AFTER_EPOCH` from `nextUpgrade()` after the announcement executes. In bootstrap legacy mode, record the absolute target before Safe signing, include the notice duration and signing buffer in the requested-delay cell, and verify the same target on-chain after execution. The observed value is the source of truth for the execute step and external communications.
+Set the requested delay before proposing the Safe transaction. For the normal delay-based flow, fill in the actual `AFTER_EPOCH` from `nextUpgrade()` after the announcement executes. The observed value is the source of truth for the execute step and external communications.
+
+> **v1.3.1 bootstrap only:** The announcement-mode column is temporary. Record `legacy` for the v1.3.0 -> v1.3.1 rollout; upgrades from v1.3.1 onward use `delay`. Record the absolute target before Safe signing, include the notice duration and signing buffer in the requested-delay cell, and verify the same target on-chain after execution.
 
 ### Run Log
 
@@ -374,7 +376,7 @@ In Safe Transaction Builder, set target to the printed FWSS proxy, value to `0`,
 ### Phase 3: Calibnet Announce + Execute
 
 **Announce**
-- [ ] Choose the Calibnet announcement mode and requested delay, then update those fields in the schedule table
+- [ ] Set the Calibnet requested delay and update the schedule table. **v1.3.1 bootstrap only:** record the announcement mode as `legacy`; upgrades from v1.3.1 onward always use `delay`.
 
 - [ ] Generate announce calldata and submit/sign/execute in Safe UI:
 
@@ -541,7 +543,7 @@ The unique `smoke_run` metadata is required so this validates new Data Set creat
 - [ ] Technical owner records Mainnet go/no-go after reviewing Calibnet evidence, rollback status, dependency targets, and cross-repo status
 - [ ] Confirm required cross-repo changes are merged/released or explicitly waived by the technical owner
 - [ ] Notify stakeholders before announcing Mainnet, including FilB so they can propagate the upgrade notice
-- [ ] Choose the Mainnet announcement mode and requested delay, then update those fields in the schedule table
+- [ ] Set the Mainnet requested delay and update the schedule table. **v1.3.1 bootstrap only:** record the announcement mode as `legacy`; upgrades from v1.3.1 onward always use `delay`.
 
 - [ ] Generate announce calldata and submit/sign/execute in Safe UI:
 
@@ -702,7 +704,7 @@ The unique `smoke_run` metadata is required so this validates new Data Set creat
 
 ### Phase 5: Promote Release and Close Out
 - [ ] Confirm live Calibnet and Mainnet FWSS implementation slots match the new implementation addresses
-- [ ] After FWSS v1.3.1 is live on Calibnet and Mainnet, treat `ANNOUNCEMENT_MODE=legacy` as deprecated and decide whether rollback to v1.3.0 is still supported. Once that rollback path is retired, open and merge a follow-up PR that removes the legacy mode, its `AFTER_EPOCH` handling, the README bootstrap example, and the Temporary Bootstrap Compatibility instructions; record the cleanup PR link. If v1.3.0 rollback remains supported, retain legacy mode or document the exact v1.3.1-tagged helper that operators must use.
+- [ ] After FWSS v1.3.1 is live on Calibnet and Mainnet, treat `ANNOUNCEMENT_MODE=legacy` as deprecated and decide whether rollback to v1.3.0 is still supported. Once that rollback path is retired, open and merge a follow-up PR that removes the legacy mode, its `AFTER_EPOCH` handling, the temporary announcement-mode schedule column and bootstrap clauses, the README bootstrap example, and the Temporary Bootstrap Compatibility instructions; record the cleanup PR link. If v1.3.0 rollback remains supported, retain legacy mode or document the exact v1.3.1-tagged helper that operators must use.
 - [ ] Confirm cross-repo follow-ups are complete or tracked with owners
 - [ ] Open or update follow-up PR(s) to `main` for `service_contracts/deployments.json` after the relevant Calibnet/Mainnet proxy switches and, if applicable, View switches are live. Include live implementation addresses, View addresses, deployment bytecode metadata, and `pdp_version` / `fwss_version` fields for each updated network.
 - [ ] Record the `service_contracts/deployments.json` PR link(s) in Release Tracking, then merge after checksum validation, bytecode metadata verification, and live-slot verification

--- a/service_contracts/tools/UPGRADE-CHECKLIST.md
+++ b/service_contracts/tools/UPGRADE-CHECKLIST.md
@@ -158,7 +158,7 @@ echo "Requested upgrade delay: $UPGRADE_DELAY_EPOCHS epochs"
 
 ### Temporary Bootstrap Compatibility
 
-The rollout that first installs `announceUpgradePlan(address,uint96)` must announce through the currently deployed `announcePlannedUpgrade((address,uint96))` interface. Use `ANNOUNCEMENT_MODE=legacy` with an absolute `AFTER_EPOCH` for both Calibnet and Mainnet during that rollout. Include a conservative Safe-signing buffer so the legacy proposal is still in the future when it executes.
+FWSS v1.3.0 is currently deployed on Calibnet and Mainnet and does not expose `announceUpgradePlan(address,uint96)`. The v1.3.0 -> v1.3.1 rollout must announce through `announcePlannedUpgrade((address,uint96))`. Use `ANNOUNCEMENT_MODE=legacy` with an absolute `AFTER_EPOCH` for both networks and include a conservative Safe-signing buffer so the proposal is still in the future when it executes.
 
 ```bash
 export ANNOUNCEMENT_MODE=legacy
@@ -170,7 +170,7 @@ unset UPGRADE_DELAY_EPOCHS
 echo "Legacy target epoch: $AFTER_EPOCH"
 ```
 
-This is a bootstrap exception, not a second long-term workflow. After both networks run an implementation that exposes `announceUpgradePlan`, use the Phase 5 cleanup item to decide whether any rollback path still needs legacy mode and remove it once that path is retired.
+This is a v1.3.1 bootstrap exception, not a second long-term workflow. Treat legacy mode as deprecated once v1.3.1 is live on both networks, then use the Phase 5 cleanup item to remove it when rollback to v1.3.0 is retired.
 
 ### Post-Upgrade Evidence Required
 
@@ -392,7 +392,7 @@ export UPGRADE_DELAY_EPOCHS=240 # use a longer window if desired
 unset ANNOUNCEMENT_MODE AFTER_EPOCH
 ```
 
-For the temporary bootstrap rollout only, use this configuration instead:
+For the v1.3.0 -> v1.3.1 bootstrap rollout only, use this configuration instead:
 
 ```bash
 export ANNOUNCEMENT_MODE=legacy
@@ -559,7 +559,7 @@ export UPGRADE_DELAY_EPOCHS=2880 # use 20160 for breaking changes
 unset ANNOUNCEMENT_MODE AFTER_EPOCH
 ```
 
-For the temporary bootstrap rollout only, use this configuration instead:
+For the v1.3.0 -> v1.3.1 bootstrap rollout only, use this configuration instead:
 
 ```bash
 export ANNOUNCEMENT_MODE=legacy
@@ -702,7 +702,7 @@ The unique `smoke_run` metadata is required so this validates new Data Set creat
 
 ### Phase 5: Promote Release and Close Out
 - [ ] Confirm live Calibnet and Mainnet FWSS implementation slots match the new implementation addresses
-- [ ] If this is the bootstrap rollout for `announceUpgradePlan`, decide whether rollback to an implementation without that selector is still supported. Once both networks are upgraded **and** that rollback path is retired, open and merge a follow-up PR that removes `ANNOUNCEMENT_MODE=legacy`, its `AFTER_EPOCH` handling, the README bootstrap example, and the Temporary Bootstrap Compatibility instructions; record the cleanup PR link. If rollback remains supported, retain legacy mode or document the exact tagged helper that operators must use. For later releases, mark this `N/A` with the versions observed on both networks.
+- [ ] After FWSS v1.3.1 is live on Calibnet and Mainnet, treat `ANNOUNCEMENT_MODE=legacy` as deprecated and decide whether rollback to v1.3.0 is still supported. Once that rollback path is retired, open and merge a follow-up PR that removes the legacy mode, its `AFTER_EPOCH` handling, the README bootstrap example, and the Temporary Bootstrap Compatibility instructions; record the cleanup PR link. If v1.3.0 rollback remains supported, retain legacy mode or document the exact v1.3.1-tagged helper that operators must use.
 - [ ] Confirm cross-repo follow-ups are complete or tracked with owners
 - [ ] Open or update follow-up PR(s) to `main` for `service_contracts/deployments.json` after the relevant Calibnet/Mainnet proxy switches and, if applicable, View switches are live. Include live implementation addresses, View addresses, deployment bytecode metadata, and `pdp_version` / `fwss_version` fields for each updated network.
 - [ ] Record the `service_contracts/deployments.json` PR link(s) in Release Tracking, then merge after checksum validation, bytecode metadata verification, and live-slot verification

--- a/service_contracts/tools/UPGRADE-CHECKLIST.md
+++ b/service_contracts/tools/UPGRADE-CHECKLIST.md
@@ -49,10 +49,12 @@ Field ownership for duplicated rollout data:
 
 ### Upgrade Schedule
 
-| Network | AFTER_EPOCH | Status |
-|---|---:|---|
-| Calibnet | `TBD` | Pending |
-| Mainnet | `TBD` | Pending |
+| Network | Announcement mode | Requested delay | Actual `AFTER_EPOCH` | Status |
+|---|---|---:|---:|---|
+| Calibnet | `TBD` | `TBD` | `TBD` | Pending |
+| Mainnet | `TBD` | `TBD` | `TBD` | Pending |
+
+Choose the announcement mode and requested delay before proposing the Safe transaction. In delay mode, fill in the actual `AFTER_EPOCH` from `nextUpgrade()` after the announcement executes. In bootstrap legacy mode, record the absolute target before Safe signing, include the notice duration and signing buffer in the requested-delay cell, and verify the same target on-chain after execution. The observed value is the source of truth for the execute step and external communications.
 
 ### Run Log
 
@@ -60,10 +62,10 @@ The Run Log is this release issue's operator journal for rollout facts discovere
 
 Keep this table current as values become known.
 
-| Network | New FWSS implementation | StateView / setView tx | Announce tx | Execute tx | Post-upgrade checks |
-|---|---|---|---|---|---|
-| Calibnet | `TBD` | `TBD` | `TBD` | `TBD` | Pending |
-| Mainnet | `TBD` | `TBD` | `TBD` | `TBD` | Pending |
+| Network | New FWSS implementation | StateView / setView tx | Announce tx | Actual `afterEpoch` | Execute tx | Post-upgrade checks |
+|---|---|---|---|---:|---|---|
+| Calibnet | `TBD` | `TBD` | `TBD` | `TBD` | `TBD` | Pending |
+| Mainnet | `TBD` | `TBD` | `TBD` | `TBD` | `TBD` | Pending |
 
 ### Scope
 - In scope: `FilecoinWarmStorageService` implementation upgrade behind the existing FWSS proxy.
@@ -137,7 +139,8 @@ Record validation that proves the planned upgrade works against the full contrac
 - Do not announce Mainnet until Calibnet execution, on-chain checks, explorer checks, smoke/E2E checks, and `filecoin-pin` Data Set creation validation are complete.
 - Do not announce Mainnet until required cross-repo changes are merged/released or explicitly waived by the technical owner.
 - `service_contracts/deployments.json` reflects what is live behind proxies and View contracts. Update it only after the relevant proxy switch and, if applicable, View switch are complete, normally through follow-up PR(s) to `main`, and record PR links in Release Tracking.
-- If an `AFTER_EPOCH` changes, submit a new `announcePlannedUpgrade()` transaction and record that it supersedes the previous announcement.
+- In the normal delay-based flow, the requested delay starts when the Safe announcement executes. After execution, verify both fields returned by `nextUpgrade()` and record its exact `afterEpoch` as the source of truth.
+- A later announcement replaces the pending plan. Record the replacement transaction and explicitly mark it as superseding the previous announcement.
 
 ### Notice Guidance
 
@@ -146,14 +149,28 @@ Record validation that proves the planned upgrade works against the full contrac
 | Routine | `2880` epochs (~24h) | 1-2 days |
 | Breaking change | `20160` epochs (~1 week) | 1-2 weeks |
 
-Calibnet can use a shorter window for rehearsal and validation, but use enough time for signers to coordinate.
+Calibnet can use a shorter window for rehearsal and validation, but use enough time for signers to coordinate. Select a positive operational delay; the contract's one-epoch floor is an emergency safety bound, not the routine notice policy.
 
 ```bash
-export UPGRADE_WAIT_DURATION_EPOCHS=2880 # use 240+ for Calibnet rehearsal, 20160 for breaking changes
-CURRENT_EPOCH=$(cast block-number --rpc-url "$ETH_RPC_URL")
-AFTER_EPOCH=$((CURRENT_EPOCH + UPGRADE_WAIT_DURATION_EPOCHS))
-echo "Current: $CURRENT_EPOCH, Upgrade after: $AFTER_EPOCH"
+export UPGRADE_DELAY_EPOCHS=2880 # use 240+ for Calibnet rehearsal, 20160 for breaking changes
+echo "Requested upgrade delay: $UPGRADE_DELAY_EPOCHS epochs"
 ```
+
+### Temporary Bootstrap Compatibility
+
+The rollout that first installs `announceUpgradePlan(address,uint96)` must announce through the currently deployed `announcePlannedUpgrade((address,uint96))` interface. Use `ANNOUNCEMENT_MODE=legacy` with an absolute `AFTER_EPOCH` for both Calibnet and Mainnet during that rollout. Include a conservative Safe-signing buffer so the legacy proposal is still in the future when it executes.
+
+```bash
+export ANNOUNCEMENT_MODE=legacy
+export LEGACY_NOTICE_EPOCHS=2880
+export SAFE_SIGNING_BUFFER_EPOCHS=240
+CURRENT_EPOCH=$(cast block-number --rpc-url "$ETH_RPC_URL")
+export AFTER_EPOCH=$((CURRENT_EPOCH + SAFE_SIGNING_BUFFER_EPOCHS + LEGACY_NOTICE_EPOCHS))
+unset UPGRADE_DELAY_EPOCHS
+echo "Legacy target epoch: $AFTER_EPOCH"
+```
+
+This is a bootstrap exception, not a second long-term workflow. After both networks run an implementation that exposes `announceUpgradePlan`, use the Phase 5 cleanup item to decide whether any rollback path still needs legacy mode and remove it once that path is retired.
 
 ### Post-Upgrade Evidence Required
 
@@ -228,10 +245,10 @@ cat > /tmp/fwss-release-notes.md <<'EOF'
 
 ## Rollout Status
 
-| Network | FWSS Proxy | FWSS Implementation | StateView | Announce tx | Execute tx | Status |
-|---|---|---|---|---|---|---|
-| Calibnet | `0x02925630df557F957f70E112bA06e50965417CA0` | `TBD` | `TBD` | `TBD` | `TBD` | Pending |
-| Mainnet | `0x8408502033C418E1bbC97cE9ac48E5528F371A9f` | `TBD` | `TBD` | `TBD` | `TBD` | Pending |
+| Network | FWSS Proxy | FWSS Implementation | StateView | Announce tx | Actual `afterEpoch` | Execute tx | Status |
+|---|---|---|---|---|---:|---|---|
+| Calibnet | `0x02925630df557F957f70E112bA06e50965417CA0` | `TBD` | `TBD` | `TBD` | `TBD` | `TBD` | Pending |
+| Mainnet | `0x8408502033C418E1bbC97cE9ac48E5528F371A9f` | `TBD` | `TBD` | `TBD` | `TBD` | `TBD` | Pending |
 
 ## Action Required For Integrators
 - TBD
@@ -357,15 +374,7 @@ In Safe Transaction Builder, set target to the printed FWSS proxy, value to `0`,
 ### Phase 3: Calibnet Announce + Execute
 
 **Announce**
-- [ ] Compute Calibnet `AFTER_EPOCH` and update the schedule table
-
-```bash
-export ETH_RPC_URL="https://api.calibration.node.glif.io/rpc/v1"
-export UPGRADE_WAIT_DURATION_EPOCHS=240 # use a longer window if desired
-CURRENT_EPOCH=$(cast block-number --rpc-url "$ETH_RPC_URL")
-AFTER_EPOCH=$((CURRENT_EPOCH + UPGRADE_WAIT_DURATION_EPOCHS))
-echo "$CURRENT_EPOCH -> $AFTER_EPOCH"
-```
+- [ ] Choose the Calibnet announcement mode and requested delay, then update those fields in the schedule table
 
 - [ ] Generate announce calldata and submit/sign/execute in Safe UI:
 
@@ -374,17 +383,75 @@ cd service_contracts/tools
 export ETH_RPC_URL="https://api.calibration.node.glif.io/rpc/v1"
 export FWSS_PROXY_ADDRESS="0x02925630df557F957f70E112bA06e50965417CA0"
 export NEW_FWSS_IMPLEMENTATION_ADDRESS="$CALI_NEW_IMPL"
-export AFTER_EPOCH="$AFTER_EPOCH"
+```
 
+For the normal delay-based flow:
+
+```bash
+export UPGRADE_DELAY_EPOCHS=240 # use a longer window if desired
+unset ANNOUNCEMENT_MODE AFTER_EPOCH
+```
+
+For the temporary bootstrap rollout only, use this configuration instead:
+
+```bash
+export ANNOUNCEMENT_MODE=legacy
+export LEGACY_NOTICE_EPOCHS=240
+export SAFE_SIGNING_BUFFER_EPOCHS=240
+CURRENT_EPOCH=$(cast block-number --rpc-url "$ETH_RPC_URL")
+export AFTER_EPOCH=$((CURRENT_EPOCH + SAFE_SIGNING_BUFFER_EPOCHS + LEGACY_NOTICE_EPOCHS))
+unset UPGRADE_DELAY_EPOCHS
+```
+
+Generate the transaction after selecting exactly one configuration above:
+
+```bash
 CALLDATA_ONLY=true ./warm-storage-announce-upgrade.sh
 ```
 
 - [ ] In Safe Transaction Builder, set target to the printed FWSS proxy, value to `0`, and data to the printed calldata
-- [ ] Record Calibnet announce tx link in the Run Log
-- [ ] Update the GitHub pre-release Calibnet rollout status with the announce tx and `AFTER_EPOCH`
+- [ ] After the Safe transaction executes, verify and read back the pending plan:
+
+```bash
+export ANNOUNCE_TX_HASH="0x..." # Safe execution transaction hash
+
+CURRENT_VIEW=$(cast call --rpc-url "$ETH_RPC_URL" \
+  "$FWSS_PROXY_ADDRESS" \
+  'viewContractAddress()(address)')
+
+UPGRADE_PLAN=($(cast call --rpc-url "$ETH_RPC_URL" \
+  "$CURRENT_VIEW" \
+  'nextUpgrade()(address,uint96)'))
+
+OBSERVED_IMPL=${UPGRADE_PLAN[0]}
+OBSERVED_AFTER_EPOCH=${UPGRADE_PLAN[1]}
+echo "Planned implementation: $OBSERVED_IMPL (expected $CALI_NEW_IMPL)"
+echo "Actual afterEpoch: $OBSERVED_AFTER_EPOCH"
+
+if [ "${ANNOUNCEMENT_MODE:-delay}" = "legacy" ]; then
+  EXPECTED_AFTER_EPOCH=$AFTER_EPOCH
+else
+  ANNOUNCE_EPOCH=$(cast receipt --rpc-url "$ETH_RPC_URL" "$ANNOUNCE_TX_HASH" blockNumber)
+  EFFECTIVE_DELAY_EPOCHS=$UPGRADE_DELAY_EPOCHS
+  [ "$EFFECTIVE_DELAY_EPOCHS" -eq 0 ] && EFFECTIVE_DELAY_EPOCHS=1
+  EXPECTED_AFTER_EPOCH=$((ANNOUNCE_EPOCH + EFFECTIVE_DELAY_EPOCHS))
+fi
+
+if [ "$(printf '%s' "$OBSERVED_IMPL" | tr '[:upper:]' '[:lower:]')" != "$(printf '%s' "$CALI_NEW_IMPL" | tr '[:upper:]' '[:lower:]')" ]; then
+  echo "ERROR: announced implementation mismatch"
+  exit 1
+fi
+if [ "$OBSERVED_AFTER_EPOCH" -ne "$EXPECTED_AFTER_EPOCH" ]; then
+  echo "ERROR: afterEpoch mismatch ($OBSERVED_AFTER_EPOCH != $EXPECTED_AFTER_EPOCH)"
+  exit 1
+fi
+```
+
+- [ ] Record the Calibnet announce tx and observed `afterEpoch` in the schedule and Run Log
+- [ ] Update the GitHub pre-release Calibnet rollout status with the announce tx and observed `afterEpoch`
 
 **Execute**
-- [ ] Wait for `AFTER_EPOCH`
+- [ ] Wait for the observed Calibnet `afterEpoch`
 - [ ] Generate execute calldata and submit/sign/execute in Safe UI:
 
 ```bash
@@ -474,15 +541,7 @@ The unique `smoke_run` metadata is required so this validates new Data Set creat
 - [ ] Technical owner records Mainnet go/no-go after reviewing Calibnet evidence, rollback status, dependency targets, and cross-repo status
 - [ ] Confirm required cross-repo changes are merged/released or explicitly waived by the technical owner
 - [ ] Notify stakeholders before announcing Mainnet, including FilB so they can propagate the upgrade notice
-- [ ] Compute Mainnet `AFTER_EPOCH` and update the schedule table
-
-```bash
-export ETH_RPC_URL="https://api.node.glif.io/rpc/v1"
-export UPGRADE_WAIT_DURATION_EPOCHS=2880 # use 20160 for breaking changes
-CURRENT_EPOCH=$(cast block-number --rpc-url "$ETH_RPC_URL")
-AFTER_EPOCH=$((CURRENT_EPOCH + UPGRADE_WAIT_DURATION_EPOCHS))
-echo "$CURRENT_EPOCH -> $AFTER_EPOCH"
-```
+- [ ] Choose the Mainnet announcement mode and requested delay, then update those fields in the schedule table
 
 - [ ] Generate announce calldata and submit/sign/execute in Safe UI:
 
@@ -491,17 +550,75 @@ cd service_contracts/tools
 export ETH_RPC_URL="https://api.node.glif.io/rpc/v1"
 export FWSS_PROXY_ADDRESS="0x8408502033C418E1bbC97cE9ac48E5528F371A9f"
 export NEW_FWSS_IMPLEMENTATION_ADDRESS="$MAIN_NEW_IMPL"
-export AFTER_EPOCH="$AFTER_EPOCH"
+```
 
+For the normal delay-based flow:
+
+```bash
+export UPGRADE_DELAY_EPOCHS=2880 # use 20160 for breaking changes
+unset ANNOUNCEMENT_MODE AFTER_EPOCH
+```
+
+For the temporary bootstrap rollout only, use this configuration instead:
+
+```bash
+export ANNOUNCEMENT_MODE=legacy
+export LEGACY_NOTICE_EPOCHS=2880
+export SAFE_SIGNING_BUFFER_EPOCHS=2880
+CURRENT_EPOCH=$(cast block-number --rpc-url "$ETH_RPC_URL")
+export AFTER_EPOCH=$((CURRENT_EPOCH + SAFE_SIGNING_BUFFER_EPOCHS + LEGACY_NOTICE_EPOCHS))
+unset UPGRADE_DELAY_EPOCHS
+```
+
+Generate the transaction after selecting exactly one configuration above:
+
+```bash
 CALLDATA_ONLY=true ./warm-storage-announce-upgrade.sh
 ```
 
 - [ ] In Safe Transaction Builder, set target to the printed FWSS proxy, value to `0`, and data to the printed calldata
-- [ ] Record Mainnet announce tx link in the Run Log
-- [ ] Update the GitHub pre-release Mainnet rollout status with the announce tx and `AFTER_EPOCH`
+- [ ] After the Safe transaction executes, verify and read back the pending plan:
+
+```bash
+export ANNOUNCE_TX_HASH="0x..." # Safe execution transaction hash
+
+CURRENT_VIEW=$(cast call --rpc-url "$ETH_RPC_URL" \
+  "$FWSS_PROXY_ADDRESS" \
+  'viewContractAddress()(address)')
+
+UPGRADE_PLAN=($(cast call --rpc-url "$ETH_RPC_URL" \
+  "$CURRENT_VIEW" \
+  'nextUpgrade()(address,uint96)'))
+
+OBSERVED_IMPL=${UPGRADE_PLAN[0]}
+OBSERVED_AFTER_EPOCH=${UPGRADE_PLAN[1]}
+echo "Planned implementation: $OBSERVED_IMPL (expected $MAIN_NEW_IMPL)"
+echo "Actual afterEpoch: $OBSERVED_AFTER_EPOCH"
+
+if [ "${ANNOUNCEMENT_MODE:-delay}" = "legacy" ]; then
+  EXPECTED_AFTER_EPOCH=$AFTER_EPOCH
+else
+  ANNOUNCE_EPOCH=$(cast receipt --rpc-url "$ETH_RPC_URL" "$ANNOUNCE_TX_HASH" blockNumber)
+  EFFECTIVE_DELAY_EPOCHS=$UPGRADE_DELAY_EPOCHS
+  [ "$EFFECTIVE_DELAY_EPOCHS" -eq 0 ] && EFFECTIVE_DELAY_EPOCHS=1
+  EXPECTED_AFTER_EPOCH=$((ANNOUNCE_EPOCH + EFFECTIVE_DELAY_EPOCHS))
+fi
+
+if [ "$(printf '%s' "$OBSERVED_IMPL" | tr '[:upper:]' '[:lower:]')" != "$(printf '%s' "$MAIN_NEW_IMPL" | tr '[:upper:]' '[:lower:]')" ]; then
+  echo "ERROR: announced implementation mismatch"
+  exit 1
+fi
+if [ "$OBSERVED_AFTER_EPOCH" -ne "$EXPECTED_AFTER_EPOCH" ]; then
+  echo "ERROR: afterEpoch mismatch ($OBSERVED_AFTER_EPOCH != $EXPECTED_AFTER_EPOCH)"
+  exit 1
+fi
+```
+
+- [ ] Record the Mainnet announce tx and observed `afterEpoch` in the schedule and Run Log
+- [ ] Update the GitHub pre-release Mainnet rollout status with the announce tx and observed `afterEpoch`
 
 **Execute**
-- [ ] Wait for `AFTER_EPOCH`
+- [ ] Wait for the observed Mainnet `afterEpoch`
 - [ ] Generate execute calldata and submit/sign/execute in Safe UI:
 
 ```bash
@@ -585,6 +702,7 @@ The unique `smoke_run` metadata is required so this validates new Data Set creat
 
 ### Phase 5: Promote Release and Close Out
 - [ ] Confirm live Calibnet and Mainnet FWSS implementation slots match the new implementation addresses
+- [ ] If this is the bootstrap rollout for `announceUpgradePlan`, decide whether rollback to an implementation without that selector is still supported. Once both networks are upgraded **and** that rollback path is retired, open and merge a follow-up PR that removes `ANNOUNCEMENT_MODE=legacy`, its `AFTER_EPOCH` handling, the README bootstrap example, and the Temporary Bootstrap Compatibility instructions; record the cleanup PR link. If rollback remains supported, retain legacy mode or document the exact tagged helper that operators must use. For later releases, mark this `N/A` with the versions observed on both networks.
 - [ ] Confirm cross-repo follow-ups are complete or tracked with owners
 - [ ] Open or update follow-up PR(s) to `main` for `service_contracts/deployments.json` after the relevant Calibnet/Mainnet proxy switches and, if applicable, View switches are live. Include live implementation addresses, View addresses, deployment bytecode metadata, and `pdp_version` / `fwss_version` fields for each updated network.
 - [ ] Record the `service_contracts/deployments.json` PR link(s) in Release Tracking, then merge after checksum validation, bytecode metadata verification, and live-slot verification

--- a/service_contracts/tools/warm-storage-announce-upgrade.sh
+++ b/service_contracts/tools/warm-storage-announce-upgrade.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 
+set -o pipefail
+
 # warm-storage-announce-upgrade.sh: Announces a planned FWSS upgrade
-# Required args: ETH_RPC_URL, FWSS_PROXY_ADDRESS, NEW_FWSS_IMPLEMENTATION_ADDRESS, AFTER_EPOCH
+# Required args: ETH_RPC_URL, FWSS_PROXY_ADDRESS, NEW_FWSS_IMPLEMENTATION_ADDRESS
+# Required in the default delay mode: UPGRADE_DELAY_EPOCHS
+# Required in bootstrap legacy mode: ANNOUNCEMENT_MODE=legacy, AFTER_EPOCH
 # Required for direct send (not CALLDATA_ONLY): ETH_KEYSTORE, PASSWORD
-# Optional: CALLDATA_ONLY=true to generate calldata for Safe multisig instead of sending
+# Optional: CALLDATA_ONLY=true to generate calldata for Safe multisig instead of sending;
+#           ANNOUNCEMENT_MODE=delay|legacy (default: delay)
 
 # Get script directory and source deployments.sh
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
@@ -11,6 +16,15 @@ source "$SCRIPT_DIR/deployments.sh"
 source "$SCRIPT_DIR/multisig.sh"
 
 CALLDATA_ONLY="${CALLDATA_ONLY:-false}"
+ANNOUNCEMENT_MODE="${ANNOUNCEMENT_MODE:-delay}"
+
+case "$CALLDATA_ONLY" in
+  true | false) ;;
+  *)
+    echo "Error: CALLDATA_ONLY must be 'true' or 'false'"
+    exit 1
+    ;;
+esac
 
 if [ -z "$ETH_RPC_URL" ]; then
   echo "Error: ETH_RPC_URL is not set"
@@ -30,7 +44,7 @@ if [ "$CALLDATA_ONLY" != "true" ]; then
 fi
 
 if [ -z "$CHAIN" ]; then
-  CHAIN=$(cast chain-id)
+  CHAIN=$(cast chain-id --rpc-url "$ETH_RPC_URL")
   if [ -z "$CHAIN" ]; then
     echo "Error: Failed to detect chain ID from RPC"
     exit 1
@@ -42,28 +56,103 @@ if [ -z "$NEW_FWSS_IMPLEMENTATION_ADDRESS" ]; then
   exit 1
 fi
 
-if [ -z "$AFTER_EPOCH" ]; then
-  echo "AFTER_EPOCH is not set"
-  exit 1
-fi
-
-CURRENT_EPOCH=$(cast block-number 2>/dev/null)
-
-if [ "$CURRENT_EPOCH" -gt "$AFTER_EPOCH" ]; then
-  echo "Already past AFTER_EPOCH ($CURRENT_EPOCH > $AFTER_EPOCH)"
-  exit 1
-else
-  echo "Announcing planned upgrade after $(($AFTER_EPOCH - $CURRENT_EPOCH)) epochs"
-fi
-
 if [ -z "$FWSS_PROXY_ADDRESS" ]; then
   echo "Error: FWSS_PROXY_ADDRESS is not set"
   exit 1
 fi
 
+is_non_negative_integer() {
+  [[ "$1" =~ ^(0|[1-9][0-9]*)$ ]]
+}
+
+CALL_SIGNATURE=""
+CALL_ARGS=()
+
+case "$ANNOUNCEMENT_MODE" in
+  delay)
+    if [ -z "$UPGRADE_DELAY_EPOCHS" ]; then
+      echo "Error: UPGRADE_DELAY_EPOCHS is not set"
+      exit 1
+    fi
+    if ! is_non_negative_integer "$UPGRADE_DELAY_EPOCHS"; then
+      echo "Error: UPGRADE_DELAY_EPOCHS must be a non-negative base-10 integer without leading zeros"
+      exit 1
+    fi
+    if [ -n "$AFTER_EPOCH" ]; then
+      echo "Error: AFTER_EPOCH is only valid with ANNOUNCEMENT_MODE=legacy"
+      exit 1
+    fi
+
+    CALL_SIGNATURE="announceUpgradePlan(address,uint96)"
+    CALL_ARGS=("$NEW_FWSS_IMPLEMENTATION_ADDRESS" "$UPGRADE_DELAY_EPOCHS")
+    echo "Announcing upgrade with a requested delay of $UPGRADE_DELAY_EPOCHS epochs"
+    echo "Delay mode requires the deployed FWSS implementation to expose announceUpgradePlan"
+    if [ "$UPGRADE_DELAY_EPOCHS" = "0" ]; then
+      echo "The contract will enforce a minimum delay of one epoch"
+    fi
+    ;;
+  legacy)
+    # Bootstrap only: the deployed FWSS version that predates announceUpgradePlan
+    # cannot use delay mode. Remove this branch after both networks are upgraded and
+    # rollback to a pre-selector implementation is retired (UPGRADE-CHECKLIST Phase 5).
+    if [ -z "$AFTER_EPOCH" ]; then
+      echo "Error: AFTER_EPOCH is not set for ANNOUNCEMENT_MODE=legacy"
+      exit 1
+    fi
+    if ! is_non_negative_integer "$AFTER_EPOCH"; then
+      echo "Error: AFTER_EPOCH must be a non-negative base-10 integer without leading zeros"
+      exit 1
+    fi
+    if [ -n "$UPGRADE_DELAY_EPOCHS" ]; then
+      echo "Error: UPGRADE_DELAY_EPOCHS is not valid with ANNOUNCEMENT_MODE=legacy"
+      exit 1
+    fi
+
+    CURRENT_EPOCH=$(cast block-number --rpc-url "$ETH_RPC_URL" 2>/dev/null)
+    if ! is_non_negative_integer "$CURRENT_EPOCH"; then
+      echo "Error: Failed to read the current epoch"
+      exit 1
+    fi
+    if [ "$CURRENT_EPOCH" -ge "$AFTER_EPOCH" ]; then
+      echo "Error: legacy AFTER_EPOCH must be in the future ($CURRENT_EPOCH >= $AFTER_EPOCH)"
+      exit 1
+    fi
+
+    CALL_SIGNATURE="announcePlannedUpgrade((address,uint96))"
+    CALL_ARGS=("($NEW_FWSS_IMPLEMENTATION_ADDRESS,$AFTER_EPOCH)")
+    echo "Using bootstrap legacy mode; announcing upgrade after $((AFTER_EPOCH - CURRENT_EPOCH)) epochs"
+    echo "Ensure AFTER_EPOCH includes enough Safe-signing buffer; legacy calldata can expire before execution"
+    ;;
+  *)
+    echo "Error: ANNOUNCEMENT_MODE must be 'delay' or 'legacy'"
+    exit 1
+    ;;
+esac
+
+ZERO_ADDRESS="0x0000000000000000000000000000000000000000"
+if ! PROXY_OWNER=$(cast call --rpc-url "$ETH_RPC_URL" --from "$ZERO_ADDRESS" \
+  "$FWSS_PROXY_ADDRESS" "owner()(address)" 2>/dev/null); then
+  echo "Error: Failed to read the FWSS proxy owner"
+  exit 1
+fi
+
+# Simulate from the owner before producing calldata. This catches unsupported
+# announcement modes, invalid implementation addresses, and delay overflow.
+if ! cast call --rpc-url "$ETH_RPC_URL" --from "$PROXY_OWNER" \
+  "$FWSS_PROXY_ADDRESS" "$CALL_SIGNATURE" "${CALL_ARGS[@]}" >/dev/null; then
+  echo "Error: $CALL_SIGNATURE would revert against the current FWSS proxy"
+  if [ "$ANNOUNCEMENT_MODE" = "delay" ]; then
+    echo "If this proxy predates announceUpgradePlan, rerun with ANNOUNCEMENT_MODE=legacy"
+  fi
+  exit 1
+fi
+
 if [ "$CALLDATA_ONLY" = "true" ]; then
-  CALLDATA=$(cast calldata "announcePlannedUpgrade((address,uint96))" "($NEW_FWSS_IMPLEMENTATION_ADDRESS,$AFTER_EPOCH)")
-  print_safe_transaction "$FWSS_PROXY_ADDRESS" "announcePlannedUpgrade((address,uint96))" "$CALLDATA"
+  if ! CALLDATA=$(cast calldata "$CALL_SIGNATURE" "${CALL_ARGS[@]}"); then
+    echo "Error: Failed to encode $CALL_SIGNATURE calldata"
+    exit 1
+  fi
+  print_safe_transaction "$FWSS_PROXY_ADDRESS" "$CALL_SIGNATURE" "$CALLDATA"
   exit 0
 fi
 
@@ -73,20 +162,17 @@ echo "Sending announcement from owner address: $ADDR"
 # Get current nonce
 NONCE=$(cast nonce "$ADDR")
 
-PROXY_OWNER=$(cast call -f 0x0000000000000000000000000000000000000000 "$FWSS_PROXY_ADDRESS" "owner()(address)" 2>/dev/null)
 if [ "$PROXY_OWNER" != "$ADDR" ]; then
   echo "Supplied ETH_KEYSTORE ($ADDR) is not the proxy owner ($PROXY_OWNER)."
   exit 1
 fi
 
-TX_HASH=$(cast send "$FWSS_PROXY_ADDRESS" "announcePlannedUpgrade((address,uint96))" "($NEW_FWSS_IMPLEMENTATION_ADDRESS,$AFTER_EPOCH)" \
+if ! TX_HASH=$(cast send "$FWSS_PROXY_ADDRESS" "$CALL_SIGNATURE" "${CALL_ARGS[@]}" \
   --password "$PASSWORD" \
   --nonce "$NONCE" \
-  --json | jq -r '.transactionHash')
-
-if [ -z "$TX_HASH" ]; then
-  echo "Error: Failed to send announcePlannedUpgrade transaction"
+  --json | jq -er '.transactionHash | select(type == "string" and length > 0)'); then
+  echo "Error: Failed to send $CALL_SIGNATURE transaction"
   exit 1
 fi
 
-echo "announcePlannedUpgrade transaction sent: $TX_HASH"
+echo "$CALL_SIGNATURE transaction sent: $TX_HASH"

--- a/service_contracts/tools/warm-storage-announce-upgrade.sh
+++ b/service_contracts/tools/warm-storage-announce-upgrade.sh
@@ -5,7 +5,7 @@ set -o pipefail
 # warm-storage-announce-upgrade.sh: Announces a planned FWSS upgrade
 # Required args: ETH_RPC_URL, FWSS_PROXY_ADDRESS, NEW_FWSS_IMPLEMENTATION_ADDRESS
 # Required in the default delay mode: UPGRADE_DELAY_EPOCHS
-# Required in bootstrap legacy mode: ANNOUNCEMENT_MODE=legacy, AFTER_EPOCH
+# Required for the v1.3.0 -> v1.3.1 bootstrap: ANNOUNCEMENT_MODE=legacy, AFTER_EPOCH
 # Required for direct send (not CALLDATA_ONLY): ETH_KEYSTORE, PASSWORD
 # Optional: CALLDATA_ONLY=true to generate calldata for Safe multisig instead of sending;
 #           ANNOUNCEMENT_MODE=delay|legacy (default: delay)
@@ -92,9 +92,9 @@ case "$ANNOUNCEMENT_MODE" in
     fi
     ;;
   legacy)
-    # Bootstrap only: the deployed FWSS version that predates announceUpgradePlan
-    # cannot use delay mode. Remove this branch after both networks are upgraded and
-    # rollback to a pre-selector implementation is retired (UPGRADE-CHECKLIST Phase 5).
+    # Bootstrap only: FWSS v1.3.0 predates announceUpgradePlan, so the v1.3.1
+    # rollout cannot use delay mode. Deprecate this branch after v1.3.1 is live on
+    # both networks; remove it once rollback to v1.3.0 is retired (checklist Phase 5).
     if [ -z "$AFTER_EPOCH" ]; then
       echo "Error: AFTER_EPOCH is not set for ANNOUNCEMENT_MODE=legacy"
       exit 1
@@ -120,7 +120,7 @@ case "$ANNOUNCEMENT_MODE" in
 
     CALL_SIGNATURE="announcePlannedUpgrade((address,uint96))"
     CALL_ARGS=("($NEW_FWSS_IMPLEMENTATION_ADDRESS,$AFTER_EPOCH)")
-    echo "Using bootstrap legacy mode; announcing upgrade after $((AFTER_EPOCH - CURRENT_EPOCH)) epochs"
+    echo "Using v1.3.0 bootstrap legacy mode; announcing upgrade after $((AFTER_EPOCH - CURRENT_EPOCH)) epochs"
     echo "Ensure AFTER_EPOCH includes enough Safe-signing buffer; legacy calldata can expire before execution"
     ;;
   *)
@@ -142,7 +142,7 @@ if ! cast call --rpc-url "$ETH_RPC_URL" --from "$PROXY_OWNER" \
   "$FWSS_PROXY_ADDRESS" "$CALL_SIGNATURE" "${CALL_ARGS[@]}" >/dev/null; then
   echo "Error: $CALL_SIGNATURE would revert against the current FWSS proxy"
   if [ "$ANNOUNCEMENT_MODE" = "delay" ]; then
-    echo "If this proxy predates announceUpgradePlan, rerun with ANNOUNCEMENT_MODE=legacy"
+    echo "For the FWSS v1.3.0 -> v1.3.1 bootstrap, rerun with ANNOUNCEMENT_MODE=legacy"
   fi
   exit 1
 fi


### PR DESCRIPTION
## Summary

- make `announceUpgradePlan(address,uint96)` the default FWSS operator flow
- keep an explicit bootstrap-only `ANNOUNCEMENT_MODE=legacy` path for the FWSS v1.3.0 -> v1.3.1 rollout
- simulate announcements from the proxy owner before printing or sending calldata
- record and verify the actual on-chain `afterEpoch` in the upgrade checklist and release run log
- regenerate the published FWSS ABI

## Why

This is stacked on #547. Relative delays remove the need to predict an absolute epoch before Safe signing, but the currently deployed FWSS v1.3.0 contracts do not expose the new selector. Their upgrade to v1.3.1 must therefore use the legacy interface.

Treat legacy mode as deprecated after v1.3.1 is live on Calibnet and Mainnet. Remove it once rollback to v1.3.0 is no longer supported; if that rollback remains supported, retain the mode or document the exact v1.3.1-tagged helper operators must use.