### PR TITLE
feat: introduce IFilecoinServiceMetadata and apply it in FWSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Storage providers submit on-chain transactions on behalf of clients (piece addit
 
 The complete on-chain price catalogue is exposed via `FilecoinWarmStorageServiceStateView.getPriceList()`. It returns a single nested `PriceList` struct covering token, streaming rates, one-time fees, and lockup amounts/periods. See [SPEC.md](SPEC.md) for details on rate calculation, operation fees, pricing updates, and top-up/renewal behavior.
 
+## Service metadata
+
+FilecoinWarmStorageService implements `IFilecoinServiceMetadata`, exposing a `name()` and `description()` for `eth_call`. Other FOC services are encouraged to use this interface so explorers and clients can identify service operator contracts without hard-coded address maps. Consumers should note that this output should be treated as untrusted data and should only ever be presented to users in carefully escaped form.
+
 ## 🚀 Quick Start
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The complete on-chain price catalogue is exposed via `FilecoinWarmStorageService
 
 ## Service metadata
 
-FilecoinWarmStorageService implements `IFilecoinServiceMetadata`, exposing a `name()` and `description()` for `eth_call`. Other FOC services are encouraged to use this interface so explorers and clients can identify service operator contracts without hard-coded address maps. Consumers should note that this output should be treated as untrusted data and should only ever be presented to users in carefully escaped form.
+FilecoinWarmStorageService implements `IFilecoinServiceMetadata`, exposing `name()`, `description()`, and `homepage()` for `eth_call`. Other FOC services are encouraged to use this interface so explorers and clients can identify service operator contracts without hard-coded address maps. `description()` is capped at 256 bytes and should be treated as untrusted display-only text. `homepage()` is an optional URL, capped at 256 bytes, and returns an empty string when not provided. Consumers should validate metadata from unverified contracts and carefully escape all displayed values.
 
 ## 🚀 Quick Start
 
@@ -148,4 +148,3 @@ See [service_contracts/CONTRIBUTING.md](./service_contracts/CONTRIBUTING.md) for
 
 ## 📄 License
 Dual-licensed under [MIT](https://github.com/FilOzone/filecoin-services/blob/main/LICENSE.md) + [Apache 2.0](https://github.com/FilOzone/filecoin-services/blob/main/LICENSE.md)
-

--- a/service_contracts/Makefile
+++ b/service_contracts/Makefile
@@ -138,6 +138,7 @@ check-layout:
 # Core contracts we publish ABIs for.
 ABI_CONTRACTS := \
 	FilecoinWarmStorageService \
+	IFilecoinServiceMetadata \
 	FilecoinWarmStorageServiceStateLibrary \
 	FilecoinWarmStorageServiceStateView \
 	FilecoinPayV1 \

--- a/service_contracts/README.md
+++ b/service_contracts/README.md
@@ -7,6 +7,7 @@ This directory contains the smart contracts for different Filecoin services usin
 - `src/` - Contract source files
   - `FilecoinWarmStorageService.sol` - A service contract with [PDP](https://github.com/FilOzone/pdp) (Proof of Data Possession) and payment integration
   - `FilecoinWarmStorageServiceStateView.sol` - View contract for reading `FilecoinWarmStorageService` with `eth_call`.
+  - `IFilecoinServiceMetadata.sol` - Minimal service identity interface (`name`, `description`)
   - `src/lib` - Library source files
     - `FilecoinWarmStorageServiceLayout.sol` - Constants conveying the storage layout of `FilecoinWarmStorageService`
     - `FilecoinWarmStorageServiceStateInternalLibrary.sol` - `internal` library for embedding logic to read `FilecoinWarmStorageService`

--- a/service_contracts/README.md
+++ b/service_contracts/README.md
@@ -7,7 +7,7 @@ This directory contains the smart contracts for different Filecoin services usin
 - `src/` - Contract source files
   - `FilecoinWarmStorageService.sol` - A service contract with [PDP](https://github.com/FilOzone/pdp) (Proof of Data Possession) and payment integration
   - `FilecoinWarmStorageServiceStateView.sol` - View contract for reading `FilecoinWarmStorageService` with `eth_call`.
-  - `IFilecoinServiceMetadata.sol` - Minimal service identity interface (`name`, `description`)
+  - `IFilecoinServiceMetadata.sol` - Minimal service identity interface (`name`, `description`, `homepage`)
   - `src/lib` - Library source files
     - `FilecoinWarmStorageServiceLayout.sol` - Constants conveying the storage layout of `FilecoinWarmStorageService`
     - `FilecoinWarmStorageServiceStateInternalLibrary.sol` - `internal` library for embedding logic to read `FilecoinWarmStorageService`

--- a/service_contracts/abi/Errors.abi.json
+++ b/service_contracts/abi/Errors.abi.json
@@ -504,28 +504,6 @@
   },
   {
     "type": "error",
-    "name": "InvalidServiceDescriptionLength",
-    "inputs": [
-      {
-        "name": "length",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "InvalidServiceNameLength",
-    "inputs": [
-      {
-        "name": "length",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
     "name": "InvalidSignature",
     "inputs": [
       {

--- a/service_contracts/abi/FilecoinWarmStorageService.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageService.abi.json
@@ -387,6 +387,19 @@
   },
   {
     "type": "function",
+    "name": "homepage",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
     "name": "initialize",
     "inputs": [
       {

--- a/service_contracts/abi/FilecoinWarmStorageService.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageService.abi.json
@@ -188,6 +188,19 @@
   },
   {
     "type": "function",
+    "name": "description",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
     "name": "eip712Domain",
     "inputs": [],
     "outputs": [
@@ -390,16 +403,6 @@
         "name": "_filBeamControllerAddress",
         "type": "address",
         "internalType": "address"
-      },
-      {
-        "name": "_name",
-        "type": "string",
-        "internalType": "string"
-      },
-      {
-        "name": "_description",
-        "type": "string",
-        "internalType": "string"
       }
     ],
     "outputs": [],
@@ -417,6 +420,19 @@
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "name",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
   },
   {
     "type": "function",
@@ -1724,28 +1740,6 @@
     "type": "error",
     "name": "InvalidInitialization",
     "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "InvalidServiceDescriptionLength",
-    "inputs": [
-      {
-        "name": "length",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "InvalidServiceNameLength",
-    "inputs": [
-      {
-        "name": "length",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
   },
   {
     "type": "error",

--- a/service_contracts/abi/IFilecoinServiceMetadata.abi.json
+++ b/service_contracts/abi/IFilecoinServiceMetadata.abi.json
@@ -1,0 +1,28 @@
+[
+  {
+    "type": "function",
+    "name": "description",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "name",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  }
+]

--- a/service_contracts/abi/IFilecoinServiceMetadata.abi.json
+++ b/service_contracts/abi/IFilecoinServiceMetadata.abi.json
@@ -14,6 +14,19 @@
   },
   {
     "type": "function",
+    "name": "homepage",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "name",
     "inputs": [],
     "outputs": [

--- a/service_contracts/src/Errors.sol
+++ b/service_contracts/src/Errors.sol
@@ -74,14 +74,6 @@ library Errors {
     /// @param challengeWindowSize The provided challenge window size
     error InvalidChallengeWindowSize(uint256 maxProvingPeriod, uint256 challengeWindowSize);
 
-    /// @notice The service name length must be >0 and <= 256
-    /// @param length the attempted length
-    error InvalidServiceNameLength(uint256 length);
-
-    /// @notice The service description length must be >0 and <= 256
-    /// @param length the attempted length
-    error InvalidServiceDescriptionLength(uint256 length);
-
     /// @notice This function can only be called by the contract itself during upgrade
     /// @param expected The expected caller (the contract address)
     /// @param actual The actual caller address

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -14,6 +14,7 @@ import {EIP712Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/crypt
 import {ERC1967Utils} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
 import {FilecoinPayV1, IValidator} from "@fws-payments/FilecoinPayV1.sol";
 import {Errors} from "./Errors.sol";
+import {IFilecoinServiceMetadata} from "./IFilecoinServiceMetadata.sol";
 
 import {ServiceProviderRegistry} from "./ServiceProviderRegistry.sol";
 
@@ -69,6 +70,7 @@ uint256 constant MAX_TERMINATE_SERVICE_EXTRA_DATA_SIZE = 256; // 256 bytes
 /// and adjusts payment rates based on storage size. Also implements validation
 /// to reduce payments for faulted epochs.
 contract FilecoinWarmStorageService is
+    IFilecoinServiceMetadata,
     PDPListener,
     IValidator,
     Initializable,
@@ -79,6 +81,9 @@ contract FilecoinWarmStorageService is
 {
     // Version tracking
     string public constant VERSION = "1.3.0";
+    string private constant SERVICE_NAME = "Filecoin Warm Storage Service";
+    string private constant SERVICE_DESCRIPTION =
+        "Warm storage service for the Filecoin Onchain Cloud. Manages PDP-backed datasets, Filecoin Pay storage rails, lifecycle fees, and optional CDN payment rails.";
 
     using Rails for FilecoinPayV1;
 
@@ -372,20 +377,15 @@ contract FilecoinWarmStorageService is
     }
 
     /**
-     * @notice Initialize the contract with PDP proving period parameters
+     * @notice Initialize the contract with PDP proving period parameters.
      * @param _maxProvingPeriod Maximum number of epochs between two consecutive proofs
      * @param _challengeWindowSize Number of epochs for the challenge window
      * @param _filBeamControllerAddress Address authorized to terminate CDN services
-     * @param _name Service name (max 256 characters, cannot be empty)
-     * @param _description Service description (max 256 characters, cannot be empty)
      */
-    function initialize(
-        uint64 _maxProvingPeriod,
-        uint256 _challengeWindowSize,
-        address _filBeamControllerAddress,
-        string memory _name,
-        string memory _description
-    ) public initializer {
+    function initialize(uint64 _maxProvingPeriod, uint256 _challengeWindowSize, address _filBeamControllerAddress)
+        public
+        initializer
+    {
         __Ownable_init(msg.sender);
         __UUPSUpgradeable_init();
         __EIP712_init("FilecoinWarmStorageService", "1");
@@ -399,19 +399,18 @@ contract FilecoinWarmStorageService is
         require(_filBeamControllerAddress != address(0), Errors.ZeroAddress(Errors.AddressField.FilBeamController));
         filBeamControllerAddress = _filBeamControllerAddress;
 
-        uint256 serviceNameLength = bytes(_name).length;
-        require(serviceNameLength > 0, Errors.InvalidServiceNameLength(serviceNameLength));
-        require(serviceNameLength <= 256, Errors.InvalidServiceNameLength(serviceNameLength));
-
-        uint256 serviceDescriptionLength = bytes(_description).length;
-        require(serviceDescriptionLength > 0, Errors.InvalidServiceDescriptionLength(serviceDescriptionLength));
-        require(serviceDescriptionLength <= 256, Errors.InvalidServiceDescriptionLength(serviceDescriptionLength));
-
-        // Emit the FilecoinServiceDeployed event
-        emit FilecoinServiceDeployed(_name, _description);
+        emit FilecoinServiceDeployed(SERVICE_NAME, SERVICE_DESCRIPTION);
 
         maxProvingPeriod = _maxProvingPeriod;
         challengeWindowSize = _challengeWindowSize;
+    }
+
+    function name() external pure override returns (string memory) {
+        return SERVICE_NAME;
+    }
+
+    function description() external pure override returns (string memory) {
+        return SERVICE_DESCRIPTION;
     }
 
     function announceUpgradePlan(address nextImplementation, uint96 delayEpochs) external {

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -84,6 +84,7 @@ contract FilecoinWarmStorageService is
     string private constant SERVICE_NAME = "Filecoin Warm Storage Service";
     string private constant SERVICE_DESCRIPTION =
         "Warm storage service for the Filecoin Onchain Cloud. Manages PDP-backed datasets, Filecoin Pay storage rails, lifecycle fees, and optional CDN payment rails.";
+    string private constant SERVICE_HOMEPAGE = "https://github.com/FilOzone/filecoin-services";
 
     using Rails for FilecoinPayV1;
 
@@ -411,6 +412,10 @@ contract FilecoinWarmStorageService is
 
     function description() external pure override returns (string memory) {
         return SERVICE_DESCRIPTION;
+    }
+
+    function homepage() external pure override returns (string memory) {
+        return SERVICE_HOMEPAGE;
     }
 
     function announceUpgradePlan(address nextImplementation, uint96 delayEpochs) external {

--- a/service_contracts/src/IFilecoinServiceMetadata.sol
+++ b/service_contracts/src/IFilecoinServiceMetadata.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+pragma solidity ^0.8.20;
+
+/// @title IFilecoinServiceMetadata
+/// @notice Minimal service identity interface for Filecoin Onchain Cloud service contracts.
+interface IFilecoinServiceMetadata {
+    /// @notice Human-readable service name.
+    function name() external view returns (string memory);
+
+    /// @notice Human-readable service description.
+    function description() external view returns (string memory);
+}

--- a/service_contracts/src/IFilecoinServiceMetadata.sol
+++ b/service_contracts/src/IFilecoinServiceMetadata.sol
@@ -4,9 +4,16 @@ pragma solidity ^0.8.20;
 /// @title IFilecoinServiceMetadata
 /// @notice Minimal service identity interface for Filecoin Onchain Cloud service contracts.
 interface IFilecoinServiceMetadata {
-    /// @notice Human-readable service name.
+    /// @notice Short, human-readable service name.
     function name() external view returns (string memory);
 
-    /// @notice Human-readable service description.
+    /// @notice Concise, human-readable service description.
+    /// @dev Implementations must limit the UTF-8 encoded value to 256 bytes.
+    ///      Consumers should treat the value as untrusted display-only text.
     function description() external view returns (string memory);
+
+    /// @notice Optional URL for service documentation, specifications, or source code.
+    /// @dev Implementations must limit the UTF-8 encoded value to 256 bytes and
+    ///      return an empty string when no homepage is provided.
+    function homepage() external view returns (string memory);
 }

--- a/service_contracts/test/Abandonment.t.sol
+++ b/service_contracts/test/Abandonment.t.sol
@@ -109,10 +109,7 @@ contract AbandonmentTest is MockFVMTest {
         );
         MyERC1967Proxy fwssProxy = new MyERC1967Proxy(
             address(fwssImpl),
-            abi.encodeCall(
-                FilecoinWarmStorageService.initialize,
-                (uint64(2880), uint256(60), filBeamController, "Test FWSS", "Abandonment test service")
-            )
+            abi.encodeCall(FilecoinWarmStorageService.initialize, (uint64(2880), uint256(60), filBeamController))
         );
         fwss = FilecoinWarmStorageService(address(fwssProxy));
 

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -339,6 +339,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         IFilecoinServiceMetadata metadata = IFilecoinServiceMetadata(address(pdpServiceWithPayments));
         string memory serviceName = metadata.name();
         string memory serviceDescription = metadata.description();
+        string memory serviceHomepage = metadata.homepage();
 
         assertEq(serviceName, "Filecoin Warm Storage Service", "Service name should match");
         assertEq(
@@ -346,6 +347,9 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
             "Warm storage service for the Filecoin Onchain Cloud. Manages PDP-backed datasets, Filecoin Pay storage rails, lifecycle fees, and optional CDN payment rails.",
             "Service description should match"
         );
+        assertEq(serviceHomepage, "https://github.com/FilOzone/filecoin-services", "Service homepage should match");
+        assertLe(bytes(serviceDescription).length, 256, "Service description should not exceed 256 bytes");
+        assertLe(bytes(serviceHomepage).length, 256, "Service homepage should not exceed 256 bytes");
     }
 
     function testAnnouncePlannedUpgrade() public {

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -12,6 +12,7 @@ import {SessionKeyRegistry} from "@session-key-registry/SessionKeyRegistry.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 import {CHALLENGES_PER_PROOF, FilecoinWarmStorageService} from "../src/FilecoinWarmStorageService.sol";
+import {IFilecoinServiceMetadata} from "../src/IFilecoinServiceMetadata.sol";
 import {FilecoinWarmStorageServiceStateView} from "../src/FilecoinWarmStorageServiceStateView.sol";
 import {SignatureVerificationLib} from "../src/lib/SignatureVerificationLib.sol";
 import {FilecoinWarmStorageServiceStateLibrary} from "../src/lib/FilecoinWarmStorageServiceStateLibrary.sol";
@@ -231,9 +232,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
             FilecoinWarmStorageService.initialize.selector,
             uint64(2880), // maxProvingPeriod
             uint256(60), // challengeWindowSize
-            filBeamController, // filBeamControllerAddress
-            "Filecoin Warm Storage Service", // service name
-            "A decentralized storage service with proof-of-data-possession and payment integration" // service description
+            filBeamController // filBeamControllerAddress
         );
 
         MyERC1967Proxy pdpServiceProxy = new MyERC1967Proxy(address(pdpServiceImpl), initializeData);
@@ -302,7 +301,6 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
     }
 
     function testFilecoinServiceDeployedEvent() public {
-        // Deploy a new service instance to test the event
         FilecoinWarmStorageService newServiceImpl = new FilecoinWarmStorageService(
             address(mockPDPVerifier),
             address(payments),
@@ -313,139 +311,41 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
             4
         );
 
-        // Expected event parameters
-        string memory expectedName = "Test Event Service";
-        string memory expectedDescription = "Service for testing events";
-
         bytes memory initData = abi.encodeWithSelector(
-            FilecoinWarmStorageService.initialize.selector,
-            uint64(2880),
-            uint256(60),
-            filBeamController,
-            expectedName,
-            expectedDescription
+            FilecoinWarmStorageService.initialize.selector, uint64(2880), uint256(60), filBeamController
         );
 
-        // Expect the FilecoinServiceDeployed event
-        vm.expectEmit(true, true, true, true);
-        emit FilecoinWarmStorageService.FilecoinServiceDeployed(expectedName, expectedDescription);
+        vm.recordLogs();
+        MyERC1967Proxy newServiceProxy = new MyERC1967Proxy(address(newServiceImpl), initData);
+        IFilecoinServiceMetadata metadata = IFilecoinServiceMetadata(address(newServiceProxy));
 
-        // Deploy the proxy which triggers the initialize function
-        new MyERC1967Proxy(address(newServiceImpl), initData);
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        bytes32 eventSignature = keccak256("FilecoinServiceDeployed(string,string)");
+        bool found;
+        for (uint256 i = 0; i < entries.length; i++) {
+            if (entries[i].topics.length == 1 && entries[i].topics[0] == eventSignature) {
+                (string memory emittedName, string memory emittedDescription) =
+                    abi.decode(entries[i].data, (string, string));
+                assertEq(emittedName, metadata.name(), "Event name should match metadata");
+                assertEq(emittedDescription, metadata.description(), "Event description should match metadata");
+                found = true;
+            }
+        }
+
+        assertTrue(found, "FilecoinServiceDeployed event should be emitted");
     }
 
-    function testServiceNameAndDescriptionValidation() public {
-        // Test empty name validation
-        FilecoinWarmStorageService serviceImpl1 = new FilecoinWarmStorageService(
-            address(mockPDPVerifier),
-            address(payments),
-            mockUSDFC,
-            filBeamBeneficiary,
-            serviceProviderRegistry,
-            sessionKeyRegistry,
-            4
+    function testServiceMetadata() public view {
+        IFilecoinServiceMetadata metadata = IFilecoinServiceMetadata(address(pdpServiceWithPayments));
+        string memory serviceName = metadata.name();
+        string memory serviceDescription = metadata.description();
+
+        assertEq(serviceName, "Filecoin Warm Storage Service", "Service name should match");
+        assertEq(
+            serviceDescription,
+            "Warm storage service for the Filecoin Onchain Cloud. Manages PDP-backed datasets, Filecoin Pay storage rails, lifecycle fees, and optional CDN payment rails.",
+            "Service description should match"
         );
-
-        bytes memory initDataEmptyName = abi.encodeWithSelector(
-            FilecoinWarmStorageService.initialize.selector,
-            uint64(2880),
-            uint256(60),
-            filBeamController,
-            "", // empty name
-            "Valid description"
-        );
-
-        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidServiceNameLength.selector, 0));
-        new MyERC1967Proxy(address(serviceImpl1), initDataEmptyName);
-
-        // Test empty description validation
-        FilecoinWarmStorageService serviceImpl2 = new FilecoinWarmStorageService(
-            address(mockPDPVerifier),
-            address(payments),
-            mockUSDFC,
-            filBeamBeneficiary,
-            serviceProviderRegistry,
-            sessionKeyRegistry,
-            4
-        );
-
-        bytes memory initDataEmptyDesc = abi.encodeWithSelector(
-            FilecoinWarmStorageService.initialize.selector,
-            uint64(2880),
-            uint256(60),
-            filBeamController,
-            "Valid name",
-            "" // empty description
-        );
-
-        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidServiceDescriptionLength.selector, 0));
-        new MyERC1967Proxy(address(serviceImpl2), initDataEmptyDesc);
-
-        // Test name exceeding 256 characters
-        FilecoinWarmStorageService serviceImpl3 = new FilecoinWarmStorageService(
-            address(mockPDPVerifier),
-            address(payments),
-            mockUSDFC,
-            filBeamBeneficiary,
-            serviceProviderRegistry,
-            sessionKeyRegistry,
-            4
-        );
-
-        string memory longName = string(
-            abi.encodePacked(
-                "This is a very long name that exceeds the maximum allowed length of 256 characters. ",
-                "It needs to be long enough to trigger the validation error in the contract. ",
-                "Adding more text here to ensure we go past the limit. ",
-                "Still need more characters to exceed 256 total length for this test case to work properly. ",
-                "Almost there, just a bit more text needed to push us over the limit."
-            )
-        );
-
-        bytes memory initDataLongName = abi.encodeWithSelector(
-            FilecoinWarmStorageService.initialize.selector,
-            uint64(2880),
-            uint256(60),
-            filBeamController,
-            longName,
-            "Valid description"
-        );
-
-        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidServiceNameLength.selector, bytes(longName).length));
-        new MyERC1967Proxy(address(serviceImpl3), initDataLongName);
-
-        // Test description exceeding 256 characters
-        FilecoinWarmStorageService serviceImpl4 = new FilecoinWarmStorageService(
-            address(mockPDPVerifier),
-            address(payments),
-            mockUSDFC,
-            filBeamBeneficiary,
-            serviceProviderRegistry,
-            sessionKeyRegistry,
-            4
-        );
-
-        string memory longDesc = string(
-            abi.encodePacked(
-                "This is a very long description that exceeds the maximum allowed length of 256 characters. ",
-                "It needs to be long enough to trigger the validation error in the contract. ",
-                "Adding more text here to ensure we go past the limit. ",
-                "Still need more characters to exceed 256 total length for this test case to work properly. ",
-                "Almost there, just a bit more text needed to push us over the limit."
-            )
-        );
-
-        bytes memory initDataLongDesc = abi.encodeWithSelector(
-            FilecoinWarmStorageService.initialize.selector,
-            uint64(2880),
-            uint256(60),
-            filBeamController,
-            "Valid name",
-            longDesc
-        );
-
-        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidServiceDescriptionLength.selector, bytes(longDesc).length));
-        new MyERC1967Proxy(address(serviceImpl4), initDataLongDesc);
     }
 
     function testAnnouncePlannedUpgrade() public {
@@ -467,17 +367,8 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
             4
         );
 
-        // Expected event parameters
-        string memory name = "FWSS";
-        string memory description = "FilecoinWarmStorageService";
-
         bytes memory initData = abi.encodeWithSelector(
-            FilecoinWarmStorageService.initialize.selector,
-            uint64(2880),
-            uint256(60),
-            filBeamController,
-            name,
-            description
+            FilecoinWarmStorageService.initialize.selector, uint64(2880), uint256(60), filBeamController
         );
 
         // Deploy the proxy which triggers the initialize function
@@ -5516,9 +5407,7 @@ contract FilecoinWarmStorageServiceUpgradeTest is Test {
             FilecoinWarmStorageService.initialize.selector,
             uint64(2880), // maxProvingPeriod
             uint256(60), // challengeWindowSize
-            filBeamController, // filBeamControllerAddress
-            "Test Service", // service name
-            "Test Description" // service description
+            filBeamController // filBeamControllerAddress
         );
 
         MyERC1967Proxy warmStorageProxy = new MyERC1967Proxy(address(warmStorageImpl), initData);

--- a/service_contracts/test/FilecoinWarmStorageServiceOwner.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageServiceOwner.t.sol
@@ -104,12 +104,7 @@ contract FilecoinWarmStorageServiceOwnerTest is MockFVMTest {
         );
 
         bytes memory serviceInitData = abi.encodeWithSelector(
-            FilecoinWarmStorageService.initialize.selector,
-            uint64(2880),
-            uint256(1440),
-            filBeamController,
-            "Test Service",
-            "Test Description"
+            FilecoinWarmStorageService.initialize.selector, uint64(2880), uint256(1440), filBeamController
         );
         MyERC1967Proxy serviceProxy = new MyERC1967Proxy(address(serviceImpl), serviceInitData);
         serviceContract = FilecoinWarmStorageService(address(serviceProxy));

--- a/service_contracts/test/ProviderValidation.t.sol
+++ b/service_contracts/test/ProviderValidation.t.sol
@@ -80,12 +80,7 @@ contract ProviderValidationTest is MockFVMTest {
             4
         );
         bytes memory warmStorageInitData = abi.encodeWithSelector(
-            FilecoinWarmStorageService.initialize.selector,
-            uint64(2880),
-            uint256(60),
-            filBeamController,
-            "Provider Validation Test Service",
-            "Test service for provider validation"
+            FilecoinWarmStorageService.initialize.selector, uint64(2880), uint256(60), filBeamController
         );
         MyERC1967Proxy warmStorageProxy = new MyERC1967Proxy(address(warmStorageImpl), warmStorageInitData);
         warmStorage = FilecoinWarmStorageService(address(warmStorageProxy));

--- a/service_contracts/tools/warm-storage-deploy-all.sh
+++ b/service_contracts/tools/warm-storage-deploy-all.sh
@@ -3,7 +3,6 @@
 # Auto-detects network based on RPC chain ID and sets appropriate configuration
 # Assumption: KEYSTORE, PASSWORD, ETH_RPC_URL env vars are set to an appropriate eth keystore path and password
 # and to a valid ETH_RPC_URL for the target network.
-# Assumption: Must configure SERVICE_NAME, SERVICE_DESCRIPTION
 # Assumption: forge, cast, jq are in the PATH
 # Assumption: called from contracts directory so forge paths work out
 #
@@ -102,34 +101,6 @@ if [ "$DRY_RUN" != "true" ] && [ -z "$ETH_KEYSTORE" ]; then
   exit 1
 fi
 
-# Service name and description - mandatory environment variables
-if [ -z "$SERVICE_NAME" ]; then
-  echo "Error: SERVICE_NAME is not set. Please set SERVICE_NAME environment variable (max 256 characters)"
-  exit 1
-fi
-
-if [ -z "$SERVICE_DESCRIPTION" ]; then
-  echo "Error: SERVICE_DESCRIPTION is not set. Please set SERVICE_DESCRIPTION environment variable (max 256 characters)"
-  exit 1
-fi
-
-# Validate name and description lengths
-NAME_LENGTH=${#SERVICE_NAME}
-DESC_LENGTH=${#SERVICE_DESCRIPTION}
-
-if [ $NAME_LENGTH -eq 0 ] || [ $NAME_LENGTH -gt 256 ]; then
-  echo "Error: SERVICE_NAME must be between 1 and 256 characters (current: $NAME_LENGTH)"
-  exit 1
-fi
-
-if [ $DESC_LENGTH -eq 0 ] || [ $DESC_LENGTH -gt 256 ]; then
-  echo "Error: SERVICE_DESCRIPTION must be between 1 and 256 characters (current: $DESC_LENGTH)"
-  exit 1
-fi
-
-echo "Service configuration:"
-echo "  Name: $SERVICE_NAME"
-echo "  Description: $SERVICE_DESCRIPTION"
 
 # Use environment variables if set, otherwise use network defaults
 if [ -z "$FILBEAM_CONTROLLER_ADDRESS" ]; then
@@ -402,8 +373,8 @@ deploy_implementation_if_needed \
 unset LIBRARIES
 
 # Step 9: Deploy or use existing FilecoinWarmStorageService proxy
-# Initialize with max proving period, challenge window size, FilBeam controller address, name, and description
-INIT_DATA=$(cast calldata "initialize(uint64,uint256,address,string,string)" $MAX_PROVING_PERIOD $CHALLENGE_WINDOW_SIZE $FILBEAM_CONTROLLER_ADDRESS "$SERVICE_NAME" "$SERVICE_DESCRIPTION")
+# Initialize with max proving period, challenge window size, and FilBeam controller address
+INIT_DATA=$(cast calldata "initialize(uint64,uint256,address)" $MAX_PROVING_PERIOD $CHALLENGE_WINDOW_SIZE $FILBEAM_CONTROLLER_ADDRESS)
 deploy_proxy_if_needed \
     "FWSS_PROXY_ADDRESS" \
     "$FWSS_IMPLEMENTATION_ADDRESS" \
@@ -481,8 +452,6 @@ echo "Challenge window size: $CHALLENGE_WINDOW_SIZE epochs"
 echo "USDFC token address: $USDFC_TOKEN_ADDRESS"
 echo "FilBeam controller address: $FILBEAM_CONTROLLER_ADDRESS"
 echo "FilBeam beneficiary address: $FILBEAM_BENEFICIARY_ADDRESS"
-echo "Service name: $SERVICE_NAME"
-echo "Service description: $SERVICE_DESCRIPTION"
 
 # Contract verification
 if [ "$DRY_RUN" = "false" ] && [ "${AUTO_VERIFY:-true}" = "true" ]; then


### PR DESCRIPTION
Closes: https://github.com/FilOzone/filecoin-services/issues/535

Need's @jennijuju's sign-off. We talked over the various permutations about this and she was going to decide what she wants to consume for the console.

My words of caution about this:

* Untrusted from any contract you don't know, always escape all output and even consider hiding because you never know what it's going to contain. Links shouldn't be clickable etc.
* For contracts you do trust, it's not really critical you have this because you presumably know what that contract is, but this would give those contracts the ability to adjust their own branding .. which implies you _trust_ them enough to defer these strings to them.