### PR TITLE
Special case pre-activation epochs for settlement & preserve activation epoch across reactivation

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -96,7 +96,7 @@ Only the contract owner can update pricing, by upgrading the contract.
 
 Rate recalculation timing differs for additions and deletions due to proving semantics:
 
-- **Adding pieces**: The rate updates immediately when `piecesAdded()` is called. The client begins paying for new pieces right away, even though those pieces won't be included in proof challenges until the next proving period. This fail-fast behavior protects providers: if the client lacks sufficient funds for the new lockup, the transaction fails before the provider commits resources.
+- **Adding pieces**: The rate and corresponding lockup requirement update immediately when `piecesAdded()` is called, even before proving activation. This fail-fast behavior protects providers by rejecting additions the client cannot fund before the provider commits resources. Streaming storage payment becomes eligible only after the first `nextProvingPeriod()` activates proving; pre-activation epochs settle with zero payment. One-time lifecycle fees remain payable before activation.
 
 - **Removing pieces**: Deletions are scheduled and take effect at the next proving boundary (`nextProvingPeriod()`). The client continues paying the existing rate until the removal is finalized. This deferral is required because proofs may challenge any portion of the current data set during the proving period—the provider must continue storing and proving all existing data until the period ends.
 
@@ -104,11 +104,11 @@ Rate recalculation timing differs for additions and deletions due to proving sem
 
 During each proving period, proofs are generated over a fixed data set. The prover must maintain the complete data set because challenges can target any leaf:
 
-- **Additions expand the proof space** but don't affect existing challenges. New pieces simply won't be challenged until the next period. Payment starts immediately because storage resources are committed.
+- **Additions expand the proof space** but don't affect existing challenges. Before activation they update the rate and lockup without earning streaming payment. After activation the new rate becomes payable immediately, even though the added pieces won't be challenged until the next period.
 
 - **Deletions would shrink the proof space** mid-period, potentially invalidating challenges. The data must remain intact until `nextProvingPeriod()` finalizes the removal. Only then does the rate decrease.
 
-This ensures proof integrity while providing fair payment semantics: you pay when you add, and continue paying for deletions until the proving period boundary.
+This ensures proof integrity while providing fair payment semantics: additions reserve funding immediately and become payable once proving is active, while deletions remain payable until the proving period boundary.
 
 ### Rate Changes After Termination
 
@@ -147,6 +147,18 @@ Deposits extend the duration without changing the rate (unless adding pieces tri
 **Delinquency**: When a client's funded epoch falls below the current epoch, the payment rail can no longer be settled—no further payments flow to the provider. The provider may terminate the service to claim payment from the locked funds, guaranteeing up to 30 days of payment from the last funded epoch.
 
 ## Settlement and Payment Validation
+
+### Proving Activation Lifecycle
+
+Data set creation does not activate proving. Client tooling typically uses PDPVerifier's combined create-and-add operation. PDPVerifier delivers that operation to FWSS as separate `dataSetCreated()` and `piecesAdded()` callbacks. A data set may receive one or more such piece callbacks before the service provider's first `nextProvingPeriod()` call.
+
+The data set may also be terminated before proving activates. The first `nextProvingPeriod()` can still activate proving while the PDP rail's termination window remains open. A callback that modifies payment state must execute strictly before `pdpEndEpoch`; at `pdpEndEpoch`, activation succeeds only when no pending fee or scheduled removal requires a payment update. Consent-based immediate termination can therefore coincide with activation in the same epoch when no payment update is needed.
+
+The first `nextProvingPeriod()` sets `provingActivationEpoch` to the current epoch `A` and schedules the first deadline. `A` is a boundary marker, not a billable epoch; the first billable proving epoch is `A+1`.
+
+Before activation, `piecesAdded()` still updates the Filecoin Pay rate and lockup requirement. This enforces funding before the provider commits storage, but does not make pre-activation epochs payable. When Filecoin Pay later presents a rate segment ending at or before `A`, `validatePayment()` advances `settleUpto` through the segment with zero payment. Segments crossing `A` exclude their pre-activation epochs from payment. This also lets terminated, never-activated data sets release their streaming lockup cleanly.
+
+One-time lifecycle fees are independent of proving activation and remain payable when their operations occur.
 
 ### Proving Period Epoch Conventions
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -156,6 +156,14 @@ The data set may also be terminated before proving activates. The first `nextPro
 
 The first `nextProvingPeriod()` sets `provingActivationEpoch` to the current epoch `A` and schedules the first deadline. `A` is a boundary marker, not a billable epoch; the first billable proving epoch is `A+1`.
 
+If all pieces are removed, PDPVerifier reports `NO_CHALLENGE_SCHEDULED` and FWSS suspends proving by clearing the current deadline. The original activation epoch remains the lifetime origin for proving-period deadlines, proof bitmap indices, and payment validation. Adding pieces later does not rebase this history.
+
+For an inactive data set with a prior activation, `nextPDPChallengeWindowStart()` returns a challenge window on the original timeline. Given the current epoch `C`, it chooses the earliest canonical deadline `D = A + n*M` with `D >= C+M`, and returns `D-W`, where `W` is the challenge-window size. The subsequent `nextProvingPeriod()` independently derives the earliest valid deadline at execution, accepts only a challenge epoch in its window, and preserves `A`.
+
+Periods elapsed while proving is suspended have no proof and settle with zero payment once their deadlines pass. Proof bits recorded before suspension retain their original period IDs and remain payable. Pieces added while proving is suspended update the rate and lockup immediately, but epochs before the selected reactivation period have no proof and therefore earn no streaming payment.
+
+Because the view call and transaction use their respective current epochs, the returned window can become stale before inclusion if the earliest valid deadline advances. A caller receiving `InvalidChallengeEpoch` must query `nextPDPChallengeWindowStart()` again and retry. The challenge must also satisfy PDPVerifier's normal minimum and maximum delay rules; the current mainnet and calibnet parameters provide ample headroom.
+
 Before activation, `piecesAdded()` still updates the Filecoin Pay rate and lockup requirement. This enforces funding before the provider commits storage, but does not make pre-activation epochs payable. When Filecoin Pay later presents a rate segment ending at or before `A`, `validatePayment()` advances `settleUpto` through the segment with zero payment. Segments crossing `A` exclude their pre-activation epochs from payment. This also lets terminated, never-activated data sets release their streaming lockup cleanly.
 
 One-time lifecycle fees are independent of proving activation and remain payable when their operations occur.

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -920,19 +920,42 @@ contract FilecoinWarmStorageService is
         uint96 pending = info.pendingOneTimePayments;
         uint96 reserveBalance = info.lifecycleReserveBalance;
 
-        // initialize state for new data set
+        uint256 activationEpoch = provingActivationEpoch[dataSetId];
         if (provingDeadlines[dataSetId] == NO_PROVING_DEADLINE) {
-            uint256 firstDeadline = block.number + maxProvingPeriod;
+            uint256 firstDeadline;
+            if (activationEpoch == 0) {
+                // First activation establishes the lifetime proving-period origin.
+                activationEpoch = block.number;
+                provingActivationEpoch[dataSetId] = activationEpoch;
+                firstDeadline = activationEpoch + maxProvingPeriod;
+            } else {
+                // Reactivation resumes the original proving-period timeline. The PDPVerifier
+                // guarantees a future challenge epoch; derive its canonical deadline without
+                // rebasing payment history or proven-period IDs.
+                require(
+                    challengeEpoch > activationEpoch,
+                    Errors.InvalidChallengeEpoch(
+                        dataSetId, activationEpoch + 1, activationEpoch + maxProvingPeriod, challengeEpoch
+                    )
+                );
+                uint256 period = _provingPeriodForEpoch(activationEpoch, challengeEpoch, maxProvingPeriod);
+                firstDeadline = _calcPeriodDeadline(activationEpoch, period);
+                if (firstDeadline < block.number + maxProvingPeriod) {
+                    uint256 minimumDeadline = block.number + maxProvingPeriod;
+                    uint256 periodsFromActivation =
+                        (minimumDeadline - activationEpoch + maxProvingPeriod - 1) / maxProvingPeriod;
+                    uint256 firstAllowedDeadline = activationEpoch + periodsFromActivation * maxProvingPeriod;
+                    revert Errors.InvalidChallengeEpoch(
+                        dataSetId, firstAllowedDeadline - challengeWindowSize, firstAllowedDeadline, challengeEpoch
+                    );
+                }
+            }
+
             uint256 minWindow = firstDeadline - challengeWindowSize;
-            uint256 maxWindow = firstDeadline;
-            if (challengeEpoch < minWindow || challengeEpoch > maxWindow) {
-                revert Errors.InvalidChallengeEpoch(dataSetId, minWindow, maxWindow, challengeEpoch);
+            if (challengeEpoch < minWindow || challengeEpoch > firstDeadline) {
+                revert Errors.InvalidChallengeEpoch(dataSetId, minWindow, firstDeadline, challengeEpoch);
             }
             provingDeadlines[dataSetId] = firstDeadline;
-
-            // Initialize the activation epoch when proving first starts
-            // This marks when the data set became active for proving
-            provingActivationEpoch[dataSetId] = block.number;
 
             // Rate was already set in piecesAdded; only update if pieces were removed or fees are pending
             if (processScheduledPieceMetadataRemovals(dataSetId) || pending > 0) {

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -929,26 +929,17 @@ contract FilecoinWarmStorageService is
                 provingActivationEpoch[dataSetId] = activationEpoch;
                 firstDeadline = activationEpoch + maxProvingPeriod;
             } else {
-                // Reactivation resumes the original proving-period timeline. The PDPVerifier
-                // guarantees a future challenge epoch; derive its canonical deadline without
-                // rebasing payment history or proven-period IDs.
+                // Reactivation resumes the original timeline, pinned to the earliest deadline with a full
+                // period of headroom, keeping the window one period wide.
                 require(
                     challengeEpoch > activationEpoch,
                     Errors.InvalidChallengeEpoch(
                         dataSetId, activationEpoch + 1, activationEpoch + maxProvingPeriod, challengeEpoch
                     )
                 );
-                uint256 period = _provingPeriodForEpoch(activationEpoch, challengeEpoch, maxProvingPeriod);
+                uint256 minimumDeadline = block.number + maxProvingPeriod;
+                uint256 period = _provingPeriodForEpoch(activationEpoch, minimumDeadline, maxProvingPeriod);
                 firstDeadline = _calcPeriodDeadline(activationEpoch, period);
-                if (firstDeadline < block.number + maxProvingPeriod) {
-                    uint256 minimumDeadline = block.number + maxProvingPeriod;
-                    uint256 periodsFromActivation =
-                        (minimumDeadline - activationEpoch + maxProvingPeriod - 1) / maxProvingPeriod;
-                    uint256 firstAllowedDeadline = activationEpoch + periodsFromActivation * maxProvingPeriod;
-                    revert Errors.InvalidChallengeEpoch(
-                        dataSetId, firstAllowedDeadline - challengeWindowSize, firstAllowedDeadline, challengeEpoch
-                    );
-                }
             }
 
             uint256 minWindow = firstDeadline - challengeWindowSize;

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -1489,11 +1489,11 @@ contract FilecoinWarmStorageService is
         uint256 totalEpochsRequested = toEpoch - fromEpoch;
         require(totalEpochsRequested > 0, Errors.InvalidEpochRange(fromEpoch, toEpoch));
 
-        // No proving activity: pay nothing, advance settleUpto = toEpoch so settleRail can
-        // discharge lockup. Hit by never-activated data sets and by the finalize leg of
-        // abandonment (which wipes activationEpoch between settles to unblock the open period)
+        // No active proving period covers epochs through the activation boundary. Advance
+        // settlement with zero payment so FilecoinPay can discharge pre-activation rate
+        // segments, including segments recorded before the first nextProvingPeriod call.
         uint256 activationEpoch = provingActivationEpoch[dataSetId];
-        if (activationEpoch == 0) {
+        if (activationEpoch == 0 || toEpoch <= activationEpoch) {
             return ValidationResult({modifiedAmount: 0, settleUpto: toEpoch, note: "No proving activity"});
         }
 
@@ -1553,9 +1553,6 @@ contract FilecoinWarmStorageService is
             fromEpoch = activationEpoch;
         }
         settleUpTo = fromEpoch;
-        if (toEpoch == activationEpoch) {
-            return (0, settleUpTo);
-        }
         uint256 startingPeriod = _provingPeriodForEpoch(activationEpoch, fromEpoch + 1, maxProvingPeriod);
         uint256 endingPeriod = _provingPeriodForEpoch(activationEpoch, toEpoch, maxProvingPeriod);
         uint256 deadline = _calcPeriodDeadline(activationEpoch, startingPeriod);

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceStateInternalLibrary.sol
@@ -301,12 +301,23 @@ library FilecoinWarmStorageServiceStateInternalLibrary {
         returns (uint256)
     {
         uint256 deadline = provingDeadline(service, setId);
+        uint64 maxProvingPeriod = getMaxProvingPeriod(service);
+        uint256 challengeWindowSize = challengeWindow(service);
 
         if (deadline == NO_PROVING_DEADLINE) {
-            revert Errors.ProvingPeriodNotInitialized(setId);
-        }
+            uint256 activationEpoch = provingActivationEpoch(service, setId);
+            if (activationEpoch == 0) {
+                revert Errors.ProvingPeriodNotInitialized(setId);
+            }
 
-        uint64 maxProvingPeriod = getMaxProvingPeriod(service);
+            // Leave one full proving period for PDP challenge finality and transaction
+            // inclusion, then align the window to the dataset's lifetime period origin.
+            uint256 minimumDeadline = block.number + maxProvingPeriod;
+            uint256 periodsFromActivation =
+                (minimumDeadline - activationEpoch + maxProvingPeriod - 1) / maxProvingPeriod;
+            deadline = activationEpoch + periodsFromActivation * maxProvingPeriod;
+            return deadline - challengeWindowSize;
+        }
 
         // If the current period is open this is the next period's challenge window
         if (block.number <= deadline) {

--- a/service_contracts/src/lib/FilecoinWarmStorageServiceStateLibrary.sol
+++ b/service_contracts/src/lib/FilecoinWarmStorageServiceStateLibrary.sol
@@ -293,12 +293,23 @@ library FilecoinWarmStorageServiceStateLibrary {
         returns (uint256)
     {
         uint256 deadline = provingDeadline(service, setId);
+        uint64 maxProvingPeriod = getMaxProvingPeriod(service);
+        uint256 challengeWindowSize = challengeWindow(service);
 
         if (deadline == NO_PROVING_DEADLINE) {
-            revert Errors.ProvingPeriodNotInitialized(setId);
-        }
+            uint256 activationEpoch = provingActivationEpoch(service, setId);
+            if (activationEpoch == 0) {
+                revert Errors.ProvingPeriodNotInitialized(setId);
+            }
 
-        uint64 maxProvingPeriod = getMaxProvingPeriod(service);
+            // Leave one full proving period for PDP challenge finality and transaction
+            // inclusion, then align the window to the dataset's lifetime period origin.
+            uint256 minimumDeadline = block.number + maxProvingPeriod;
+            uint256 periodsFromActivation =
+                (minimumDeadline - activationEpoch + maxProvingPeriod - 1) / maxProvingPeriod;
+            deadline = activationEpoch + periodsFromActivation * maxProvingPeriod;
+            return deadline - challengeWindowSize;
+        }
 
         // If the current period is open this is the next period's challenge window
         if (block.number <= deadline) {

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -6221,6 +6221,72 @@ contract ValidatePaymentTest is FilecoinWarmStorageServiceTest {
         );
     }
 
+    function testEmptyDataset_ReactivationRejectsFarFutureChallengeEpoch() public {
+        uint256 dataSetId = createDataSetForServiceProviderTest(sp1, client, "Reactivated");
+        Cids.Cid[] memory pieceData = new Cids.Cid[](1);
+        pieceData[0] = Cids.CommPv2FromDigest(0, 35, keccak256("original-piece"));
+        uint256 leafCount = Cids.leafCount(0, 35);
+
+        makeSignaturePass(client);
+        mockPDPVerifier.addPieces(
+            pdpServiceWithPayments,
+            dataSetId,
+            0,
+            pieceData,
+            nextClientDataSetId++,
+            FAKE_SIGNATURE,
+            new string[](0),
+            new string[](0)
+        );
+
+        (uint64 maxProvingPeriod, uint256 challengeWindow,,) = viewContract.getPDPConfig();
+        uint256 firstDeadline = block.number + maxProvingPeriod;
+        mockPDPVerifier.nextProvingPeriod(pdpServiceWithPayments, dataSetId, firstDeadline, leafCount, "");
+
+        vm.roll(firstDeadline - (challengeWindow / 2));
+        vm.prank(address(mockPDPVerifier));
+        pdpServiceWithPayments.possessionProven(dataSetId, leafCount, 12345, CHALLENGES_PER_PROOF);
+
+        uint256[] memory pieceIds = new uint256[](1);
+        pieceIds[0] = 0;
+        makeSignaturePass(client);
+        mockPDPVerifier.piecesScheduledRemove(
+            dataSetId, pieceIds, address(pdpServiceWithPayments), abi.encode(FAKE_SIGNATURE)
+        );
+        mockPDPVerifier.nextProvingPeriod(pdpServiceWithPayments, dataSetId, 0, 0, "");
+        mockPDPVerifier.setDataSetLeafCount(dataSetId, 0);
+
+        pieceData[0] = Cids.CommPv2FromDigest(0, 35, keccak256("reactivated-piece"));
+        makeSignaturePass(client);
+        mockPDPVerifier.addPieces(
+            pdpServiceWithPayments,
+            dataSetId,
+            1,
+            pieceData,
+            nextClientDataSetId++,
+            FAKE_SIGNATURE,
+            new string[](0),
+            new string[](0)
+        );
+
+        uint256 firstAllowedDeadline = firstDeadline + maxProvingPeriod;
+        uint256 firstAllowedWindowStart = firstAllowedDeadline - challengeWindow;
+
+        // A challengeEpoch landing in the period *after* the earliest allowed one must still be
+        // rejected -- the SP cannot defer resumed proving by picking a later canonical period.
+        uint256 farFutureChallengeEpoch = firstAllowedDeadline + maxProvingPeriod - (challengeWindow / 2);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.InvalidChallengeEpoch.selector,
+                dataSetId,
+                firstAllowedWindowStart,
+                firstAllowedDeadline,
+                farFutureChallengeEpoch
+            )
+        );
+        mockPDPVerifier.nextProvingPeriod(pdpServiceWithPayments, dataSetId, farFutureChallengeEpoch, leafCount, "");
+    }
+
     /**
      * @notice Test: Request range before activation - should advance without payment
      */

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -6016,6 +6016,211 @@ contract ValidatePaymentTest is FilecoinWarmStorageServiceTest {
         assertEq(result.modifiedAmount, 0, "No payment to SP for empty period after all pieces removed");
     }
 
+    function testEmptyDataset_ReactivationPreservesProvingTimeline() public {
+        uint256 dataSetId = createDataSetForServiceProviderTest(sp1, client, "Reactivated");
+        Cids.Cid[] memory pieceData = new Cids.Cid[](1);
+        pieceData[0] = Cids.CommPv2FromDigest(0, 35, keccak256("original-piece"));
+        uint256 leafCount = Cids.leafCount(0, 35);
+
+        makeSignaturePass(client);
+        mockPDPVerifier.addPieces(
+            pdpServiceWithPayments,
+            dataSetId,
+            0,
+            pieceData,
+            nextClientDataSetId++,
+            FAKE_SIGNATURE,
+            new string[](0),
+            new string[](0)
+        );
+
+        (uint64 maxProvingPeriod, uint256 challengeWindow,,) = viewContract.getPDPConfig();
+        uint256 firstDeadline = block.number + maxProvingPeriod;
+        mockPDPVerifier.nextProvingPeriod(pdpServiceWithPayments, dataSetId, firstDeadline, leafCount, "");
+        uint256 activationEpoch = vm.getBlockNumber();
+
+        vm.roll(firstDeadline - (challengeWindow / 2));
+        vm.prank(address(mockPDPVerifier));
+        pdpServiceWithPayments.possessionProven(dataSetId, leafCount, 12345, CHALLENGES_PER_PROOF);
+
+        uint256[] memory pieceIds = new uint256[](1);
+        pieceIds[0] = 0;
+        makeSignaturePass(client);
+        mockPDPVerifier.piecesScheduledRemove(
+            dataSetId, pieceIds, address(pdpServiceWithPayments), abi.encode(FAKE_SIGNATURE)
+        );
+
+        vm.roll(firstDeadline + 1);
+        mockPDPVerifier.nextProvingPeriod(pdpServiceWithPayments, dataSetId, 0, 0, "");
+        mockPDPVerifier.setDataSetLeafCount(dataSetId, 0);
+
+        assertEq(viewContract.provingDeadline(dataSetId), 0, "Empty dataset should suspend proving");
+        assertEq(
+            viewContract.provingActivationEpoch(dataSetId),
+            activationEpoch,
+            "Empty dataset should retain its activation epoch"
+        );
+
+        vm.roll(activationEpoch + maxProvingPeriod * 3 + (maxProvingPeriod / 2));
+        pieceData[0] = Cids.CommPv2FromDigest(0, 35, keccak256("reactivated-piece"));
+        makeSignaturePass(client);
+        mockPDPVerifier.addPieces(
+            pdpServiceWithPayments,
+            dataSetId,
+            1,
+            pieceData,
+            nextClientDataSetId++,
+            FAKE_SIGNATURE,
+            new string[](0),
+            new string[](0)
+        );
+        uint256 additionEpoch = vm.getBlockNumber();
+
+        uint256 challengeWindowStart = viewContract.nextPDPChallengeWindowStart(dataSetId);
+        uint256 reactivationDeadline = challengeWindowStart + challengeWindow;
+        uint256 challengeEpoch = challengeWindowStart + (challengeWindow / 2);
+        assertEq(
+            (reactivationDeadline - activationEpoch) % maxProvingPeriod,
+            0,
+            "Reactivation deadline should remain aligned to original activation"
+        );
+        assertGe(
+            challengeEpoch - additionEpoch,
+            maxProvingPeriod - (challengeWindow / 2),
+            "Challenge should retain finality headroom"
+        );
+        assertLt(
+            challengeEpoch - additionEpoch, maxProvingPeriod * 2, "Challenge should remain within two proving periods"
+        );
+
+        mockPDPVerifier.nextProvingPeriod(pdpServiceWithPayments, dataSetId, challengeEpoch, leafCount, "");
+
+        assertEq(
+            viewContract.provingActivationEpoch(dataSetId),
+            activationEpoch,
+            "Reactivation should preserve the original activation epoch"
+        );
+        assertEq(
+            viewContract.provingDeadline(dataSetId),
+            reactivationDeadline,
+            "Callback should accept the deadline returned by the state view"
+        );
+        assertTrue(viewContract.provenPeriods(dataSetId, 0), "Original proven period should remain recorded");
+
+        uint256 reactivationPeriod = pdpServiceWithPayments.getProvingPeriodForEpoch(dataSetId, challengeEpoch);
+        assertFalse(
+            viewContract.provenPeriods(dataSetId, reactivationPeriod),
+            "Reactivated period should not inherit an old proof bit"
+        );
+
+        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
+        (uint256 oldSettlementAmount,,,, uint256 oldSettlementEpoch,) =
+            payments.settleRail(info.pdpRailId, firstDeadline);
+        assertGt(oldSettlementAmount, 0, "Original proven period should remain payable");
+        assertEq(oldSettlementEpoch, firstDeadline, "Original period should settle after reactivation");
+
+        vm.roll(challengeEpoch);
+        vm.prank(address(mockPDPVerifier));
+        pdpServiceWithPayments.possessionProven(dataSetId, leafCount, 67890, CHALLENGES_PER_PROOF);
+        assertTrue(
+            viewContract.provenPeriods(dataSetId, reactivationPeriod),
+            "Reactivated proof should use its canonical period ID"
+        );
+
+        uint256 reactivationPeriodStart = reactivationDeadline - maxProvingPeriod;
+        uint256 requestedEpochs = challengeEpoch - additionEpoch;
+        uint256 provenEpochs = challengeEpoch - reactivationPeriodStart;
+        uint256 proposedAmount = requestedEpochs * 1e6;
+        vm.prank(address(payments));
+        IValidator.ValidationResult memory result =
+            pdpServiceWithPayments.validatePayment(info.pdpRailId, proposedAmount, additionEpoch, challengeEpoch, 0);
+        assertEq(
+            result.modifiedAmount,
+            provenEpochs * 1e6,
+            "Payment should cover only the proven canonical portion after reactivation"
+        );
+        assertEq(result.settleUpto, challengeEpoch, "Proven reactivation period should settle normally");
+    }
+
+    function testEmptyDataset_ReactivationRejectsPreviouslyProvenPeriod() public {
+        uint256 dataSetId = createDataSetForServiceProviderTest(sp1, client, "Reactivated");
+        Cids.Cid[] memory pieceData = new Cids.Cid[](1);
+        pieceData[0] = Cids.CommPv2FromDigest(0, 35, keccak256("original-piece"));
+        uint256 leafCount = Cids.leafCount(0, 35);
+
+        makeSignaturePass(client);
+        mockPDPVerifier.addPieces(
+            pdpServiceWithPayments,
+            dataSetId,
+            0,
+            pieceData,
+            nextClientDataSetId++,
+            FAKE_SIGNATURE,
+            new string[](0),
+            new string[](0)
+        );
+
+        (uint64 maxProvingPeriod, uint256 challengeWindow,,) = viewContract.getPDPConfig();
+        uint256 firstDeadline = block.number + maxProvingPeriod;
+        mockPDPVerifier.nextProvingPeriod(pdpServiceWithPayments, dataSetId, firstDeadline, leafCount, "");
+
+        vm.roll(firstDeadline - (challengeWindow / 2));
+        vm.prank(address(mockPDPVerifier));
+        pdpServiceWithPayments.possessionProven(dataSetId, leafCount, 12345, CHALLENGES_PER_PROOF);
+
+        uint256[] memory pieceIds = new uint256[](1);
+        pieceIds[0] = 0;
+        makeSignaturePass(client);
+        mockPDPVerifier.piecesScheduledRemove(
+            dataSetId, pieceIds, address(pdpServiceWithPayments), abi.encode(FAKE_SIGNATURE)
+        );
+        mockPDPVerifier.nextProvingPeriod(pdpServiceWithPayments, dataSetId, 0, 0, "");
+        mockPDPVerifier.setDataSetLeafCount(dataSetId, 0);
+
+        pieceData[0] = Cids.CommPv2FromDigest(0, 35, keccak256("reactivated-piece"));
+        makeSignaturePass(client);
+        mockPDPVerifier.addPieces(
+            pdpServiceWithPayments,
+            dataSetId,
+            1,
+            pieceData,
+            nextClientDataSetId++,
+            FAKE_SIGNATURE,
+            new string[](0),
+            new string[](0)
+        );
+
+        uint256 firstAllowedDeadline = firstDeadline + maxProvingPeriod;
+        uint256 firstAllowedWindowStart = firstAllowedDeadline - challengeWindow;
+        assertEq(
+            viewContract.nextPDPChallengeWindowStart(dataSetId),
+            firstAllowedWindowStart,
+            "State view should skip the previously proven period"
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.InvalidChallengeEpoch.selector,
+                dataSetId,
+                firstAllowedWindowStart,
+                firstAllowedDeadline,
+                firstDeadline
+            )
+        );
+        mockPDPVerifier.nextProvingPeriod(pdpServiceWithPayments, dataSetId, firstDeadline, leafCount, "");
+
+        uint256 challengeEpoch = firstAllowedWindowStart + (challengeWindow / 2);
+        mockPDPVerifier.nextProvingPeriod(pdpServiceWithPayments, dataSetId, challengeEpoch, leafCount, "");
+
+        assertTrue(viewContract.provenPeriods(dataSetId, 0), "Original period should remain proven");
+        assertFalse(viewContract.provenPeriods(dataSetId, 1), "Reactivated period should require a new proof");
+        assertEq(
+            viewContract.provingDeadline(dataSetId),
+            firstAllowedDeadline,
+            "Reactivation should resume at the first safe deadline"
+        );
+    }
+
     /**
      * @notice Test: Request range before activation - should advance without payment
      */

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -6017,34 +6017,28 @@ contract ValidatePaymentTest is FilecoinWarmStorageServiceTest {
     }
 
     /**
-     * @notice Test: Request range before activation - should pay nothing
+     * @notice Test: Request range before activation - should advance without payment
      */
-    function testValidatePayment_BeforeActivation() public {
+    function testValidatePayment_BeforeActivationSettlesWithZeroPayment() public {
         uint256 dataSetId = createDataSetForServiceProviderTest(sp1, client, "Test");
 
-        // Move forward to create some block height
         vm.roll(block.number + 1000);
 
-        // Start proving
         (uint64 maxProvingPeriod, uint256 challengeWindow,,) = viewContract.getPDPConfig();
         uint256 challengeEpoch = block.number + maxProvingPeriod - (challengeWindow / 2);
-
         mockPDPVerifier.nextProvingPeriod(pdpServiceWithPayments, dataSetId, challengeEpoch, 100, "");
 
         uint256 activationEpoch = vm.getBlockNumber();
-
-        // Try to validate for epochs before activation
         FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
         uint256 fromEpoch = activationEpoch - 500;
         uint256 toEpoch = activationEpoch - 100;
-        uint256 proposedAmount = 1000e6;
 
         vm.prank(address(payments));
-        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidEpochRange.selector, fromEpoch, toEpoch));
         IValidator.ValidationResult memory result =
-            pdpServiceWithPayments.validatePayment(info.pdpRailId, proposedAmount, fromEpoch, toEpoch, 0);
+            pdpServiceWithPayments.validatePayment(info.pdpRailId, 1000e6, fromEpoch, toEpoch, 0);
 
-        assertEq(result.modifiedAmount, 0, "Should pay nothing for pre-activation epochs");
+        assertEq(result.modifiedAmount, 0, "Pre-activation epochs should not be payable");
+        assertEq(result.settleUpto, toEpoch, "Settlement should consume the pre-activation range");
     }
 
     function testValidatePayment_ActivationBoundarySettlesWithZeroPayment() public {
@@ -6066,7 +6060,7 @@ contract ValidatePaymentTest is FilecoinWarmStorageServiceTest {
 
         assertEq(result.modifiedAmount, 0, "Activation boundary should not be payable");
         assertEq(result.settleUpto, activationEpoch, "Should settle to activation boundary");
-        assertEq(result.note, "No proven epochs in the requested range");
+        assertEq(result.note, "No proving activity");
     }
 
     function testSettleRail_EndEpochAtActivationBoundaryFinalizes() public {
@@ -6120,6 +6114,62 @@ contract ValidatePaymentTest is FilecoinWarmStorageServiceTest {
         vm.prank(sp1);
         mockPDPVerifier.deleteDataSet(pdpServiceWithPayments, dataSetId, "");
         assertEq(viewContract.getDataSet(dataSetId).pdpRailId, 0, "Dataset should be deleted after finalization");
+    }
+
+    function testSettleRail_MultiplePreActivationRateSegmentsSettleWithZeroPayment() public {
+        uint256 dataSetId = createDataSetForServiceProviderTest(sp1, client, "Test");
+
+        Cids.Cid[] memory pieceData = new Cids.Cid[](1);
+        pieceData[0] = Cids.CommPv2FromDigest(0, 35, keccak256("first-pre-activation-piece"));
+        uint256 leafCount = Cids.leafCount(0, 35);
+
+        makeSignaturePass(client);
+        mockPDPVerifier.addPieces(
+            pdpServiceWithPayments,
+            dataSetId,
+            0,
+            pieceData,
+            nextClientDataSetId++,
+            FAKE_SIGNATURE,
+            new string[](0),
+            new string[](0)
+        );
+
+        vm.roll(block.number + 3);
+        pieceData[0] = Cids.CommPv2FromDigest(0, 35, keccak256("second-pre-activation-piece"));
+        makeSignaturePass(client);
+        mockPDPVerifier.addPieces(
+            pdpServiceWithPayments,
+            dataSetId,
+            1,
+            pieceData,
+            nextClientDataSetId++,
+            FAKE_SIGNATURE,
+            new string[](0),
+            new string[](0)
+        );
+
+        FilecoinWarmStorageService.DataSetInfoView memory info = viewContract.getDataSet(dataSetId);
+        FilecoinPayV1.RailView memory railBeforeActivation = payments.getRail(info.pdpRailId);
+        assertLt(
+            railBeforeActivation.settledUpTo, block.number, "Second addition should leave a pre-activation rate segment"
+        );
+
+        (uint64 maxProvingPeriod, uint256 challengeWindow,,) = viewContract.getPDPConfig();
+        vm.roll(block.number + 3);
+        uint256 challengeEpoch = block.number + maxProvingPeriod - (challengeWindow / 2);
+        mockPDPVerifier.nextProvingPeriod(pdpServiceWithPayments, dataSetId, challengeEpoch, leafCount * 2, "");
+
+        uint256 activationEpoch = vm.getBlockNumber();
+        (uint256 settledAmount,,,, uint256 finalEpoch,) = payments.settleRail(info.pdpRailId, activationEpoch);
+
+        assertEq(settledAmount, 0, "Pre-activation rate segments should not be payable");
+        assertEq(finalEpoch, activationEpoch, "Settlement should consume every pre-activation rate segment");
+        assertEq(
+            payments.getRail(info.pdpRailId).settledUpTo,
+            activationEpoch,
+            "Rail should be settled to the activation boundary"
+        );
     }
 
     /**


### PR DESCRIPTION
This follows on from https://github.com/FilOzone/filecoin-services/pull/545 and arose while reviewing the complexity Curio currently needs to handle pre-activation settlement in https://github.com/filecoin-project/curio/pull/1346. Most of that complexity should become unnecessary once this is deployed.

There is also a latent reactivation bug whose payment consequences are made worse by the first fix, so the second commit addresses that as part of the same activation-epoch model.

1. The first commit deals with pre-activation settlement: Data set activation (the first `nextProvingPeriod()` call) typically follows rate change activity, notably piece additions (combined create+add is the norm). So likely we've already adjusted the rate on the PDP rail. Filecoin Pay can therefore present FWSS with rate segments that end before activation, which FWSS previously could not validate cleanly. A client may also terminate before the SP calls `nextProvingPeriod()`, further exposing this case. From a billing perspective, streaming payment should not begin until the SP signals that proving has started. Ranges ending at or before the activation epoch shoudl settle with zero payment. Ranges _crossing_ activation exclude the pre-activation portion and validate the remainder normally. So, we clearly say that streaming payment eligibility begins at `activationEpoch + 1` and remains proof-dependent. This generalises the fix from https://github.com/FilOzone/filecoin-services/pull/545.
2. The second commit deals with the latent reactivation bug: When all pieces are removed, the data set becomes inactive by setting `provingDeadlines[dataSetId] = 0`, but its proof bitmap and payment history remain. Previously, the first `nextProvingPeriod()` after pieces were re-added overwrote `provingActivationEpoch` with the current block, rebasing the proving timeline and restarting period numbering from zero. This can make legitimate historical settlement fail with `InvalidEpochRange`. With the first commit, those historical epochs could instead be misclassified as pre-activation and settled with zero payment. Restarting period numbering could also allow aliasing of retained proof bits (!), making a reactivated period appear proven before the newly added pieces have been proved. The fix treats `provingActivationEpoch` as the immutable lifetime origin and uses `provingDeadlines == 0` only to represent temporary proving suspension. "Reactivation" must resume on a fresh proving period aligned with the original timeline. `nextPDPChallengeWindowStart()` now supplies that aligned future window, which Curio should use for reactivation once this contract version is deployed.

Clear as mud?