### PR TITLE
fix: bound reactivation challenge epoch

### DIFF
--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -929,7 +929,7 @@ contract FilecoinWarmStorageService is
                 firstDeadline = activationEpoch + maxProvingPeriod;
             } else {
                 // Reactivation resumes the original timeline, pinned to the earliest deadline with a full
-                // period of headroom (not challengeEpoch's period), keeping the window one period wide.
+                // period of headroom, keeping the window one period wide.
                 require(
                     challengeEpoch > activationEpoch,
                     Errors.InvalidChallengeEpoch(

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -928,26 +928,17 @@ contract FilecoinWarmStorageService is
                 activationEpoch = block.number;
                 firstDeadline = activationEpoch + maxProvingPeriod;
             } else {
-                // Reactivation resumes the original proving-period timeline. The PDPVerifier
-                // guarantees a future challenge epoch; derive its canonical deadline without
-                // rebasing payment history or proven-period IDs.
+                // Reactivation resumes the original timeline, pinned to the earliest deadline with a full
+                // period of headroom (not challengeEpoch's period), keeping the window one period wide.
                 require(
                     challengeEpoch > activationEpoch,
                     Errors.InvalidChallengeEpoch(
                         dataSetId, activationEpoch + 1, activationEpoch + maxProvingPeriod, challengeEpoch
                     )
                 );
-                uint256 period = _provingPeriodForEpoch(activationEpoch, challengeEpoch, maxProvingPeriod);
+                uint256 minimumDeadline = block.number + maxProvingPeriod;
+                uint256 period = _provingPeriodForEpoch(activationEpoch, minimumDeadline, maxProvingPeriod);
                 firstDeadline = _calcPeriodDeadline(activationEpoch, period);
-                if (firstDeadline < block.number + maxProvingPeriod) {
-                    uint256 minimumDeadline = block.number + maxProvingPeriod;
-                    uint256 periodsFromActivation =
-                        (minimumDeadline - activationEpoch + maxProvingPeriod - 1) / maxProvingPeriod;
-                    uint256 firstAllowedDeadline = activationEpoch + periodsFromActivation * maxProvingPeriod;
-                    revert Errors.InvalidChallengeEpoch(
-                        dataSetId, firstAllowedDeadline - challengeWindowSize, firstAllowedDeadline, challengeEpoch
-                    );
-                }
             }
 
             uint256 minWindow = firstDeadline - challengeWindowSize;

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -6221,6 +6221,72 @@ contract ValidatePaymentTest is FilecoinWarmStorageServiceTest {
         );
     }
 
+    function testEmptyDataset_ReactivationRejectsFarFutureChallengeEpoch() public {
+        uint256 dataSetId = createDataSetForServiceProviderTest(sp1, client, "Reactivated");
+        Cids.Cid[] memory pieceData = new Cids.Cid[](1);
+        pieceData[0] = Cids.CommPv2FromDigest(0, 35, keccak256("original-piece"));
+        uint256 leafCount = Cids.leafCount(0, 35);
+
+        makeSignaturePass(client);
+        mockPDPVerifier.addPieces(
+            pdpServiceWithPayments,
+            dataSetId,
+            0,
+            pieceData,
+            nextClientDataSetId++,
+            FAKE_SIGNATURE,
+            new string[](0),
+            new string[](0)
+        );
+
+        (uint64 maxProvingPeriod, uint256 challengeWindow,,) = viewContract.getPDPConfig();
+        uint256 firstDeadline = block.number + maxProvingPeriod;
+        mockPDPVerifier.nextProvingPeriod(pdpServiceWithPayments, dataSetId, firstDeadline, leafCount, "");
+
+        vm.roll(firstDeadline - (challengeWindow / 2));
+        vm.prank(address(mockPDPVerifier));
+        pdpServiceWithPayments.possessionProven(dataSetId, leafCount, 12345, CHALLENGES_PER_PROOF);
+
+        uint256[] memory pieceIds = new uint256[](1);
+        pieceIds[0] = 0;
+        makeSignaturePass(client);
+        mockPDPVerifier.piecesScheduledRemove(
+            dataSetId, pieceIds, address(pdpServiceWithPayments), abi.encode(FAKE_SIGNATURE)
+        );
+        mockPDPVerifier.nextProvingPeriod(pdpServiceWithPayments, dataSetId, 0, 0, "");
+        mockPDPVerifier.setDataSetLeafCount(dataSetId, 0);
+
+        pieceData[0] = Cids.CommPv2FromDigest(0, 35, keccak256("reactivated-piece"));
+        makeSignaturePass(client);
+        mockPDPVerifier.addPieces(
+            pdpServiceWithPayments,
+            dataSetId,
+            1,
+            pieceData,
+            nextClientDataSetId++,
+            FAKE_SIGNATURE,
+            new string[](0),
+            new string[](0)
+        );
+
+        uint256 firstAllowedDeadline = firstDeadline + maxProvingPeriod;
+        uint256 firstAllowedWindowStart = firstAllowedDeadline - challengeWindow;
+
+        // A challengeEpoch landing in the period *after* the earliest allowed one must still be
+        // rejected -- the SP cannot defer resumed proving by picking a later canonical period.
+        uint256 farFutureChallengeEpoch = firstAllowedDeadline + maxProvingPeriod - (challengeWindow / 2);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.InvalidChallengeEpoch.selector,
+                dataSetId,
+                firstAllowedWindowStart,
+                firstAllowedDeadline,
+                farFutureChallengeEpoch
+            )
+        );
+        mockPDPVerifier.nextProvingPeriod(pdpServiceWithPayments, dataSetId, farFutureChallengeEpoch, leafCount, "");
+    }
+
     /**
      * @notice Test: Request range before activation - should advance without payment
      */


### PR DESCRIPTION

Reviewer @rvagg
Fixes [unbounded `challengeEpoch`](https://github.com/FilOzone/filecoin-services/pull/552/changes#r3573821198)
#### Changes
* calculate `firstDeadline` from `minimumDeadline` instead of `challengeEpoch`