### PR TITLE
feat: add homepage to service metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The complete on-chain price catalogue is exposed via `FilecoinWarmStorageService
 
 ## Service metadata
 
-FilecoinWarmStorageService implements `IFilecoinServiceMetadata`, exposing a `name()` and `description()` for `eth_call`. Other FOC services are encouraged to use this interface so explorers and clients can identify service operator contracts without hard-coded address maps. Consumers should note that this output should be treated as untrusted data and should only ever be presented to users in carefully escaped form.
+FilecoinWarmStorageService implements `IFilecoinServiceMetadata`, exposing `name()`, `description()`, and `homepage()` for `eth_call`. Other FOC services are encouraged to use this interface so explorers and clients can identify service operator contracts without hard-coded address maps. `description()` is capped at 256 bytes and should be treated as untrusted display-only text. `homepage()` is an optional URL, capped at 256 bytes, and returns an empty string when not provided. Consumers should validate metadata from unverified contracts and carefully escape all displayed values.
 
 ## 🚀 Quick Start
 
@@ -148,4 +148,3 @@ See [service_contracts/CONTRIBUTING.md](./service_contracts/CONTRIBUTING.md) for
 
 ## 📄 License
 Dual-licensed under [MIT](https://github.com/FilOzone/filecoin-services/blob/main/LICENSE.md) + [Apache 2.0](https://github.com/FilOzone/filecoin-services/blob/main/LICENSE.md)
-

--- a/service_contracts/README.md
+++ b/service_contracts/README.md
@@ -7,7 +7,7 @@ This directory contains the smart contracts for different Filecoin services usin
 - `src/` - Contract source files
   - `FilecoinWarmStorageService.sol` - A service contract with [PDP](https://github.com/FilOzone/pdp) (Proof of Data Possession) and payment integration
   - `FilecoinWarmStorageServiceStateView.sol` - View contract for reading `FilecoinWarmStorageService` with `eth_call`.
-  - `IFilecoinServiceMetadata.sol` - Minimal service identity interface (`name`, `description`)
+  - `IFilecoinServiceMetadata.sol` - Minimal service identity interface (`name`, `description`, `homepage`)
   - `src/lib` - Library source files
     - `FilecoinWarmStorageServiceLayout.sol` - Constants conveying the storage layout of `FilecoinWarmStorageService`
     - `FilecoinWarmStorageServiceStateInternalLibrary.sol` - `internal` library for embedding logic to read `FilecoinWarmStorageService`

--- a/service_contracts/abi/FilecoinWarmStorageService.abi.json
+++ b/service_contracts/abi/FilecoinWarmStorageService.abi.json
@@ -369,6 +369,19 @@
   },
   {
     "type": "function",
+    "name": "homepage",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
     "name": "initialize",
     "inputs": [
       {

--- a/service_contracts/abi/IFilecoinServiceMetadata.abi.json
+++ b/service_contracts/abi/IFilecoinServiceMetadata.abi.json
@@ -14,6 +14,19 @@
   },
   {
     "type": "function",
+    "name": "homepage",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "name",
     "inputs": [],
     "outputs": [

--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -84,6 +84,7 @@ contract FilecoinWarmStorageService is
     string private constant SERVICE_NAME = "Filecoin Warm Storage Service";
     string private constant SERVICE_DESCRIPTION =
         "Warm storage service for the Filecoin Onchain Cloud. Manages PDP-backed datasets, Filecoin Pay storage rails, lifecycle fees, and optional CDN payment rails.";
+    string private constant SERVICE_HOMEPAGE = "https://github.com/FilOzone/filecoin-services";
 
     using Rails for FilecoinPayV1;
 
@@ -402,6 +403,10 @@ contract FilecoinWarmStorageService is
 
     function description() external pure override returns (string memory) {
         return SERVICE_DESCRIPTION;
+    }
+
+    function homepage() external pure override returns (string memory) {
+        return SERVICE_HOMEPAGE;
     }
 
     function announcePlannedUpgrade(PlannedUpgrade calldata plannedUpgrade) external onlyOwner {

--- a/service_contracts/src/IFilecoinServiceMetadata.sol
+++ b/service_contracts/src/IFilecoinServiceMetadata.sol
@@ -4,9 +4,16 @@ pragma solidity ^0.8.20;
 /// @title IFilecoinServiceMetadata
 /// @notice Minimal service identity interface for Filecoin Onchain Cloud service contracts.
 interface IFilecoinServiceMetadata {
-    /// @notice Human-readable service name.
+    /// @notice Short, human-readable service name.
     function name() external view returns (string memory);
 
-    /// @notice Human-readable service description.
+    /// @notice Concise, human-readable service description.
+    /// @dev Implementations must limit the UTF-8 encoded value to 256 bytes.
+    ///      Consumers should treat the value as untrusted display-only text.
     function description() external view returns (string memory);
+
+    /// @notice Optional URL for service documentation, specifications, or source code.
+    /// @dev Implementations must limit the UTF-8 encoded value to 256 bytes and
+    ///      return an empty string when no homepage is provided.
+    function homepage() external view returns (string memory);
 }

--- a/service_contracts/test/FilecoinWarmStorageService.t.sol
+++ b/service_contracts/test/FilecoinWarmStorageService.t.sol
@@ -337,6 +337,7 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
         IFilecoinServiceMetadata metadata = IFilecoinServiceMetadata(address(pdpServiceWithPayments));
         string memory serviceName = metadata.name();
         string memory serviceDescription = metadata.description();
+        string memory serviceHomepage = metadata.homepage();
 
         assertEq(serviceName, "Filecoin Warm Storage Service", "Service name should match");
         assertEq(
@@ -344,6 +345,9 @@ contract FilecoinWarmStorageServiceTest is MockFVMTest {
             "Warm storage service for the Filecoin Onchain Cloud. Manages PDP-backed datasets, Filecoin Pay storage rails, lifecycle fees, and optional CDN payment rails.",
             "Service description should match"
         );
+        assertEq(serviceHomepage, "https://github.com/FilOzone/filecoin-services", "Service homepage should match");
+        assertLe(bytes(serviceDescription).length, 256, "Service description should not exceed 256 bytes");
+        assertLe(bytes(serviceHomepage).length, 256, "Service homepage should not exceed 256 bytes");
     }
 
     function testUpgrade() public {


### PR DESCRIPTION
## Summary

- add `homepage()` to `IFilecoinServiceMetadata`
- define the optional-field semantics as an empty string when no homepage is provided
- cap `description()` and `homepage()` at 256 UTF-8 bytes in the interface documentation
- expose the Filecoin Services repository as the FWSS homepage
- regenerate the interface and FWSS ABIs and update tests/documentation

## Context

This is a stacked follow-up to #551 and targets its head branch directly.

After chatting with Jennifer about the intended scope of the v1 Filecoin service metadata standard, the initial version should expose:

- `name()` — a short service label
- `description()` — a concise description, capped at approximately 256 bytes and treated as untrusted display-only text
- `homepage()` — an optional, size-capped URL for technical documentation, specifications, or the service repository
