### PR TITLE
feat: programmable ACLs support

### DIFF
--- a/service_contracts/src/FilecoinWarmStorageService.sol
+++ b/service_contracts/src/FilecoinWarmStorageService.sol
@@ -47,21 +47,24 @@ uint256 constant PDP_INACTIVITY_WINDOW = 86400;
 
 /*
 * Maximum extraData for createDataSet
-* Supports: 10 metadata entries with max sizes
+* Supports: 10 metadata entries with max sizes; plus
+*           1 Authorizer payload (perms + WebAuthn + P256 ~1024 bytes)
 */
-uint256 constant MAX_CREATE_DATA_SET_EXTRA_DATA_SIZE = 4096; // 4 KiB
+uint256 constant MAX_CREATE_DATA_SET_EXTRA_DATA_SIZE = 5120; // 5 KiB
 
 /*
 * Maximum extraData for schedulePieceRemovals
-* Supports: signature (160 bytes needed)
+* Supports: legacy signature (160 bytes needed); or
+*           1 Authorizer payload (perms + WebAuthn + P256 ~1024 bytes)
 */
-uint256 constant MAX_SCHEDULE_PIECE_REMOVALS_EXTRA_DATA_SIZE = 256; // 256 bytes
+uint256 constant MAX_SCHEDULE_PIECE_REMOVALS_EXTRA_DATA_SIZE = 1024; // 1KiB
 
 /*
 * Maximum extraData for terminateService
-* Supports: signature (160 bytes needed)
+* Supports: legacy signature (160 bytes needed); or
+*           1 Authorizer payload (perms + WebAuthn + P256 ~512 bytes)
 */
-uint256 constant MAX_TERMINATE_SERVICE_EXTRA_DATA_SIZE = 256; // 256 bytes
+uint256 constant MAX_TERMINATE_SERVICE_EXTRA_DATA_SIZE = 1024; // 1KiB
 
 /// @title FilecoinWarmStorageService
 /// @notice An implementation of PDP Listener with payment integration.


### PR DESCRIPTION
Bump up extradata sizes to accommodate ACL payloads.

ONLY NEEDED IF #536 MERGES!

Rationale: we already know that passkeys and WebAuthn are targets for identified service users. WebAuthn envelope with P256 on its own is around 700 bytes so rounding up to a KiB gives space for usable payload without going overboard.

For TerminateService and SchedulePieceRemovals we just set the limit to 1KiB as the only thing that was in there before was a legacy signature, and we make it either/or. For AddPieces we _increase_ by 1KiB so as not to reduce the total capacity for the metadata that's also carried in there. I guess in principle we could take 160b off this to remove the previous SKR entry but I'm not sure how worthwhile that is with an already large structure.

Note that a companion PR is needed in Curio for TerminateService because Curio checks size before even trying the contract. I'll get that in next.