### PR TITLE
chore: add PiecesScheduledForRemoval to PDPVerifier ABI

### DIFF
--- a/service_contracts/abi/PDPVerifier.abi.json
+++ b/service_contracts/abi/PDPVerifier.abi.json
@@ -1252,7 +1252,7 @@
   },
   {
     "type": "event",
-    "name": "PiecesScheduledForRemoval",
+    "name": "PiecesRemoved",
     "inputs": [
       {
         "name": "setId",
@@ -1271,7 +1271,7 @@
   },
   {
     "type": "event",
-    "name": "PiecesRemoved",
+    "name": "PiecesScheduledForRemoval",
     "inputs": [
       {
         "name": "setId",

--- a/service_contracts/abi/PDPVerifier.abi.json
+++ b/service_contracts/abi/PDPVerifier.abi.json
@@ -1252,6 +1252,25 @@
   },
   {
     "type": "event",
+    "name": "PiecesScheduledForRemoval",
+    "inputs": [
+      {
+        "name": "setId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "pieceIds",
+        "type": "uint256[]",
+        "indexed": false,
+        "internalType": "uint256[]"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "PiecesRemoved",
     "inputs": [
       {


### PR DESCRIPTION
## Summary
- Add `PiecesScheduledForRemoval(uint256 indexed setId, uint256[] pieceIds)` to the checked-in `PDPVerifier` ABI so consumers can decode the event from FilOzone/pdp#287.

## Notes
- Generated to match the existing `PiecesRemoved` fragment shape (same args).
- **Depends on** FilOzone/pdp#287 merging first. After that lands, the `service_contracts/lib/pdp` submodule should be bumped to the merge commit and `make -C service_contracts update-abi` re-run so `check-abi` stays green against source.

## Test plan
- [ ] Confirm event fragment present in `service_contracts/abi/PDPVerifier.abi.json`
- [x] After pdp#287 merge: bump submodule + `make update-abi` + `check-abi` CI green