### PR TITLE
fix: report drift for pinned deployments

### DIFF
--- a/.github/workflows/deploy-contract.yml
+++ b/.github/workflows/deploy-contract.yml
@@ -188,7 +188,7 @@ jobs:
               echo "### Deployment Plan"
               echo ""
               echo '```text'
-              grep -E "Initializer counters|Next implementation counters|initcode changed|constructor args changed|Deploying |Would deploy|Up to date|Pinned/preserved|Using existing|requires a separate Safe" \
+              grep -E "Initializer counters|Next implementation counters|initcode changed|constructor args changed|deployment metadata missing|candidate artifact unavailable|library .* bytecode changed|Deploying |Would deploy|Up to date|Pinned/preserved|Using existing|requires a separate Safe" \
                 "$RUNNER_TEMP/deploy-output.txt" || echo "No deployment decisions found in output"
               echo '```'
             fi

--- a/service_contracts/tools/UPGRADE-CHECKLIST.md
+++ b/service_contracts/tools/UPGRADE-CHECKLIST.md
@@ -88,7 +88,7 @@ Check every pre-seeded row and list each required cross-repo change or release. 
 
 ### Dependency Targets and Compatibility
 
-Record the intended deployed dependency versions or addresses, then verify actual deployed state against those targets before go/no-go.
+Populate this table while reviewing the Phase 1 deployment inventory. The dry-run supplies the observed addresses and pinned deployment-metadata comparison; the technical owner records the compatibility disposition for every changed pinned component before approving the inventory.
 
 | Dependency | Target version/address | Calibnet observed | Mainnet observed | Verification/status |
 |---|---|---|---|---|
@@ -212,8 +212,12 @@ forge inspect src/FilecoinWarmStorageService.sol:FilecoinWarmStorageService stor
 - [ ] Create release branch from `main` after the release-prep PR(s) land (recommended: `{{RELEASE_BRANCH}}`). Use this branch as the stable ref for rendering the release issue and as the landing branch for rollout patches if `main` moves on.
 - [ ] Create the release issue by running the [Create Release Issue]({{CREATE_ISSUE_WORKFLOW_LINK}}) workflow from the release branch so the issue is rendered from that branch's checklist template
 - [ ] Name the technical owner, update the Overview, and confirm they own the written upgrade plan and go/no-go decision
+- [ ] Run and obtain technical-owner approval of the complete Phase 1 two-network deployment inventory:
+  - From the release candidate, run the [Deploy Contract workflow]({{DEPLOY_WORKFLOW_LINK}}) for both Calibnet and Mainnet with `contract=Warm Storage stack` and `dry_run=true`.
+  - Populate Dependency Targets and Compatibility from the results and review every `Would deploy`, `Up to date`, `Using existing`, and `Pinned/preserved` result.
+  - Add a pinned component with `candidate drift; explicit review required` to the rollout scope or explicitly approve it as compatible while preserved.
+  - Stop, correct the release ref or deployment metadata, and rerun both plans for any unapproved difference.
 - [ ] Fill Cross-Repo Impact with required PRs, issues, releases, or `None`
-- [ ] Fill Dependency Targets and Compatibility by comparing target versions/addresses with observed Calibnet and Mainnet deployed state
 - [ ] Fill Rollback Plan, including whether rollback is safe and the approved procedure/script link when available
 - [ ] Run foc-devnet post-upgrade state validation, or record the technical owner's approved exception
 - [ ] Freeze the deploy commit and record it in Release Tracking
@@ -274,8 +278,8 @@ gh release create {{RELEASE_VERSION}} \
 ### Phase 2: Deploy Contracts
 Deploy both networks before any announce/execute.
 
-- [ ] Run the metadata-aware deploy dry-run for each target network before live deployment and record every `Deploying`/`Would deploy` and `Pinned/preserved` decision in the Run Log. The reviewed release ref must encode scope through deployment metadata; do not pin or unpin components ad hoc during rollout.
-- [ ] Review and approve the complete dry-run inventory, then run the [Deploy Contract workflow]({{DEPLOY_WORKFLOW_LINK}}) once per network with `contract=Warm Storage stack` and `dry_run=false`. The metadata-aware stack run deploys every changed, unpinned component in nonce order; do not select components manually or run separate FWSS/SPR deployment paths.
+- [ ] Immediately before each live deployment, rerun the metadata-aware dry-run from the frozen release tag and confirm it exactly matches the Phase 1 approved inventory, including every pinned-drift disposition. Stop and return to scope review if it differs; do not change pins ad hoc during rollout.
+- [ ] Run the [Deploy Contract workflow]({{DEPLOY_WORKFLOW_LINK}}) once per network from the same frozen tag with `contract=Warm Storage stack` and `dry_run=false`. The metadata-aware stack run deploys every approved changed, unpinned component in nonce order; do not select components manually or run separate FWSS/SPR deployment paths.
 - [ ] Run `service_contracts/tools/verify-deployments.sh --chain <CHAIN>` for each target network after deployment metadata is available. Resolve or explicitly waive any bytecode/metadata mismatch before live announce.
 - [ ] If linked libraries or StateView are newly deployed, record their addresses, verification status, and ABI-publishing decision in the Run Log.
 
@@ -292,29 +296,25 @@ ETH_RPC_URL="https://api.node.glif.io/rpc/v1" \
   ./tools/verify-deployments.sh --chain 314
 ```
 
-Use the deploy dry-run output to distinguish contracts that are `Pinned/preserved`, `Up to date`, or `Would deploy`. Record the final deploy set before any live announce transaction.
+Use the deploy dry-run output to distinguish contracts that are `Pinned/preserved`, `Up to date`, or `Would deploy`. `Pinned/preserved` is a policy decision, not proof that candidate code is unchanged: the output reports whether the candidate matches recorded deployment metadata or requires explicit drift review. Record the approved deploy set and every preserve disposition before any live announce transaction.
 
 | Dry-run marks as needing deployment | Operator action |
 |---|---|
 | `SignatureVerificationLib`, `Rails`, or `FilecoinWarmStorageService` | The approved `contract=Warm Storage stack` live run deploys each changed, unpinned component automatically and records its address |
 | `ServiceProviderRegistry` | Only unpin in the reviewed release-prep PR when the release explicitly includes it; add an exception section to this issue, then let the approved `contract=Warm Storage stack` run deploy it |
-| `PDPVerifier`, `FilecoinPay`, `ProviderIdSet`, or `FilecoinWarmStorageServiceStateView` | Keep pinned in the reviewed release ref unless the release explicitly includes it and the technical owner approves the expanded scope before the live stack run |
+| `PDPVerifier`, `FilecoinPay`, `ProviderIdSet`, or `FilecoinWarmStorageServiceStateView` | If candidate metadata matches, keep pinned unless the release explicitly includes it. If candidate drift is reported, either expand the reviewed scope and unpin in the release ref or record the technical owner's compatibility approval for preserving the deployed version |
 | `SessionKeyRegistry` | Only deploy if explicitly included; use the dedicated `contract=SessionKeyRegistry` workflow option and add an exception section to this issue |
 
 </details>
 
 **Calibnet Warm Storage Stack**
-- [ ] Run [Deploy Contract workflow]({{DEPLOY_WORKFLOW_LINK}}) with `network=Calibnet`, `contract=Warm Storage stack`, `dry_run=true`
-- [ ] Confirm the inventory exactly matches the approved release scope; stop and resolve any unexpected deployment before broadcasting
-- [ ] Re-run with `dry_run=false`
+- [ ] Complete the frozen-tag Calibnet drift check above, then rerun the same workflow inputs with `dry_run=false`
 - [ ] Capture `CALI_NEW_IMPL`, plus `CALI_NEW_SPR_IMPL`, new library addresses, and `CALI_NEW_VIEW` when those components are in the approved inventory, and add them to the Run Log
 - [ ] Verify every newly deployed contract on Sourcify and Blockscout
 - [ ] Attempt FilFox verification and record result
 
 **Mainnet Warm Storage Stack**
-- [ ] Run [Deploy Contract workflow]({{DEPLOY_WORKFLOW_LINK}}) with `network=Mainnet`, `contract=Warm Storage stack`, `dry_run=true`
-- [ ] Confirm the inventory exactly matches the approved release scope; stop and resolve any unexpected deployment before broadcasting
-- [ ] Re-run with `dry_run=false`
+- [ ] Complete the frozen-tag Mainnet drift check above, then rerun the same workflow inputs with `dry_run=false`
 - [ ] Capture `MAIN_NEW_IMPL`, plus `MAIN_NEW_SPR_IMPL`, new library addresses, and `MAIN_NEW_VIEW` when those components are in the approved inventory, and add them to the Run Log
 - [ ] Verify every newly deployed contract on Sourcify and Blockscout
 - [ ] Attempt FilFox verification and record result

--- a/service_contracts/tools/deployments.sh
+++ b/service_contracts/tools/deployments.sh
@@ -276,17 +276,12 @@ _build_libs_json() {
     printf '%s' "$libs_json"
 }
 
-# Returns 0 (needs deployment) if stored metadata is absent or if initcode hash,
-# constructor args, or library deployed bytecode has changed. Returns 1 (up to date).
+# Returns 0 if stored deployment metadata differs from the candidate artifact,
+# constructor args, or linked-library bytecode. Returns 1 when they match.
+# This comparison deliberately ignores the pinned policy flag so callers can
+# surface candidate drift without turning it into an automatic deployment.
 # Args: $1=chain_id, $2=contract_key, $3=artifact_contract, $4=libraries_str, $5...=constructor_args
-deployment_is_pinned() {
-    local chain_id="$1"
-    local contract_key="$2"
-    [ "$(jq -r ".[\"$chain_id\"].contracts[\"$contract_key\"].pinned // false" \
-        "$DEPLOYMENTS_JSON_PATH" 2>/dev/null)" = "true" ]
-}
-
-needs_deployment() {
+deployment_metadata_has_drift() {
     local chain_id="$1"
     local contract_key="$2"
     local artifact_contract="$3"
@@ -294,33 +289,21 @@ needs_deployment() {
     shift 4
     local constructor_args=("$@")
 
-    # No on-chain address yet → always deploy
-    local addr_var="${contract_key}_ADDRESS"
-    if [ -z "${!addr_var:-}" ]; then
-        return 0
-    fi
-
-    # Pinned contracts must not be redeployed through normal deploy scripts.
-    # Upgrades are handled out-of-band (e.g. proxy announcePlannedUpgrade/upgradeTo, manual governance).
-    if deployment_is_pinned "$chain_id" "$contract_key"; then
-        return 1
-    fi
-
-    # No stored metadata → always deploy
     local stored_hash
     stored_hash=$(jq -r ".[\"$chain_id\"].contracts[\"$contract_key\"].initcode_hash // empty" \
         "$DEPLOYMENTS_JSON_PATH" 2>/dev/null)
     if [ -z "$stored_hash" ]; then
+        echo "  📝 $contract_key: deployment metadata missing"
         return 0
     fi
 
     local artifact_path
     artifact_path=$(_artifact_path "$artifact_contract")
     if [ ! -f "$artifact_path" ]; then
+        echo "  📝 $contract_key: candidate artifact unavailable at $artifact_path"
         return 0
     fi
 
-    # Check initcode hash
     local current_hash
     current_hash=$(_compute_initcode_hash "$artifact_path" "$libraries_str")
     if [ "$current_hash" != "$stored_hash" ]; then
@@ -328,7 +311,6 @@ needs_deployment() {
         return 0
     fi
 
-    # Check constructor args
     local stored_args
     stored_args=$(jq -c ".[\"$chain_id\"].contracts[\"$contract_key\"].constructor_args // []" \
         "$DEPLOYMENTS_JSON_PATH" 2>/dev/null)
@@ -337,7 +319,6 @@ needs_deployment() {
         return 0
     fi
 
-    # Check library deployed bytecode via on-chain lookup
     if [ -n "$libraries_str" ]; then
         local libs_json
         libs_json=$(_build_libs_json "$libraries_str")
@@ -371,7 +352,65 @@ needs_deployment() {
         done < <(printf '%s' "$libs_json" | jq -r 'to_entries[] | "\(.key)=\(.value)"')
     fi
 
-    return 1  # up to date
+    return 1
+}
+
+# Reports whether a pinned deployment matches candidate metadata without ever
+# changing the pin or converting drift into a deployment action.
+# Args: same as deployment_metadata_has_drift
+report_pinned_deployment_status() {
+    local chain_id="$1"
+    local contract_key="$2"
+    local artifact_contract="$3"
+    local libraries_str="$4"
+    shift 4
+    local constructor_args=("$@")
+    local addr_var="${contract_key}_ADDRESS"
+
+    if deployment_metadata_has_drift \
+        "$chain_id" "$contract_key" "$artifact_contract" "$libraries_str" \
+        "${constructor_args[@]}"; then
+        echo "  ⚠️  Pinned/preserved at: ${!addr_var} (candidate drift; explicit review required)"
+    else
+        echo "  📌 Pinned/preserved at: ${!addr_var} (candidate matches recorded deployment metadata)"
+    fi
+}
+
+# Returns success when the deployment policy pins this contract.
+# Args: $1=chain_id, $2=contract_key
+deployment_is_pinned() {
+    local chain_id="$1"
+    local contract_key="$2"
+    [ "$(jq -r ".[\"$chain_id\"].contracts[\"$contract_key\"].pinned // false" \
+        "$DEPLOYMENTS_JSON_PATH" 2>/dev/null)" = "true" ]
+}
+
+# Returns 0 (needs deployment) if stored metadata is absent or if initcode hash,
+# constructor args, or library deployed bytecode has changed. Returns 1 (up to date).
+# Args: $1=chain_id, $2=contract_key, $3=artifact_contract, $4=libraries_str, $5...=constructor_args
+needs_deployment() {
+    local chain_id="$1"
+    local contract_key="$2"
+    local artifact_contract="$3"
+    local libraries_str="$4"
+    shift 4
+    local constructor_args=("$@")
+
+    # No on-chain address yet → always deploy
+    local addr_var="${contract_key}_ADDRESS"
+    if [ -z "${!addr_var:-}" ]; then
+        return 0
+    fi
+
+    # Pinned contracts must not be redeployed through normal deploy scripts.
+    # Upgrades are handled out-of-band (e.g. proxy announcePlannedUpgrade/upgradeTo, manual governance).
+    if deployment_is_pinned "$chain_id" "$contract_key"; then
+        return 1
+    fi
+
+    deployment_metadata_has_drift \
+        "$chain_id" "$contract_key" "$artifact_contract" "$libraries_str" \
+        "${constructor_args[@]}"
 }
 
 # Record bytecode metadata for a deployed contract in deployments.json
@@ -492,7 +531,9 @@ deploy_implementation_if_needed() {
 
     if deployment_is_pinned "$CHAIN" "$contract_key"; then
         echo -e "${BOLD:-}${description}${RESET:-}"
-        echo "  📌 Pinned/preserved at: ${!var_name}"
+        report_pinned_deployment_status \
+            "$CHAIN" "$contract_key" "$contract" "${LIBRARIES:-}" \
+            "${check_values[@]}"
         echo
         return 0
     fi

--- a/service_contracts/tools/warm-storage-deploy-all.sh
+++ b/service_contracts/tools/warm-storage-deploy-all.sh
@@ -543,7 +543,12 @@ deploy_proxy_if_needed \
 echo -e "${BOLD}FilecoinWarmStorageServiceStateView${RESET}"
 FWSS_VIEW_DEPLOYED=false
 if deployment_is_pinned "$CHAIN" "FWSS_VIEW"; then
-    echo "  📌 Pinned/preserved at: $FWSS_VIEW_ADDRESS"
+    report_pinned_deployment_status \
+        "$CHAIN" \
+        "FWSS_VIEW" \
+        "src/FilecoinWarmStorageServiceStateView.sol:FilecoinWarmStorageServiceStateView" \
+        "" \
+        "$FWSS_PROXY_ADDRESS"
 elif ! needs_deployment "$CHAIN" "FWSS_VIEW" "src/FilecoinWarmStorageServiceStateView.sol:FilecoinWarmStorageServiceStateView" "" "$FWSS_PROXY_ADDRESS"; then
     echo "  ✅ Up to date at: $FWSS_VIEW_ADDRESS"
 elif [ "$DRY_RUN" = "true" ]; then
@@ -577,7 +582,7 @@ echo
 # an owner transaction from the deployer key.
 echo -e "${BOLD}Setting view contract address${RESET}"
 if [ "$FWSS_VIEW_DEPLOYED" != "true" ]; then
-    echo "  ✅ No StateView change planned"
+    echo "  ✅ No StateView deployment planned by metadata; review any pinned candidate drift above"
 elif [ "$FWSS_PROXY_WAS_EXISTING" = "true" ]; then
     if [ "$DRY_RUN" = "true" ]; then
         echo "  🔍 New StateView requires a separate Safe setViewContract transaction"


### PR DESCRIPTION
## What changed

- Compare pinned implementation and StateView candidates with their recorded deployment metadata during the metadata-aware dry-run.
- Keep `pinned: true` authoritative: candidate drift is reported for explicit review but never triggers an automatic deploy or unpin.
- Include missing metadata/artifacts and linked-library drift in the GitHub Actions deployment-plan summary.
- Consolidate Phase 1 scope and dependency compatibility into one two-network inventory approval. Phase 2 now reruns the frozen tag only as a drift check before live deployment.

## Why

During the v1.3.1 rollout review in #561, the dry-run printed the existing StateView as `Pinned/preserved` even though the candidate changed `nextPDPChallengeWindowStart()` behavior. The pinned branch returned before `needs_deployment`, so reviewers could not distinguish:

- pinned and unchanged; from
- pinned despite candidate bytecode or constructor drift.

That made the deployment inventory look complete while a compatibility decision still existed outside it.

This change makes the dry-run the single authoritative review point. A changed pinned component is reported as:

```text
FWSS_VIEW: initcode changed
Pinned/preserved at: 0x... (candidate drift; explicit review required)
```

The technical owner must then either include the component in rollout scope or explicitly approve preserving the deployed version. The tooling does not make that decision.

## Validation

- `bash -n service_contracts/tools/deployments.sh`
- `bash -n service_contracts/tools/warm-storage-deploy-all.sh`
- `forge build --offline`
- Mainnet metadata-aware dry-run: passed, no transactions broadcast
- Calibnet metadata-aware dry-run: passed, no transactions broadcast
- Both dry-runs retained the existing deploy set (SPR implementation, Rails, and FWSS implementation) while surfacing pinned candidate drift for FilecoinPay, PDPVerifier, and StateView.
- `git diff --check`
