### PR TITLE
chore: include StateView in v1.3.1 rollout

### DIFF
--- a/service_contracts/deployments.json
+++ b/service_contracts/deployments.json
@@ -111,8 +111,7 @@
         "libraries": {},
         "constructor_args": [
           "0x8408502033C418E1bbC97cE9ac48E5528F371A9f"
-        ],
-        "pinned": true
+        ]
       },
       "PDP_VERIFIER_IMPLEMENTATION": {
         "initcode_hash": "0xeafb9469e2aa231a3b2db2f01c79a0de89a8e45535d7688a6e64b83083ae57c9",
@@ -185,8 +184,7 @@
         "libraries": {},
         "constructor_args": [
           "0x02925630df557F957f70E112bA06e50965417CA0"
-        ],
-        "pinned": true
+        ]
       },
       "FWSS_IMPLEMENTATION": {
         "initcode_hash": "0x03cb62b55ab80de5dc7af2be5bc10485b6fc9ecc933d666d04f48e6100195a04",


### PR DESCRIPTION
## What changed

- Unpin `FWSS_VIEW` in the Calibnet and Mainnet deployment metadata.
- Keep FilecoinPay and PDPVerifier pinned and outside this rollout.
- Preserve the existing FWSS proxy addresses and current live StateView addresses until the rollout executes.

## Why

The v1.3.1 FWSS implementation preserves the original proving activation epoch when an emptied or suspended dataset is reactivated. The candidate StateView contains the matching canonical challenge-window calculation; the currently deployed StateView instead reverts with `ProvingPeriodNotInitialized` when no proving deadline is active.

Leaving StateView pinned would therefore ship only half of the reactivation behavior. Removing the two policy pins lets the metadata-aware Warm Storage stack run deploy one candidate StateView per network.

For an existing Safe-owned FWSS proxy, the deployment workflow does not switch the View automatically. It records the new address and prints the separate `setViewContract` owner action required by the release checklist.