### PR TITLE
fix: isolate deployment preflight reads from signer env

### DIFF
--- a/service_contracts/tools/warm-storage-deploy-all.sh
+++ b/service_contracts/tools/warm-storage-deploy-all.sh
@@ -293,17 +293,22 @@ require_proxy_implementation() {
     fi
 }
 
+cast_call_read_only() {
+    env -u CHAIN -u ETH_KEYSTORE -u PASSWORD -u CAST_PASSWORD cast call "$@"
+}
+
 require_fwss_dependency() {
     local dependency_label="$1"
     local getter_signature="$2"
     local expected_address="$3"
     local actual_address
 
-    if ! actual_address=$(env -u CHAIN cast call --rpc-url "$ETH_RPC_URL" \
-        "$FWSS_PROXY_ADDRESS" "$getter_signature" 2>/dev/null | tr -d '"'); then
+    if ! actual_address=$(cast_call_read_only --rpc-url "$ETH_RPC_URL" \
+        "$FWSS_PROXY_ADDRESS" "$getter_signature"); then
         echo "Error: Failed to read $dependency_label from FWSS proxy $FWSS_PROXY_ADDRESS"
         exit 1
     fi
+    actual_address=${actual_address//\"/}
     if [ "$(printf '%s' "$actual_address" | tr '[:upper:]' '[:lower:]')" != \
          "$(printf '%s' "$expected_address" | tr '[:upper:]' '[:lower:]')" ]; then
         echo "Error: FWSS reports $dependency_label $actual_address, but candidate metadata uses $expected_address"
@@ -373,11 +378,12 @@ if [ "$DEPLOYMENT_MODE" = "upgrade" ]; then
         "filBeamBeneficiaryAddress()(address)" "$FILBEAM_BENEFICIARY_ADDRESS"
     echo "✅ FWSS dependency getters match candidate constructor addresses"
 
-    if ! CURRENT_FWSS_VIEW_ADDRESS=$(env -u CHAIN cast call --rpc-url "$ETH_RPC_URL" \
-        "$FWSS_PROXY_ADDRESS" "viewContractAddress()(address)" 2>/dev/null | tr -d '"'); then
+    if ! CURRENT_FWSS_VIEW_ADDRESS=$(cast_call_read_only --rpc-url "$ETH_RPC_URL" \
+        "$FWSS_PROXY_ADDRESS" "viewContractAddress()(address)"); then
         echo "Error: Failed to read StateView from FWSS proxy $FWSS_PROXY_ADDRESS"
         exit 1
     fi
+    CURRENT_FWSS_VIEW_ADDRESS=${CURRENT_FWSS_VIEW_ADDRESS//\"/}
     if [ "$(printf '%s' "$CURRENT_FWSS_VIEW_ADDRESS" | tr '[:upper:]' '[:lower:]')" != \
          "$(printf '%s' "$FWSS_VIEW_ADDRESS" | tr '[:upper:]' '[:lower:]')" ]; then
         echo "Error: FWSS proxy reports StateView $CURRENT_FWSS_VIEW_ADDRESS, but deployments.json records $FWSS_VIEW_ADDRESS"


### PR DESCRIPTION
## What changed

- Run the two read-only FWSS `cast call` preflight reads without `CHAIN`, `ETH_KEYSTORE`, `PASSWORD`, or `CAST_PASSWORD`.
- Capture the `cast` output directly and strip quotes only after a successful call, instead of piping through `tr` and masking a failed `cast` exit status.

This PR changes only `service_contracts/tools/warm-storage-deploy-all.sh`. It does not change Solidity, deployment metadata, ABIs, workflow inputs, or contract bytecode.

## Root cause

The [`v1.3.1` Calibnet deployment run](https://github.com/FilOzone/filecoin-services/actions/runs/31000840747) stopped during preflight with an empty reported PDPVerifier address. No transaction was broadcast.

The live workflow creates an encrypted keystore and exports `ETH_KEYSTORE`/`PASSWORD` before invoking the deployment script. Under the workflow's Foundry v1.7.1, a read-only `cast call` then tries to initialize that signer and exits with:

```text
Error: Device not configured (os error 6)
```

The script redirected stderr and piped stdout through `tr`, so the pipeline appeared successful with empty output and produced a misleading address-mismatch error.

## Impact

The live upgrade preflight can read and compare existing FWSS dependency/View addresses while the signer environment remains available for the later deployment commands. Genuine read failures now retain a failing exit status and their original stderr.

## Validation

- `bash -n service_contracts/tools/warm-storage-deploy-all.sh`
- `git diff --check`
- Reproduced the original failure with the official Foundry v1.7.1 binary and a dummy encrypted keystore.
- Ran the complete Calibnet metadata-aware deployment script with Foundry v1.7.1, `DRY_RUN=true`, `DEPLOYMENT_MODE=upgrade`, and workflow-style `ETH_KEYSTORE`, `PASSWORD`, and `CAST_PASSWORD` variables set. Preflight and the full approved inventory completed successfully:
  - deploy SPR implementation, Rails, FWSS implementation, and StateView
  - preserve FilecoinPay, PDPVerifier, all proxies, SessionKeyRegistry, SignatureVerificationLib, and endorsements

## v1.3.1 rollout follow-up

After this merges, carry only this tooling commit onto `release-v1.3.1`, verify contract-source/submodule bytecode inputs remain equivalent to immutable tag `v1.3.1`, record the tooling-only release-ref exception in [#561](https://github.com/FilOzone/filecoin-services/issues/561), rerun the dry-run from that reviewed ref, and only then retry Calibnet deployment.
