### PR TITLE
fix: backport deployment preflight isolation to v1.3.1

### DIFF
--- a/service_contracts/tools/warm-storage-deploy-all.sh
+++ b/service_contracts/tools/warm-storage-deploy-all.sh
@@ -293,17 +293,22 @@ require_proxy_implementation() {
     fi
 }
 
+cast_call_read_only() {
+    env -u CHAIN -u ETH_KEYSTORE -u PASSWORD -u CAST_PASSWORD cast call "$@"
+}
+
 require_fwss_dependency() {
     local dependency_label="$1"
     local getter_signature="$2"
     local expected_address="$3"
     local actual_address
 
-    if ! actual_address=$(env -u CHAIN cast call --rpc-url "$ETH_RPC_URL" \
-        "$FWSS_PROXY_ADDRESS" "$getter_signature" 2>/dev/null | tr -d '"'); then
+    if ! actual_address=$(cast_call_read_only --rpc-url "$ETH_RPC_URL" \
+        "$FWSS_PROXY_ADDRESS" "$getter_signature"); then
         echo "Error: Failed to read $dependency_label from FWSS proxy $FWSS_PROXY_ADDRESS"
         exit 1
     fi
+    actual_address=${actual_address//\"/}
     if [ "$(printf '%s' "$actual_address" | tr '[:upper:]' '[:lower:]')" != \
          "$(printf '%s' "$expected_address" | tr '[:upper:]' '[:lower:]')" ]; then
         echo "Error: FWSS reports $dependency_label $actual_address, but candidate metadata uses $expected_address"
@@ -373,11 +378,12 @@ if [ "$DEPLOYMENT_MODE" = "upgrade" ]; then
         "filBeamBeneficiaryAddress()(address)" "$FILBEAM_BENEFICIARY_ADDRESS"
     echo "✅ FWSS dependency getters match candidate constructor addresses"
 
-    if ! CURRENT_FWSS_VIEW_ADDRESS=$(env -u CHAIN cast call --rpc-url "$ETH_RPC_URL" \
-        "$FWSS_PROXY_ADDRESS" "viewContractAddress()(address)" 2>/dev/null | tr -d '"'); then
+    if ! CURRENT_FWSS_VIEW_ADDRESS=$(cast_call_read_only --rpc-url "$ETH_RPC_URL" \
+        "$FWSS_PROXY_ADDRESS" "viewContractAddress()(address)"); then
         echo "Error: Failed to read StateView from FWSS proxy $FWSS_PROXY_ADDRESS"
         exit 1
     fi
+    CURRENT_FWSS_VIEW_ADDRESS=${CURRENT_FWSS_VIEW_ADDRESS//\"/}
     if [ "$(printf '%s' "$CURRENT_FWSS_VIEW_ADDRESS" | tr '[:upper:]' '[:lower:]')" != \
          "$(printf '%s' "$FWSS_VIEW_ADDRESS" | tr '[:upper:]' '[:lower:]')" ]; then
         echo "Error: FWSS proxy reports StateView $CURRENT_FWSS_VIEW_ADDRESS, but deployments.json records $FWSS_VIEW_ADDRESS"


### PR DESCRIPTION
## What changed

Backports the deployment-preflight signer-environment isolation from #569 onto `release-v1.3.1`.

This release branch remains bytecode-equivalent to the immutable `v1.3.1` tag: the only changed file is `service_contracts/tools/warm-storage-deploy-all.sh`. Solidity sources, dependency gitlinks, Foundry inputs, deployment metadata, and ABIs are unchanged.

## Why

The Phase 2 deployment workflow needs this fix so read-only `cast call` preflight checks cannot consume the deployer keystore environment or have failures masked by the output pipeline. Merging #569 into `main` alone does not update the already-cut release branch.

## Validation

- Original fix reviewed and merged in #569.
- [Calibnet dry-run 31080266806](https://github.com/FilOzone/filecoin-services/actions/runs/31080266806) passed from this exact release-derived commit.
- [Mainnet dry-run 31085789316](https://github.com/FilOzone/filecoin-services/actions/runs/31085789316) passed from this exact release-derived commit.
- The dry-run produced the approved inventory: deploy SPR implementation, Rails, FWSS implementation, and StateView; preserve FilecoinPay, PDPVerifier, all proxies, SessionKeyRegistry, SignatureVerificationLib, and endorsements.

Tracks Phase 2 preparation in #561.
