### PR TITLE
fix: extend v1.3.1 deployment receipt timeout

### DIFF
--- a/service_contracts/tools/warm-storage-deploy-all.sh
+++ b/service_contracts/tools/warm-storage-deploy-all.sh
@@ -12,6 +12,11 @@
 DRY_RUN=${DRY_RUN:-true}
 DEPLOYMENT_MODE=${DEPLOYMENT_MODE:-auto}
 
+# Filecoin RPC inclusion can exceed Foundry's default broadcast receipt timeout.
+# Keep the value overrideable while allowing enough time for a mined CREATE
+# transaction to be observed before the deployment script decides it failed.
+export ETH_TIMEOUT="${ETH_TIMEOUT:-300}"
+
 case "$DRY_RUN" in
   true|false) ;;
   *)


### PR DESCRIPTION
## What changed

Sets an overrideable default `ETH_TIMEOUT=300` for the metadata-aware Warm Storage stack deployment script.

This changes only deployment tooling. Contract sources, dependencies, bytecode inputs, deployment metadata, and ABIs are unchanged from the v1.3.1 release.

## Why

Calibnet candidate-deployment run [31087119094](https://github.com/FilOzone/filecoin-services/actions/runs/31087119094) broadcast the first selected CREATE transaction successfully, but Foundry reached its default receipt timeout before observing the mined receipt and reported `Error: contract was not deployed`.

The transaction subsequently appeared on chain:

- [transaction `0x5be1…febc`](https://filecoin-testnet.blockscout.com/tx/0x5be160d55fa050c107440e6a5e1c9acb7577aa78b14eee64895dbbad5031febc)
- SPR v1.2.0 candidate `0x6D1d31871aE70Ad8Fa14F7A2E8313a8c9d56AFca`

The candidate's runtime bytecode and constructor reinitializer `3` verify against the v1.3.1 artifact. No proxy or StateView was switched. The full incident and recovery state are recorded in [release issue #561](https://github.com/FilOzone/filecoin-services/issues/561#issuecomment-5202650603).

Increasing the broadcast timeout lets `forge create` wait long enough to return the deployed address, allowing the metadata-aware stack run to persist the address in its working deployment snapshot and continue in nonce order.

## Validation

- `bash -n service_contracts/tools/warm-storage-deploy-all.sh`
- `git diff --check`
- Foundry documents `ETH_TIMEOUT` as the environment override for `forge create --timeout`.

## Recovery plan

After review and merge into `release-v1.3.1`:

1. rerun the Calibnet dry-run and confirm the approved inventory;
2. rerun the complete stack with `dry_run=false`;
3. record the already-mined SPR candidate as valid but unused/orphaned if the retry creates a second SPR candidate;
4. verify and record all candidates before any announce or proxy switch.
